### PR TITLE
Tap :reference now means something. fixes #10

### DIFF
--- a/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
+++ b/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
@@ -35,6 +35,13 @@
     @"POST@/session/:sessionID/tap/:reference" : ^(FBRouteRequest *params, FBRouteResponseCompletion completionHandler) {
       CGFloat x = [params.arguments[@"x"] floatValue];
       CGFloat y = [params.arguments[@"y"] floatValue];
+      NSInteger elementID = [params.parameters[@"reference"] integerValue];
+      UIAElement *element = [params.elementCache elementForIndex:elementID];
+      if (element != nil) {
+        CGRect rect = [[element valueForKey:@"rect"] CGRectValue];
+        x += rect.origin.x;
+        y += rect.origin.y;
+      }
       [[UIATarget localTarget] tap:@{ @"x": @(x), @"y": @(y) }];
       completionHandler(FBResponseDictionaryWithOK());
     },


### PR DESCRIPTION
I wasn't sure what the desired way to say "no reference" is. If you give
something that's not a number, then it will treat that as "reference from the
top left of the screen".

See #10 