### PR TITLE
Name

### DIFF
--- a/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
+++ b/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
@@ -60,7 +60,7 @@
       NSInteger elementID = [request.parameters[@"id"] integerValue];
       UIAElement *element = [request.elementCache elementForIndex:elementID];
       BOOL isEnabled = [[element isEnabled] boolValue];
-      return FBResponseDictionaryWithStatus(FBCommandStatusNoError, isEnabled ? @"1" : @"0");
+      return FBResponseDictionaryWithStatus(FBCommandStatusNoError, isEnabled ? @YES : @NO);
     }],
     [[FBRoute GET:@"/session/:sessionID/element/:id/text"] respond: ^ id<FBResponsePayload> (FBRouteRequest *request) {
       NSInteger elementID = [request.parameters[@"id"] integerValue];

--- a/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
+++ b/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
@@ -89,7 +89,7 @@
       return FBResponseDictionaryWithElementID(elementID);
     }],
     [[FBRoute POST:@"/session/:sessionID/element/:id/value"] respond: ^ id<FBResponsePayload> (FBRouteRequest *request) {
-      NSInteger elementID = [request.arguments[@"id"] integerValue];
+      NSInteger elementID = [request.parameters[@"id"] integerValue];
       UIAElement *element = [request.elementCache elementForIndex:elementID];
       if (![[element hasKeyboardFocus] boolValue]) {
         [element tap];

--- a/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
+++ b/WebDriverAgentLib/WebDriverCommands/FBElementCommands.m
@@ -69,7 +69,7 @@
       return FBResponseDictionaryWithStatus(FBCommandStatusNoError, text);
     }],
     [[FBRoute POST:@"/session/:sessionID/element/:id/clear"] respond: ^ id<FBResponsePayload> (FBRouteRequest *request) {
-      NSInteger elementID = [request.arguments[@"id"] integerValue];
+      NSInteger elementID = [request.parameters[@"id"] integerValue];
       UIAElement *element = [request.elementCache elementForIndex:elementID];
 
       // TODO(t8077426): This is a terrible workaround to get tests in t8036026 passing.

--- a/WebDriverAgentLib/WebDriverCommands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/WebDriverCommands/FBFindElementCommands.m
@@ -148,6 +148,8 @@ NSArray *elementsFromXpath(UIAElement *element, NSString *xpathQuery);
   if (partialSearch || [usingText isEqualToString:@"link text"]) {
     NSArray *components = [value componentsSeparatedByString:@"="];
     elements = elementsWithProperty(element, components[0], components[1], partialSearch);
+  } else if ([usingText isEqualToString:@"name"]) {
+    elements = elementsWithProperty(element, @"name", value, NO);
   } else if ([usingText isEqualToString:@"class name"]) {
     elements = elementsWithProperty(element, @"className", value, NO);
   } else if ([usingText isEqualToString:@"xpath"]) {


### PR DESCRIPTION
I'm thinking that the facebook tests must be sending the element id in the url *and* the message body, since commands like `/value` and `/clear` work for you.

`/enabled` returned a string ("0" or "1") instead of a boolean. Spec requires a boolean though.

Are these changes going to break your tests? How should we handle breaking changes to the current api like this?