### PR TITLE
By.id() == By.name()

### DIFF
--- a/WebDriverAgentLib/WebDriverCommands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/WebDriverCommands/FBFindElementCommands.m
@@ -151,7 +151,7 @@ NSArray *elementsFromXpath(UIAElement *element, NSString *xpathQuery);
   if (partialSearch || [usingText isEqualToString:@"link text"]) {
     NSArray *components = [value componentsSeparatedByString:@"="];
     elements = elementsWithProperty(element, components[0], components[1], partialSearch);
-  } else if ([usingText isEqualToString:@"name"]) {
+  } else if ([usingText isEqualToString:@"name"] || [usingText isEqualToString:@"id"]) {
     elements = elementsWithProperty(element, @"name", value, NO);
   } else if ([usingText isEqualToString:@"class name"]) {
     elements = elementsWithProperty(element, @"type", value, NO);


### PR DESCRIPTION
By.name() is the best proxy that we currently have for By.id(). Clients that attempt to use By.id() will get confusing behavior if this search method is unsupported.