### PR TITLE
Handling system alerts

### DIFF
--- a/PrivateHeaders/XCTest/XCElementSnapshot-Hitpoint.h
+++ b/PrivateHeaders/XCTest/XCElementSnapshot-Hitpoint.h
@@ -7,8 +7,8 @@
 #import <XCTWebDriverAgentLib/XCElementSnapshot.h>
 
 @interface XCElementSnapshot (Hitpoint)
-@property(readonly) struct CGPoint hitPointForScrolling;
-@property(readonly) struct CGPoint hitPoint;
+@property(readonly) CGPoint hitPointForScrolling;
+@property(readonly) CGPoint hitPoint;
 
 - (id)hitTest:(struct CGPoint)arg1;
 

--- a/PrivateHeaders/XCTest/XCElementSnapshot.h
+++ b/PrivateHeaders/XCTest/XCElementSnapshot.h
@@ -73,7 +73,7 @@
 - (BOOL)_matchesElement:(id)arg1;
 - (id)_allDescendants;
 - (BOOL)hasDescendantMatchingFilter:(CDUnknownBlockType)arg1;
-- (id)descendantsByFilteringWithBlock:(CDUnknownBlockType)arg1;
+- (id)descendantsByFilteringWithBlock:(BOOL(^)(XCElementSnapshot *snapshot))block;
 - (id)elementSnapshotMatchingAccessibilityElement:(id)arg1;
 - (void)enumerateDescendantsUsingBlock:(void(^)(XCElementSnapshot *snapshot))block;
 - (id)recursiveDescriptionWithIndent:(id)arg1 includeAccessibilityElement:(BOOL)arg2;

--- a/PrivateHeaders/XCTest/XCUIApplication.h
+++ b/PrivateHeaders/XCTest/XCUIApplication.h
@@ -53,7 +53,7 @@
 - (id)lastSnapshot;
 - (id)query;
 - (void)clearQuery;
-- (unsigned long long)elementType;
+- (XCUIElementType)elementType;
 - (id)initPrivateWithPath:(id)arg1 bundleID:(id)arg2;
 - (id)init;
 

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		EE5503551BF218A800CD04B3 /* UIAElement+WebDriverXML.h in Headers */ = {isa = PBXBuildFile; fileRef = EE55034F1BF218A800CD04B3 /* UIAElement+WebDriverXML.h */; };
 		EE5503561BF218A800CD04B3 /* UIAElement+WebDriverXML.m in Sources */ = {isa = PBXBuildFile; fileRef = EE5503501BF218A800CD04B3 /* UIAElement+WebDriverXML.m */; };
 		EE5503591BF2211400CD04B3 /* FBElement.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC28B0E1BF215D800B4DC79 /* FBElement.m */; };
+		EE5906CE1C049B7C00355001 /* XCElementSnapshot+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = EE5906CC1C049B7C00355001 /* XCElementSnapshot+Helpers.h */; };
+		EE5906CF1C049B7C00355001 /* XCElementSnapshot+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = EE5906CD1C049B7C00355001 /* XCElementSnapshot+Helpers.m */; };
 		EEC289321BF0ED2E00B4DC79 /* FBUIAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC288F21BF0ED2500B4DC79 /* FBUIAppDelegate.m */; };
 		EEC2893C1BF0ED2E00B4DC79 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC288F41BF0ED2500B4DC79 /* main.m */; };
 		EEC289591BF0ED3000B4DC79 /* FBWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = EE3D73991BECCA5A0034D1E9 /* FBWebServer.m */; };
@@ -439,6 +441,8 @@
 		EE55034E1BF218A800CD04B3 /* UIAElement+WebDriverAttributes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAElement+WebDriverAttributes.m"; sourceTree = "<group>"; };
 		EE55034F1BF218A800CD04B3 /* UIAElement+WebDriverXML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAElement+WebDriverXML.h"; sourceTree = "<group>"; };
 		EE5503501BF218A800CD04B3 /* UIAElement+WebDriverXML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAElement+WebDriverXML.m"; sourceTree = "<group>"; };
+		EE5906CC1C049B7C00355001 /* XCElementSnapshot+Helpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCElementSnapshot+Helpers.h"; sourceTree = "<group>"; };
+		EE5906CD1C049B7C00355001 /* XCElementSnapshot+Helpers.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCElementSnapshot+Helpers.m"; sourceTree = "<group>"; };
 		EEC288F11BF0ED2500B4DC79 /* FBUIAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBUIAppDelegate.h; sourceTree = "<group>"; };
 		EEC288F21BF0ED2500B4DC79 /* FBUIAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBUIAppDelegate.m; sourceTree = "<group>"; };
 		EEC288F31BF0ED2500B4DC79 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -997,6 +1001,8 @@
 		EEC28AF51BF2124700B4DC79 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				EE5906CC1C049B7C00355001 /* XCElementSnapshot+Helpers.h */,
+				EE5906CD1C049B7C00355001 /* XCElementSnapshot+Helpers.m */,
 				EEC28AF61BF2124700B4DC79 /* XCUIElement+FBIsVisible.h */,
 				EEC28AF71BF2124700B4DC79 /* XCUIElement+FBIsVisible.m */,
 				EEC28AF81BF2124700B4DC79 /* XCUIElement+FBScrolling.h */,
@@ -1153,6 +1159,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE5906CE1C049B7C00355001 /* XCElementSnapshot+Helpers.h in Headers */,
 				EED031821BFA397A007EDC1D /* XCTouchEvent.h in Headers */,
 				EED031571BFA397A007EDC1D /* XCElementSnapshot.h in Headers */,
 				EEC289BE1BF0EE4E00B4DC79 /* FBDebugCommands.h in Headers */,
@@ -1767,6 +1774,7 @@
 				EEC28B031BF2124700B4DC79 /* XCUIElement+UIAClassMapping.m in Sources */,
 				EEC289B41BF0EE4000B4DC79 /* FBFindElementCommands.m in Sources */,
 				EE5503591BF2211400CD04B3 /* FBElement.m in Sources */,
+				EE5906CF1C049B7C00355001 /* XCElementSnapshot+Helpers.m in Sources */,
 				EEC289591BF0ED3000B4DC79 /* FBWebServer.m in Sources */,
 				EEC2895E1BF0ED3000B4DC79 /* FBWDAConstants.m in Sources */,
 				EEC289631BF0ED3000B4DC79 /* FBRouteRequest.m in Sources */,

--- a/XCTWebDriverAgentLib/Categories/XCElementSnapshot+Helpers.h
+++ b/XCTWebDriverAgentLib/Categories/XCElementSnapshot+Helpers.h
@@ -1,0 +1,11 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#import <XCTWebDriverAgentLib/XCElementSnapshot.h>
+
+@interface XCElementSnapshot (Helpers)
+
++ (XCElementSnapshot *)fb_snapshotForAccessibilityElement:(XCAccessibilityElement *)accessibilityElement;
+
+- (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingType:(XCUIElementType)type;
+
+@end

--- a/XCTWebDriverAgentLib/Categories/XCElementSnapshot+Helpers.m
+++ b/XCTWebDriverAgentLib/Categories/XCElementSnapshot+Helpers.m
@@ -1,0 +1,38 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#import "XCElementSnapshot+Helpers.h"
+
+#import "FBWDALogger.h"
+#import "XCAXClient_iOS.h"
+#import "XCTestDriver.h"
+
+@implementation XCElementSnapshot (Helpers)
+
++ (XCElementSnapshot *)fb_snapshotForAccessibilityElement:(XCAccessibilityElement *)accessibilityElement
+{
+  __block BOOL loading = YES;
+  __block XCElementSnapshot *snapshot;
+  [[XCTestDriver sharedTestDriver].managerProxy _XCT_snapshotForElement:accessibilityElement
+                                                             attributes:[[XCAXClient_iOS sharedClient] defaultAttributes]
+                                                             parameters: [[XCAXClient_iOS sharedClient] defaultParameters]
+                                                                  reply:^(XCElementSnapshot *iSnapshot, NSError *error) {
+                                                                    if (error) {
+                                                                      [FBWDALogger logFmt:@"Error: %@", error];
+                                                                    }
+                                                                    snapshot = iSnapshot;
+                                                                    loading = NO;
+                                                                  }];
+  while (loading) {
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.3]];
+  }
+  return snapshot;
+}
+
+- (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingType:(XCUIElementType)type
+{
+  return [self descendantsByFilteringWithBlock:^BOOL(XCElementSnapshot *snapshot){
+    return snapshot.elementType == type;
+  }];
+}
+
+@end

--- a/XCTWebDriverAgentLib/FBXCTWebDriverAgent.m
+++ b/XCTWebDriverAgentLib/FBXCTWebDriverAgent.m
@@ -9,6 +9,7 @@
 
 #import "FBXCTWebDriverAgent.h"
 
+#import "FBWDALogger.h"
 #import "FBWebServer.h"
 #import "FBXCTExceptionHandler.h"
 
@@ -30,7 +31,7 @@
 
 - (void)start
 {
-  NSLog(@"Built at %s %s", __DATE__, __TIME__);
+  [FBWDALogger logFmt:@"Built at %s %s", __DATE__, __TIME__];
   self.server = [[FBWebServer alloc] init];
   self.server.exceptionHandler = [FBXCTExceptionHandler new];
   [self.server startServing];


### PR DESCRIPTION
XCTest detect only alerts raised by app. All system alerts are invisible, so to detect system alerts this diff query for element at point (center) and go up until type matches XCUIElementTypeAlert.

We do this only in case of alert commands, because it is slower and it is not needed when interacting with elements. XCTest will handle system alerts for us.