### PR TITLE
Preventing XCUITestRunner from stopping on app crash or other failure

### DIFF
--- a/PrivateHeaders/XCTest/XCTestCase.h
+++ b/PrivateHeaders/XCTest/XCTestCase.h
@@ -8,7 +8,7 @@
 
 @class NSInvocation, XCTestCaseRun, XCTestContext, _XCTestCaseImplementation;
 
-@interface XCTestCase : XCTest
+@interface XCTestCase ()
 {
     id _internalImplementation;
 }
@@ -16,28 +16,20 @@
 @property(readonly) XCTestContext *testContext;
 @property(readonly) unsigned long long activityRecordStackDepth;
 @property(nonatomic) BOOL shouldHaltWhenReceivesControl;
-@property BOOL continueAfterFailure;
 @property(retain) XCTestCaseRun *testCaseRun;
-@property(retain) NSInvocation *invocation;
 
 + (id)_baselineDictionary;
 + (BOOL)_treatMissingBaselinesAsTestFailures;
-+ (id)defaultPerformanceMetrics;
 + (BOOL)_reportPerformanceFailuresForLargeImprovements;
 + (BOOL)_enableSymbolication;
-+ (id)testInvocations;
+
 + (BOOL)isInheritingTestCases;
 + (id)testCaseWithSelector:(SEL)arg1;
-+ (id)testCaseWithInvocation:(id)arg1;
 
-- (void)removeUIInterruptionMonitor:(id)arg1;
-- (id)addUIInterruptionMonitorWithDescription:(id)arg1 handler:(CDUnknownBlockType)arg2;
-- (void)startActivityWithTitle:(id)arg1 block:(CDUnknownBlockType)arg2;
-- (void)measureMetrics:(id)arg1 automaticallyStartMeasuring:(BOOL)arg2 forBlock:(CDUnknownBlockType)arg3;
+
 - (void)_logAndReportPerformanceMetrics:(id)arg1 perfMetricResultsForIDs:(id)arg2 withBaselinesForTest:(id)arg3 defaultBaselinesForPerfMetricID:(id)arg4;
 - (void)_recordValues:(id)arg1 forPerformanceMetricID:(id)arg2 name:(id)arg3 unitsOfMeasurement:(id)arg4 baselineName:(id)arg5 baselineAverage:(id)arg6 maxPercentRegression:(id)arg7 maxPercentRelativeStandardDeviation:(id)arg8 maxRegression:(id)arg9 maxStandardDeviation:(id)arg10 file:(id)arg11 line:(unsigned long long)arg12;
 - (id)_symbolicationRecordForTestCodeInAddressStack:(id)arg1;
-- (void)measureBlock:(CDUnknownBlockType)arg1;
 - (void)stopMeasuring;
 - (void)startMeasuring;
 - (BOOL)_isMeasuringMetrics;
@@ -55,16 +47,14 @@
 - (Class)testRunClass;
 - (Class)_requiredTestRunBaseClass;
 - (void)_recordUnexpectedFailureWithDescription:(id)arg1 exception:(id)arg2;
-- (void)_enqueueFailureWithDescription:(id)arg1 inFile:(id)arg2 atLine:(unsigned long long)arg3 expected:(BOOL)arg4;
+- (void)_enqueueFailureWithDescription:(NSString *)description inFile:(NSString *)filePath atLine:(NSUInteger)lineNumber expected:(BOOL)expected;
 - (void)_dequeueFailures;
-- (void)recordFailureWithDescription:(id)arg1 inFile:(id)arg2 atLine:(unsigned long long)arg3 expected:(BOOL)arg4;
 - (void)_interruptTest;
 - (id)nameForLegacyLogging;
 - (id)name;
 - (id)languageAgnosticTestMethodName;
 - (unsigned long long)testCaseCount;
 - (id)initWithSelector:(SEL)arg1;
-- (id)initWithInvocation:(id)arg1;
 - (id)init;
 
 @end

--- a/PrivateHeaders/XCTest/_XCTestCaseImplementation.h
+++ b/PrivateHeaders/XCTest/_XCTestCaseImplementation.h
@@ -4,7 +4,9 @@
 //     class-dump is Copyright (C) 1997-1998, 2000-2001, 2004-2013 by Steve Nygard.
 //
 
-@class NSArray, NSInvocation, NSMutableArray, NSMutableDictionary, NSMutableSet, NSObject<OS_dispatch_source>, NSString, XCTestCaseRun, XCTestContext;
+@class NSArray, NSInvocation, NSMutableArray, NSMutableDictionary, NSMutableSet, NSString, XCTestCaseRun, XCTestContext;
+
+#import <XCTWebDriverAgentLib/CDStructures.h>
 
 @interface _XCTestCaseImplementation : NSObject
 {

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -117,7 +117,7 @@
 		EEC2898D1BF0ED3000B4DC79 /* FBResponsePayload.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3D73901BECCA5A0034D1E9 /* FBResponsePayload.h */; };
 		EEC2898F1BF0ED3000B4DC79 /* FBWebServer.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3D73981BECCA5A0034D1E9 /* FBWebServer.h */; };
 		EEC289901BF0ED3000B4DC79 /* FBCommandStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3D738B1BECCA5A0034D1E9 /* FBCommandStatus.h */; };
-		EEC289911BF0ED3000B4DC79 /* FBWDALogger.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3D739F1BECCA5A0034D1E9 /* FBWDALogger.h */; };
+		EEC289911BF0ED3000B4DC79 /* FBWDALogger.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3D739F1BECCA5A0034D1E9 /* FBWDALogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEC289921BF0ED3000B4DC79 /* FBResponseFilePayload.h in Headers */ = {isa = PBXBuildFile; fileRef = EE3D738C1BECCA5A0034D1E9 /* FBResponseFilePayload.h */; };
 		EEC289941BF0ED3000B4DC79 /* FBSession-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0CA1E51BF0D402005C43CD /* FBSession-Private.h */; };
 		EEC289AF1BF0EE2B00B4DC79 /* UITestingUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC288F71BF0ED2500B4DC79 /* UITestingUITests.m */; };
@@ -157,13 +157,13 @@
 		EEC28B081BF2128200B4DC79 /* FBUIASession.h in Headers */ = {isa = PBXBuildFile; fileRef = EEC28B061BF2128200B4DC79 /* FBUIASession.h */; };
 		EEC28B091BF2128200B4DC79 /* FBUIASession.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC28B071BF2128200B4DC79 /* FBUIASession.m */; };
 		EEC28B0F1BF215D800B4DC79 /* FBElement.m in Sources */ = {isa = PBXBuildFile; fileRef = EEC28B0E1BF215D800B4DC79 /* FBElement.m */; };
-		EED0313A1BFA3720007EDC1D /* CDStructures.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E71BFA3461007EDC1D /* CDStructures.h */; };
+		EED0313A1BFA3720007EDC1D /* CDStructures.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E71BFA3461007EDC1D /* CDStructures.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EED0313B1BFA397A007EDC1D /* _XCDarwinNotificationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030DC1BFA3461007EDC1D /* _XCDarwinNotificationExpectation.h */; };
 		EED0313C1BFA397A007EDC1D /* _XCInternalTestRun.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030DD1BFA3461007EDC1D /* _XCInternalTestRun.h */; };
 		EED0313D1BFA397A007EDC1D /* _XCKVOExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030DE1BFA3461007EDC1D /* _XCKVOExpectation.h */; };
 		EED0313E1BFA397A007EDC1D /* _XCNotificationExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030DF1BFA3461007EDC1D /* _XCNotificationExpectation.h */; };
 		EED0313F1BFA397A007EDC1D /* _XCPredicateExpectation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E01BFA3461007EDC1D /* _XCPredicateExpectation.h */; };
-		EED031401BFA397A007EDC1D /* _XCTestCaseImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E11BFA3461007EDC1D /* _XCTestCaseImplementation.h */; };
+		EED031401BFA397A007EDC1D /* _XCTestCaseImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E11BFA3461007EDC1D /* _XCTestCaseImplementation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EED031411BFA397A007EDC1D /* _XCTestCaseInterruptionException.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E21BFA3461007EDC1D /* _XCTestCaseInterruptionException.h */; };
 		EED031421BFA397A007EDC1D /* _XCTestDriverTestObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E31BFA3461007EDC1D /* _XCTestDriverTestObserver.h */; };
 		EED031431BFA397A007EDC1D /* _XCTestExpectationImplementation.h in Headers */ = {isa = PBXBuildFile; fileRef = EED030E41BFA3461007EDC1D /* _XCTestExpectationImplementation.h */; };
@@ -208,7 +208,7 @@
 		EED0316A1BFA397A007EDC1D /* XCTestCase-AsynchronousTestingPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = EED0310D1BFA3461007EDC1D /* XCTestCase-AsynchronousTestingPrivate.h */; };
 		EED0316B1BFA397A007EDC1D /* XCTestCase-RuntimeUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = EED0310E1BFA3461007EDC1D /* XCTestCase-RuntimeUtilities.h */; };
 		EED0316C1BFA397A007EDC1D /* XCTestCase-XCTestSuiteExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = EED0310F1BFA3461007EDC1D /* XCTestCase-XCTestSuiteExtensions.h */; };
-		EED0316D1BFA397A007EDC1D /* XCTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = EED031101BFA3461007EDC1D /* XCTestCase.h */; };
+		EED0316D1BFA397A007EDC1D /* XCTestCase.h in Headers */ = {isa = PBXBuildFile; fileRef = EED031101BFA3461007EDC1D /* XCTestCase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EED0316E1BFA397A007EDC1D /* XCTestCaseRun.h in Headers */ = {isa = PBXBuildFile; fileRef = EED031111BFA3461007EDC1D /* XCTestCaseRun.h */; };
 		EED0316F1BFA397A007EDC1D /* XCTestCaseSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = EED031121BFA3461007EDC1D /* XCTestCaseSuite.h */; };
 		EED031701BFA397A007EDC1D /* XCTestConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = EED031131BFA3461007EDC1D /* XCTestConfiguration.h */; };
@@ -2245,6 +2245,7 @@
 				EE836C0C1C0F118600D87246 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		EEC2894F1BF0ED2E00B4DC79 /* Build configuration list for PBXNativeTarget "XCTStubApps" */ = {
 			isa = XCConfigurationList;

--- a/XCTWebDriverAgentLib/FBXCTExceptionHandler.m
+++ b/XCTWebDriverAgentLib/FBXCTExceptionHandler.m
@@ -7,12 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <RoutingHTTPServer/RouteResponse.h>
-
 #import "FBXCTExceptionHandler.h"
+
+#import <RoutingHTTPServer/RouteResponse.h>
 
 #import "FBAlertViewCommands.h"
 #import "FBResponsePayload.h"
+#import "FBXCTSession.h"
 
 @implementation FBXCTExceptionHandler
 
@@ -20,6 +21,11 @@
 {
   if ([exception.name isEqualToString:FBUAlertObstructingElementException]) {
     id<FBResponsePayload> payload = FBResponseDictionaryWithStatus(FBCommandStatusUnexpectedAlertPresent, @"Alert is obstructing view");
+    [payload dispatchWithResponse:response];
+    return YES;
+  }
+  if ([exception.name isEqualToString:FBApplicationCrashedException]) {
+    id<FBResponsePayload> payload = FBResponseDictionaryWithStatus(FBCommandStatusStaleElementReference, [exception description]);
     [payload dispatchWithResponse:response];
     return YES;
   }

--- a/XCTWebDriverAgentLib/FBXCTSession.h
+++ b/XCTWebDriverAgentLib/FBXCTSession.h
@@ -12,6 +12,8 @@
 #import <XCTWebDriverAgentLib/FBSession.h>
 #import <XCTWebDriverAgentLib/XCUIApplication.h>
 
+extern NSString *const FBApplicationCrashedException;
+
 @interface FBXCTSession : FBSession
 @property (nonatomic, strong, readonly) XCUIApplication *application;
 

--- a/XCTWebDriverAgentLib/FBXCTSession.m
+++ b/XCTWebDriverAgentLib/FBXCTSession.m
@@ -18,6 +18,8 @@
 
 #import "FBXCTElementCache.h"
 
+NSString *const FBApplicationCrashedException = @"FBApplicationCrashedException";
+
 @interface FBXCTSession ()
 @property (nonatomic, strong, readwrite) XCUIApplication *application;
 @end
@@ -36,6 +38,9 @@
 
 - (XCUIApplication *)application
 {
+  if (!_application.running) {
+    [[NSException exceptionWithName:FBApplicationCrashedException reason:@"Application is not running, possibly crashed" userInfo:nil] raise];
+  }
   [_application resolve];
   return _application;
 }


### PR DESCRIPTION
At the moment whenever application crashes during test or we encounter any other failure test runner is immediately stopped as well.
It is way better to have test runner still responding to requests infroming that application is dead and possibly serve other requests.