### PR TITLE
Properly routes with session with empty path

### DIFF
--- a/WebDriverAgentCore/Routing/FBRoute.m
+++ b/WebDriverAgentCore/Routing/FBRoute.m
@@ -23,7 +23,7 @@
 
 @end
 
-static NSString *const FBRouteSessionPrefix = @"/session/:sessionID/";
+static NSString *const FBRouteSessionPrefix = @"/session/:sessionID";
 
 @interface FBRoute_Sync : FBRoute
 @property (nonatomic, copy, readwrite) FBRouteSyncHandler handler;
@@ -82,8 +82,11 @@ static NSString *const FBRouteSessionPrefix = @"/session/:sessionID/";
     }
   } else {
     if (range.location == 0) {
-      pathPattern = [pathPattern stringByReplacingCharactersInRange:range withString:@"/"];
+      pathPattern = [pathPattern stringByReplacingCharactersInRange:range withString:@""];
     }
+  }
+  if (pathPattern.length == 0) {
+    pathPattern = @"/";
   }
   return pathPattern;
 }

--- a/WebDriverAgentCoreTests/FBRouteTests.m
+++ b/WebDriverAgentCoreTests/FBRouteTests.m
@@ -17,17 +17,52 @@
 
 @implementation FBRouteTests
 
-- (void)testRouteWithSession
+- (void)testRouteWithSessionWithSlash
 {
   FBRoute *route = [[FBRoute POST:@"/deactivateApp"] respond:nil];
   XCTAssertEqualObjects(route.path, @"/session/:sessionID/deactivateApp");
+}
 
+- (void)testRouteWithSession
+{
+  FBRoute *route = [[FBRoute POST:@"deactivateApp"] respond:nil];
+  XCTAssertEqualObjects(route.path, @"/session/:sessionID/deactivateApp");
+}
+
+- (void)testRouteWithoutSessionWithSlash
+{
+  FBRoute *route = [[FBRoute POST:@"/deactivateApp"].withoutSession respond:nil];
+  XCTAssertEqualObjects(route.path, @"/deactivateApp");
 }
 
 - (void)testRouteWithoutSession
 {
-  FBRoute *route = [[FBRoute POST:@"/deactivateApp"].withoutSession respond:nil];
+  FBRoute *route = [[FBRoute POST:@"deactivateApp"].withoutSession respond:nil];
   XCTAssertEqualObjects(route.path, @"/deactivateApp");
+}
+
+- (void)testEmptyRouteWithSession
+{
+  FBRoute *route = [[FBRoute POST:@""] respond:nil];
+  XCTAssertEqualObjects(route.path, @"/session/:sessionID");
+}
+
+- (void)testEmptyRouteWithoutSession
+{
+  FBRoute *route = [[FBRoute POST:@""].withoutSession respond:nil];
+  XCTAssertEqualObjects(route.path, @"/");
+}
+
+- (void)testEmptyRouteWithSessionWithSlash
+{
+  FBRoute *route = [[FBRoute POST:@"/"] respond:nil];
+  XCTAssertEqualObjects(route.path, @"/session/:sessionID");
+}
+
+- (void)testEmptyRouteWithoutSessionWithSlash
+{
+  FBRoute *route = [[FBRoute POST:@"/"].withoutSession respond:nil];
+  XCTAssertEqualObjects(route.path, @"/");
 }
 
 @end


### PR DESCRIPTION
Fix issue where empty path routes with session were create with path "/session/:sessionID/session/:sessionID".