### PR TITLE
Fix for false status in response from simulator/touch_id

### DIFF
--- a/WebDriverAgentLib/Commands/FBTouchIDCommands.m
+++ b/WebDriverAgentLib/Commands/FBTouchIDCommands.m
@@ -27,7 +27,7 @@
       } else {
         name = "com.apple.BiometricKit_Sim.fingerTouch.nomatch";
       }
-      if (notify_post(name)) {
+      if (notify_post(name) == NOTIFY_STATUS_OK) {
         return FBResponseDictionaryWithOK();
       } else {
         return FBResponseDictionaryWithStatus(FBCommandStatusUnsupported, nil);


### PR DESCRIPTION
When making requests to `simulator/touch-id`, it would return a status of 1 even if the request didn't have any problems. It looks like the reason behind it is because `notify_post(name)` gets evaluated as `False` when the function returns `0` (i.e. `NOTIFY_STATUS_OK`), causing it to jump to the `else` and do that instead. This change resolves that problem by comparing the return value of `notify_post(name)` to   `NOTIFY_STATUS_OK`, instead of just trying to evaluate what the function returns as `True`/`False`.