### PR TITLE
Removed PROJECT env from build.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ branches:
     - master
 
 env:
-- PROJECT=WebDriverAgent.xcodeproj TARGET=WebDriverAgentLib SDK=iphonesimulator ACTION=test
-- PROJECT=WebDriverAgent.xcodeproj TARGET=WebDriverAgentRunner SDK=iphonesimulator ACTION=build
-- PROJECT=WebDriverAgent.xcodeproj TARGET=WebDriverAgentRunner SDK=iphoneos ACTION=build
-- PROJECT=WebDriverAgent.xcodeproj TARGET=WebDriverAgentUSBClient SDK=macosx ACTION=build
+- TARGET=WebDriverAgentLib SDK=iphonesimulator ACTION=test
+- TARGET=WebDriverAgentRunner SDK=iphonesimulator ACTION=build
+- TARGET=WebDriverAgentRunner SDK=iphoneos ACTION=build
+- TARGET=WebDriverAgentUSBClient SDK=macosx ACTION=build

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -12,7 +12,7 @@ set -eu
 
 function build() {
   xcodebuild \
-      -project $PROJECT \
+      -project WebDriverAgent.xcodeproj \
       -scheme $TARGET \
       -sdk $SDK \
       $ACTION \


### PR DESCRIPTION
Using only TARGET and ACTION is more readable on Travis task list and we only have one project file.