### PR TITLE
Kill FBAssertMainThread

### DIFF
--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -113,14 +113,11 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 
 + (XCUIElement *)elementUsing:(NSString *)usingText withValue:(NSString *)value under:(XCUIElement *)element
 {
-  FBAssertMainThread();
   return [[self elementsUsing:usingText withValue:value under:element] firstObject];
 }
 
 + (NSArray *)elementsUsing:(NSString *)usingText withValue:(NSString *)value under:(XCUIElement *)element
 {
-  FBAssertMainThread();
-
   NSArray *elements;
   const BOOL partialSearch = [usingText isEqualToString:@"partial link text"];
   const BOOL isSearchByIdentifier = ([usingText isEqualToString:@"name"] || [usingText isEqualToString:@"id"] || [usingText isEqualToString:@"accessibility id"]);

--- a/WebDriverAgentLib/Utilities/FBMacros.h
+++ b/WebDriverAgentLib/Utilities/FBMacros.h
@@ -7,9 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-// Convenience macro to make sure that we're running on the main thread.
-#define FBAssertMainThread() NSAssert([NSThread isMainThread], @"This method must be called on the main thread")
-
 // Typedef to help with storing constant strings for enums.
 #if __has_feature(objc_arc)
     typedef __unsafe_unretained NSString* FBLiteralString;


### PR DESCRIPTION
All requests should be handles on main thread, so checking everywhere for main thread is kind of redundant and pointless as we explicitly dispatch them on on main thread. Much better approach will be writing unit test.