### PR TITLE
Fixed application tests for Xcode 8

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -25,7 +25,7 @@
 {
   [self goToSpringBoard];
   XCTAssertTrue([FBSpringboardApplication fb_springboard].icons[@"Safari"].exists);
-  XCTAssertTrue([FBSpringboardApplication fb_springboard].icons[@"Game Center"].exists);
+  XCTAssertTrue([FBSpringboardApplication fb_springboard].icons[@"Extras"].exists);
 }
 
 - (void)testTappingAppOnSpringboard


### PR DESCRIPTION
"Game Center" has been moved so using "Extras" instead.

Test Plan: Run tests on Xcode 7 and Xcode 8