### PR TITLE
Move /source endpoint to GET

### DIFF
--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -23,6 +23,7 @@
   return
   @[
     [[FBRoute POST:@"/source"] respondWithTarget:self action:@selector(handleGetTreeCommand:)],
+    [[FBRoute GET:@"/source"] respondWithTarget:self action:@selector(handleGetTreeCommand:)],
     [[FBRoute POST:@"/source"].withoutSession respondWithTarget:self action:@selector(handleGetTreeCommand:)],
   ];
 }


### PR DESCRIPTION
The `/source` endpoint ought to be `GET`. See https://w3c.github.io/webdriver/webdriver-spec.html#getting-page-source