### PR TITLE
Fix inspector's cannot render hightlight node on screenshot issue.

### DIFF
--- a/Inspector/css/screen.css
+++ b/Inspector/css/screen.css
@@ -19,6 +19,6 @@
 
 .screen-highlighted-node {
   position: relative;
-  background: #D690A0;
-  opacity: 0.5;
+  background: #FBB2C2;
+  opacity: 0.8;
 }

--- a/Inspector/js/screen.js
+++ b/Inspector/js/screen.js
@@ -34,7 +34,7 @@ class Screen extends React.Component {
     return {
       width: screenshot.width * screenshot.scale,
       height: screenshot.height * screenshot.scale,
-    }
+    };
   }
 
   screenshot() {
@@ -72,10 +72,10 @@ class Screen extends React.Component {
 
     var scale = screenshot.scale;
     return {
-      left: rect.x * scale * 2,
-      top: rect.y * scale * 2 - topOffset * scale - elementsMargins,
-      width: rect.width * scale * 2,
-      height: rect.height * scale * 2,
+      left: rect.origin.x * scale * 2,
+      top: rect.origin.y * scale * 2 - topOffset * scale - elementsMargins,
+      width: rect.size.width * scale * 2,
+      height: rect.size.height * scale * 2,
     };
   }
 }


### PR DESCRIPTION
I found that that there are codes for highlighting selected nodes on screenshot, but it do not work. After debug I found it's caused by using wrong attribute name in rect.

After fix, elements of selected nodes in tree would be highlighted on screenshot like below:
![image](https://cloud.githubusercontent.com/assets/2800797/16760994/d1971df8-4850-11e6-871a-acf5d1fb736d.png)


Also, I change the css a little bit to make the highlight more obvious.