### PR TITLE
Made FBScrollingTests non-device specific

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
@@ -39,15 +39,20 @@
 
 - (void)testSimpleScroll
 {
+  FBAssertVisibleCell(@"0");
+  FBAssertVisibleCell(@"10");
   [self.tableView fb_scrollDown];
-  FBAssertVisibleCell(@"20");
+  FBAssertInvisibleCell(@"0");
+  FBAssertInvisibleCell(@"10");
+  XCTAssertTrue(self.testedApplication.cells.count > 0);
   [self.tableView fb_scrollUp];
   FBAssertVisibleCell(@"0");
+  FBAssertVisibleCell(@"10");
 }
 
 - (void)testScrollToVisible
 {
-  NSString *cellName = @"20";
+  NSString *cellName = @"30";
   FBAssertInvisibleCell(cellName);
   NSError *error;
   XCTAssertTrue([FBCellElementWithLabel(cellName) fb_scrollToVisibleWithError:&error]);


### PR DESCRIPTION
Different devices have different screen sizes which means we can't relay on certain elements being visible after single scroll. Better approach would be checking visibility of 'starting' elements before and after scroll, plus check for visibility of any cell. 