### PR TITLE
Made XCUIApplicationHelperTests non-device specific

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.h
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.h
@@ -29,9 +29,9 @@ extern NSString *const FBShowSheetAlertButtonName;
 - (void)goToAlertsPage;
 
 /**
- Navigates to SpringBoard
+ Navigates to SpringBoard first page
  */
-- (void)goToSpringBoard;
+- (void)goToSpringBoardFirstPage;
 
 /**
  Navigates integration app to scrolling page

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
@@ -51,10 +51,12 @@ NSString *const FBShowSheetAlertButtonName = @"Create Sheet Alert";
   FBAssertWaitTillBecomesTrue(self.testedApplication.buttons[FBShowAlertButtonName].fb_isVisible);
 }
 
-- (void)goToSpringBoard
+- (void)goToSpringBoardFirstPage
 {
   [[XCUIDevice sharedDevice] pressButton:XCUIDeviceButtonHome];
-  FBAssertWaitTillBecomesTrue([FBSpringboardApplication fb_springboard].icons[@"Safari"].fb_isVisible);
+  FBAssertWaitTillBecomesTrue([FBSpringboardApplication fb_springboard].icons[@"Safari"].exists);
+  [[XCUIDevice sharedDevice] pressButton:XCUIDeviceButtonHome];
+  FBAssertWaitTillBecomesTrue([FBSpringboardApplication fb_springboard].icons[@"Calendar"].exists);
 }
 
 - (void)gotToScrollsWithAccessibilityStrippedCells:(BOOL)accessibilityStrippedCells

--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -23,14 +23,14 @@
 
 - (void)testQueringSpringboard
 {
-  [self goToSpringBoard];
+  [self goToSpringBoardFirstPage];
   XCTAssertTrue([FBSpringboardApplication fb_springboard].icons[@"Safari"].exists);
-  XCTAssertTrue([FBSpringboardApplication fb_springboard].icons[@"Extras"].exists);
+  XCTAssertTrue([FBSpringboardApplication fb_springboard].icons[@"Calendar"].exists);
 }
 
 - (void)testTappingAppOnSpringboard
 {
-  [self goToSpringBoard];
+  [self goToSpringBoardFirstPage];
   NSError *error;
   XCTAssertTrue([[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:@"Safari" error:&error]);
   XCTAssertNil(error);
@@ -67,7 +67,7 @@
 - (void)testActiveApplication
 {
   XCTAssertTrue([FBApplication fb_activeApplication].buttons[@"Alerts"].fb_isVisible);
-  [self goToSpringBoard];
+  [self goToSpringBoardFirstPage];
   XCTAssertTrue([FBApplication fb_activeApplication].icons[@"Safari"].fb_isVisible);
 }
 


### PR DESCRIPTION
Different devices (iPad vs iPhone) on different iOS version have different icons on second SpringBoard screen. Changed tests to go to first screen instead to validate icon detection, which is much more reliable cross devices and iOS versions.