### PR TITLE
Stabilize fb_deactivateWithDuration

### DIFF
--- a/WebDriverAgentLib/FBSpringboardApplication.m
+++ b/WebDriverAgentLib/FBSpringboardApplication.m
@@ -45,7 +45,13 @@
   if (![appElement fb_tapWithError:error]) {
     return NO;
   }
-  return YES;
+  return
+  [[[[FBRunLoopSpinner new]
+     interval:0.3]
+    timeoutErrorMessage:@"Timeout waiting for application to activate"]
+   spinUntilTrue:^BOOL{
+     return !self.fb_mainWindowSnapshot.fb_isVisible;
+   } error:error];
 }
 
 - (BOOL)fb_waitUntilApplicationBoardIsVisible:(NSError **)error


### PR DESCRIPTION
Deactivate application test is randomly failing, as we might return before application becomes active.
This happens, because it returns immediately after tapping application icon on springboard. We can fix this by simply waiting for springboard to disappear before returning control.
