### PR TITLE
updating scrolling logic to find scrollable visible Parent

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.h
@@ -38,12 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable XCElementSnapshot *)fb_parentMatchingType:(XCUIElementType)type;
 
 /**
- Returns first (going up element tree) parent that matches one of given types. If non found returns nil.
+ Returns first (going up element tree) visible parent that matches one of given types. If non found returns nil.
  
  @param types possible parent types
- @return parent element matching one of given types
+ @return visible parent element matching one of given types
  */
-- (nullable XCElementSnapshot *)fb_parentMatchingOneOfTypes:(NSArray<NSNumber *> *)types;
+- (nullable XCElementSnapshot *)fb_findVisibleParentMatchingOneOfTypes:(NSArray<NSNumber *> *)types;
 
 /**
  Returns value for given accessibility property identifier.

--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -14,6 +14,7 @@
 #import "FBFindElementCommands.h"
 #import "FBRunLoopSpinner.h"
 #import "FBLogger.h"
+#import "FBMacros.h"
 #import "FBXPathCreator.h"
 #import "XCAXClient_iOS.h"
 #import "XCTestDriver.h"
@@ -25,6 +26,7 @@ static NSString *const kXMLIndexPathKey = @"private_indexPath";
 
 inline static BOOL valuesAreEqual(id value1, id value2);
 inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, NSArray<NSNumber *> *types);
+inline static BOOL doesSnapshotHasMoreThanOneVisibleChildrenSnapshots(XCElementSnapshot* snapshot);
 
 @implementation XCElementSnapshot (FBHelpers)
 
@@ -97,11 +99,14 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
   return snapshot;
 }
 
-- (XCElementSnapshot *)fb_parentMatchingOneOfTypes:(NSArray<NSNumber *> *)types
+- (XCElementSnapshot *)fb_findVisibleParentMatchingOneOfTypes:(NSArray<NSNumber *> *)types
 {
   XCElementSnapshot *snapshot = self.parent;
-  while (snapshot && !isSnapshotTypeAmongstGivenTypes(snapshot, types)) {
-      snapshot = snapshot.parent;
+  while (snapshot) {
+    if (isSnapshotTypeAmongstGivenTypes(snapshot, types) && [snapshot isWDVisible] && doesSnapshotHasMoreThanOneVisibleChildrenSnapshots(snapshot)) {
+      break;
+    }
+    snapshot = snapshot.parent;
   }
   return snapshot;
 }
@@ -135,6 +140,20 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
    if([@(snapshot.elementType) isEqual: types[i]] || [types[i] isEqual: @(XCUIElementTypeAny)]){
        return YES;
    }
+  }
+  return NO;
+}
+
+inline static BOOL doesSnapshotHasMoreThanOneVisibleChildrenSnapshots(XCElementSnapshot* snapshot)
+{
+  NSArray<XCElementSnapshot *> *cellSnapshots = [snapshot fb_descendantsMatchingType:XCUIElementTypeCell];
+  if (cellSnapshots.count == 0) {
+    // In some cases XCTest will not report Cell Views. In that case grabbing descendants and trying to figure out scroll directon from them.
+    cellSnapshots = snapshot._allDescendants;
+  }
+  NSArray<XCElementSnapshot *> *visibleCellSnapshots = [cellSnapshots filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K == YES", FBStringify(XCUIElement, isWDVisible)]];
+  if (visibleCellSnapshots.count > 1) {
+    return YES;
   }
   return NO;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -91,8 +91,9 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   
   if (scrollView == nil) {
     return
-    [[FBErrorBuilder builder]
-      withDescriptionFormat:@"Failed to find scrollable visible parent"];
+    [[[FBErrorBuilder builder]
+      withDescriptionFormat:@"Failed to find scrollable visible parent"]
+     buildError:error];
   }
 
   XCElementSnapshot *targetCellSnapshot = self.fb_parentCellSnapshot;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -44,7 +44,7 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
 - (void)fb_scrollRightByNormalizedDistance:(CGFloat)distance;
 - (BOOL)fb_scrollByNormalizedVector:(CGVector)normalizedScrollVector;
 - (BOOL)fb_scrollByVector:(CGVector)vector error:(NSError **)error;
-- (XCElementSnapshot *)fb_findScrollViewWithVisibleCellSnapshotWitherror:(NSError **)error;
+- (XCElementSnapshot *)fb_findVisibleScrollableView;
 
 @end
 
@@ -81,13 +81,15 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   if (self.fb_isVisible) {
     return YES;
   }
- /* NSArray *possibleParents = @[
-                               @(XCUIElementTypeScrollView),
-                               @(XCUIElementTypeCollectionView),
-                               @(XCUIElementTypeTable),
-                              ];*/
-    
-  XCElementSnapshot *scrollView = [self.lastSnapshot fb_findScrollViewWithVisibleCellSnapshotWitherror:error];
+
+  XCElementSnapshot *scrollView = [self.lastSnapshot fb_findVisibleScrollableView];
+  
+  if (scrollView == nil) {
+    return
+    [[[FBErrorBuilder builder]
+      withDescriptionFormat:@"Failed to find scrollable visible parent"]
+       buildError:error];
+  }
 
   XCElementSnapshot *targetCellSnapshot = self.fb_parentCellSnapshot;
   NSArray<XCElementSnapshot *> *cellSnapshots = [scrollView fb_descendantsMatchingType:XCUIElementTypeCell];
@@ -198,32 +200,6 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   [self fb_scrollByNormalizedVector:CGVectorMake(-distance, 0.0)];
 }
 
-- (XCElementSnapshot *)fb_findScrollViewWithVisibleCellSnapshotWitherror:(NSError **)error
-{
-    NSArray *possibleParents = @[
-                                 @(XCUIElementTypeScrollView),
-                                 @(XCUIElementTypeCollectionView),
-                                 @(XCUIElementTypeTable),
-                                 ];
-    
-    XCElementSnapshot *scrollView = [self fb_parentMatchingOneOfTypes:possibleParents];
-    
-    NSArray<XCElementSnapshot *> *cellSnapshots = [scrollView fb_descendantsMatchingType:XCUIElementTypeCell];
-    if (cellSnapshots.count == 0) {
-        // In some cases XCTest will not report Cell Views. In that case grabbing descendants and trying to figure out scroll directon from them.
-        cellSnapshots = scrollView._allDescendants;
-    }
-    NSArray<XCElementSnapshot *> *visibleCellSnapshots = [cellSnapshots filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K == YES", FBStringify(XCUIElement, fb_isVisible)]];
-    
-    if (visibleCellSnapshots.count < 2) {
-        return [scrollView fb_findScrollViewWithVisibleCellSnapshotWitherror:error];
-        
-    } else {
-        return scrollView;
-    }
-    
-}
-
 - (BOOL)fb_scrollByNormalizedVector:(CGVector)normalizedScrollVector
 {
   CGVector scrollVector = CGVectorMake(CGRectGetWidth(self.frame) * normalizedScrollVector.dx,
@@ -303,6 +279,25 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   // We should wait till scroll view cools off, before continuing
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:FBScrollCoolOffTime]];
   return didSucceed;
+}
+
+- (XCElementSnapshot *)fb_findVisibleScrollableView
+{
+  NSArray *possibleParents = @[
+                               @(XCUIElementTypeScrollView),
+                               @(XCUIElementTypeCollectionView),
+                               @(XCUIElementTypeTable),
+                              ];
+    
+  XCElementSnapshot *scrollView = [self fb_parentMatchingOneOfTypes:possibleParents];
+    
+  if (scrollView == nil) {
+    return nil;
+  } else if (![scrollView fb_isVisible]) {
+    return [scrollView fb_findVisibleScrollableView];
+  } else {
+    return scrollView;
+  }
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCElementSnapshotHelperTests.m
@@ -64,35 +64,35 @@
   XCTAssertEqual(windowSnapshot.elementType, XCUIElementTypeWindow);
 }
 
-- (void)testParentMatchingOneOfTypes
+- (void)testFindVisibleParentMatchingOneOfTypes
 {
   [self goToAttributesPage];
   XCUIElement *todayPickerWheel = self.testedApplication.pickerWheels[@"Today"];
   XCTAssertTrue(todayPickerWheel.exists);
   [todayPickerWheel resolve];
-  XCElementSnapshot *datePicker = [todayPickerWheel.lastSnapshot fb_parentMatchingOneOfTypes:@[@(XCUIElementTypeDatePicker), @(XCUIElementTypeWindow)]];
+  XCElementSnapshot *datePicker = [todayPickerWheel.lastSnapshot fb_findVisibleParentMatchingOneOfTypes:@[@(XCUIElementTypeDatePicker), @(XCUIElementTypeWindow)]];
   XCTAssertNotNil(datePicker);
   XCTAssertEqual(datePicker.elementType, XCUIElementTypeDatePicker);
 }
 
-- (void)testParentMatchingOneOfTypesWithXCUIElementTypeAny
+- (void)testFindVisibleParentMatchingOneOfTypesWithXCUIElementTypeAny
 {
   [self goToAttributesPage];
   XCUIElement *todayPickerWheel = self.testedApplication.pickerWheels[@"Today"];
   XCTAssertTrue(todayPickerWheel.exists);
   [todayPickerWheel resolve];
-  XCElementSnapshot *otherSnapshot = [todayPickerWheel.lastSnapshot fb_parentMatchingOneOfTypes:@[@(XCUIElementTypeAny), @(XCUIElementTypeWindow)]];
+  XCElementSnapshot *otherSnapshot = [todayPickerWheel.lastSnapshot fb_findVisibleParentMatchingOneOfTypes:@[@(XCUIElementTypeAny), @(XCUIElementTypeWindow)]];
   XCTAssertNotNil(otherSnapshot);
   XCTAssertEqual(otherSnapshot.elementType, XCUIElementTypeOther);
 }
 
-- (void)testParentMatchingOneOfTypesWithAbsentParents
+- (void)testFindVisibleParentMatchingOneOfTypesWithAbsentParents
 {
   [self goToAttributesPage];
   XCUIElement *todayPickerWheel = self.testedApplication.pickerWheels[@"Today"];
   XCTAssertTrue(todayPickerWheel.exists);
   [todayPickerWheel resolve];
-  XCElementSnapshot *otherSnapshot = [todayPickerWheel.lastSnapshot fb_parentMatchingOneOfTypes:@[@(XCUIElementTypeTab), @(XCUIElementTypeLink)]];
+  XCElementSnapshot *otherSnapshot = [todayPickerWheel.lastSnapshot fb_findVisibleParentMatchingOneOfTypes:@[@(XCUIElementTypeTab), @(XCUIElementTypeLink)]];
   XCTAssertNil(otherSnapshot);
 }
 


### PR DESCRIPTION
@marekcirkos : I just want to make sure that its okay to have this logic for scroll. Here we are not doing any scrolling to find parent element but just find parent element who has visible cell snapshot. Lot of code is repetitive and doesn't follow indentation rules. I can fix that later. First I just want to confirm if this approach is okay with you.
In earlier logic I was doing scroll and in fact that was recursive. Here we are just recursively finding parent element with visible snapshot.
