### PR TITLE
Moved visibility tests

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementAttributeTests.m
@@ -26,18 +26,6 @@
   [self goToAttributesPage];
 }
 
-- (void)testIsVisible
-{
-  XCTAssertTrue(self.testedApplication.buttons[@"Button"].exists);
-  XCTAssertTrue(self.testedApplication.buttons[@"Button"].fb_isVisible);
-
-  XCTAssertTrue(self.testedApplication.staticTexts[@"alpha_invisible"].exists);
-  XCTAssertFalse(self.testedApplication.staticTexts[@"alpha_invisible"].fb_isVisible);
-
-  XCTAssertTrue(self.testedApplication.staticTexts[@"hidden_invisible"].exists);
-  XCTAssertFalse(self.testedApplication.staticTexts[@"hidden_invisible"].fb_isVisible);
-}
-
 - (void)testIsAccessible
 {
   XCTAssertTrue(self.testedApplication.buttons[@"Button"].exists);

--- a/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
@@ -37,6 +37,14 @@
   [self.tableView resolve];
 }
 
+- (void)testCellVisibility
+{
+  FBAssertVisibleCell(@"0");
+  FBAssertVisibleCell(@"10");
+  FBAssertInvisibleCell(@"30");
+  FBAssertInvisibleCell(@"50");
+}
+
 - (void)testSimpleScroll
 {
   FBAssertVisibleCell(@"0");


### PR DESCRIPTION
XCTest on iOS 10.x does not report hidden and alpha hidden elements any more, however off-view cells are still reported. In order to keep visibility tests working on both iOS 9 and iOS 10 this diff moves that test to FBScrollingTests.
