### PR TITLE
Fix xcodebuild failure due to exit code 65.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ branches:
     - master
 
 env:
-- TARGET=WebDriverAgentLib SDK=iphonesimulator DESTINATION='iPad 2' ACTION=test
-- TARGET=WebDriverAgentLib SDK=iphonesimulator DESTINATION='iPhone 6' ACTION=test
+- TARGET=WebDriverAgentLib SDK=iphonesimulator DESTINATION='iPad 2' ACTION='build test'
+- TARGET=WebDriverAgentLib SDK=iphonesimulator DESTINATION='iPhone 6' ACTION='build test'
 - TARGET=WebDriverAgentRunner SDK=iphonesimulator ACTION=build
 - TARGET=WebDriverAgentRunner SDK=iphoneos ACTION=build
 - TARGET=WebDriverAgentUSBClient SDK=macosx ACTION=build


### PR DESCRIPTION
Travis often fails with exit code 65. After some digging I found out that it is due to fact that xcodebuild's 'test' command counts build time as simulator booting time so it is easy to get timeout on that step.
Easy solution is to explicitly build first and then run test.