### PR TITLE
Fix scrolling on springboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS X
+.DS_Store
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.h
@@ -11,6 +11,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ Defines directions in which scrolling is possible.
+ */
+typedef NS_ENUM(NSUInteger, FBXCUIElementScrollDirection) {
+  FBXCUIElementScrollDirectionUnknown,
+  FBXCUIElementScrollDirectionVertical,
+  FBXCUIElementScrollDirectionHorizontal,
+};
+
 @interface XCUIElement (FBScrolling)
 
 /**
@@ -43,13 +52,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Scrolls parent scroll view till receiver is visible. Whenever element is invisible it scrolls by normalizedScrollDistance
- in it's direction. Eg. if normalizedScrollDistance is equal to 0.5, each step will scroll by half of scroll view's size.
+ in its direction. E.g. if normalizedScrollDistance is equal to 0.5, each step will scroll by half of scroll view's size.
 
  @param normalizedScrollDistance single scroll step normalized (0.0 - 1.0) distance
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return YES if the operation succeeds, otherwise NO.
  */
 - (BOOL)fb_scrollToVisibleWithNormalizedScrollDistance:(CGFloat)normalizedScrollDistance error:(NSError **)error;
+
+/**
+ Scrolls parent scroll view till receiver is visible. Whenever element is invisible it scrolls by normalizedScrollDistance
+ in its direction. E.g. if normalizedScrollDistance is equal to 0.5, each step will scroll by half of scroll view's size.
+
+ @param normalizedScrollDistance single scroll step normalized (0.0 - 1.0) distance
+ @param scrollDirection the direction in which the scroll view should be scrolled, or FBXCUIElementScrollDirectionUnknown 
+ to attempt to determine it automatically
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if the operation succeeds, otherwise NO.
+ */
+- (BOOL)fb_scrollToVisibleWithNormalizedScrollDistance:(CGFloat)normalizedScrollDistance scrollDirection:(FBXCUIElementScrollDirection)scrollDirection error:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -120,16 +120,11 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   XCElementSnapshot *lastSnapshot = visibleCellSnapshots.lastObject;
   // Can't just do indexOfObject, because targetCellSnapshot may represent the same object represented by a member of cellSnapshots, yet be a different object
   // than that member. This reflects the fact that targetCellSnapshot came out of self.fb_parentCellSnapshot, not out of cellSnapshots directly.
+  // If the result is NSNotFound, we'll just proceed by scrolling downward/rightward, since NSNotFound will always be larger than the current index.
   NSUInteger targetCellIndex = [cellSnapshots indexOfObjectPassingTest:^BOOL(XCElementSnapshot * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
     return [obj _matchesElement:targetCellSnapshot];
   }];
   NSUInteger visibleCellIndex = [cellSnapshots indexOfObject:lastSnapshot];
-
-  if (targetCellIndex == NSNotFound) {
-    return [[[FBErrorBuilder builder]
-             withDescription:@"Failed to perform scroll, target cell not found"]
-            buildError:error];
-  }
 
   if (scrollDirection == FBXCUIElementScrollDirectionUnknown) {
     // Try to determine the scroll direction by determining the vector between the first and last visible cells

--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -118,7 +118,11 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
 
 
   XCElementSnapshot *lastSnapshot = visibleCellSnapshots.lastObject;
-  NSUInteger targetCellIndex = [cellSnapshots indexOfObject:targetCellSnapshot];
+  // Can't just do indexOfObject, because targetCellSnapshot may represent the same object represented by a member of cellSnapshots, yet be a different object
+  // than that member. This reflects the fact that targetCellSnapshot came out of self.fb_parentCellSnapshot, not out of cellSnapshots directly.
+  NSUInteger targetCellIndex = [cellSnapshots indexOfObjectPassingTest:^BOOL(XCElementSnapshot * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+    return [obj _matchesElement:targetCellSnapshot];
+  }];
   NSUInteger visibleCellIndex = [cellSnapshots indexOfObject:lastSnapshot];
 
   if (targetCellIndex == NSNotFound) {

--- a/WebDriverAgentLib/FBSpringboardApplication.m
+++ b/WebDriverAgentLib/FBSpringboardApplication.m
@@ -39,7 +39,7 @@
   XCUIElement *appElement = [[self descendantsMatchingType:XCUIElementTypeAny]
                              elementMatchingPredicate:[NSPredicate predicateWithFormat:@"%K = %@", FBStringify(XCUIElement, identifier), identifier]
                              ];
-  if (![appElement fb_scrollToVisibleWithNormalizedScrollDistance:1.0 error:error]) {
+  if (![appElement fb_scrollToVisibleWithNormalizedScrollDistance:1.0 scrollDirection:FBXCUIElementScrollDirectionHorizontal error:error]) {
     return NO;
   }
   if (![appElement fb_tapWithError:error]) {


### PR DESCRIPTION
This PR fixes #269. Contents include:

- Add `fb_scrollToVisibleWithNormalizedScrollDistance:scrollDirection:error:` as the primary scroll method, which accepts a scroll direction parameter
- Make `fb_scrollToVisibleWithNormalizedScrollDistance:scrollDirection:error:` only guess at the scroll direction if it is passed `FBXCUIElementScrollDirectionUnknown` as the scroll direction
- Allow cells that are of type `XCUIElementTypeIcon` if none of type `XCUIElementTypeCell` can be found
- Return an error if the target cell cannot be found
- Allow parent cells of type `XCUIElementTypeIcon` in addition to `XCUIElementTypeCell`
- Use the new `fb_scrollToVisibleWithNormalizedScrollDistance:scrollDirection:error:` in `fb_tapApplicationWithIdentifier:error:`
- Add `.DS_Store` to `.gitignore`
- Fix some variable name and documentation typos