### PR TITLE
Adding isVisible and isEnabled to the XML tree that is searchable by XPaths

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -76,6 +76,8 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
   if (snapshot.wdLabel) {
     [xmlElement addAttribute:[DDXMLNode attributeWithName:@"label" stringValue:snapshot.wdLabel]];
   }
+  [xmlElement addAttribute:[DDXMLNode attributeWithName:@"isVisible" stringValue:snapshot.wdVisible ? @"1" : @"0"]];
+  [xmlElement addAttribute:[DDXMLNode attributeWithName:@"isEnabled" stringValue:snapshot.wdEnabled ? @"1" : @"0"]];
   [xmlElement addAttribute:[DDXMLNode attributeWithName:kXMLIndexPathKey stringValue:indexPath]];
 
   NSArray *children = snapshot.children;

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -12,6 +12,7 @@
 #import "FBIntegrationTestCase.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBFind.h"
+#import "XCUIElement+FBIsVisible.h"
 
 @interface XCUIElementFBFindTests : FBIntegrationTestCase
 @property (nonatomic, strong) XCUIElement *testedView;
@@ -59,6 +60,25 @@
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
+}
+
+- (void)testVisibleDescendantWithXPathQuery
+{
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@name='Alerts' and @isEnabled=1 and @isVisible=1]"];
+  XCTAssertEqual(matchingSnapshots.count, 1);
+  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
+  XCTAssertTrue(matchingSnapshots.lastObject.isEnabled);
+  XCTAssertTrue(matchingSnapshots.lastObject.fb_isVisible);
+  XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
+}
+
+- (void)testInvisibleDescendantWithXPathQuery
+{
+  [self goToAttributesPage];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypePageIndicator[@isVisible=0]"];
+  XCTAssertEqual(matchingSnapshots.count, 1);
+  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypePageIndicator);
+  XCTAssertFalse(matchingSnapshots.lastObject.fb_isVisible);
 }
 
 - (void)testDescendantsWithPredicateString


### PR DESCRIPTION
`GET /source` includes `isVisible` and `isEnabled` attributes, however, constructing an XPath expression that includes them fails to match any elements, e.g. `//XCUIElementTypeImage[@isVisible='1']`.