### PR TITLE
Send string to picker when setting value

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -136,11 +136,14 @@
   if (!value) {
     return FBResponseWithErrorFormat(@"Missing 'value' parameter");
   }
+  NSString *textToType = value;
+  if ([value isKindOfClass:[NSArray class]]) {
+    textToType = [value componentsJoinedByString:@""];
+  }
   if (element.elementType == XCUIElementTypePickerWheel) {
-    [element adjustToPickerWheelValue:value];
+    [element adjustToPickerWheelValue:textToType];
     return FBResponseWithOK();
   }
-  NSString *textToType = [value componentsJoinedByString:@""];
   NSError *error = nil;
   if (![element fb_typeText:textToType error:&error]) {
     return FBResponseWithError(error);


### PR DESCRIPTION
I'm not at all certain that this is the correct way to do this, but it fixes the problem.

When sending text to a PickerWheel, in order to set it, the array value is not found in the possible values and it is rejected. So concatenate the array into a string.

See https://github.com/appium/appium/issues/6873