### PR TITLE
Add copied Cartfile.resolved to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ xcuserdata
 # Carthage
 Carthage/Build
 Carthage/Checkouts
+Carthage/Cartfile.resolved
 
 # Resource bundle recreated on each build
 Resources/WebDriverAgent.bundle


### PR DESCRIPTION
[`bootstrap.sh` copies `Cartfile.resolved` into the `Carthage` directory][1] as of [`eb28d74`][2]. This diff adds that copied file to `.gitignore`.

[1]: https://github.com/facebook/WebDriverAgent/blob/7ce95d21f990cf32fc623058d5cb74303edfb9e5/Scripts/bootstrap.sh#L50
[2]: https://github.com/facebook/WebDriverAgent/commit/eb28d747bcbd0e3432a84ccd0e528e902bd7cc61