### PR TITLE
Updated FBConfiguration.m

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -16,7 +16,7 @@
 
 BOOL _AXSAutomationSetFauxCollectionViewCellsEnabled(BOOL);
 
-static NSUInteger const DefaultStartingPort = 8100;
+//static NSUInteger const DefaultStartingPort = 8100;
 static NSUInteger const DefaultPortRange = 100;
 
 @implementation FBConfiguration
@@ -35,6 +35,10 @@ static NSUInteger const DefaultPortRange = 100;
 
 + (NSRange)bindingPortRange
 {
+    int lower = 8100;
+    int upper = 8200;
+    int DefaultRandomStartingPort = lower + arc4random() % (upper - lower);
+
   // 'WebDriverAgent --port 8080' can be passed via the arguments to the process
   if (self.bindingPortRangeFromArguments.location != NSNotFound) {
     return self.bindingPortRangeFromArguments;
@@ -45,7 +49,7 @@ static NSUInteger const DefaultPortRange = 100;
     return NSMakeRange([NSProcessInfo.processInfo.environment[@"USE_PORT"] integerValue] , 1);
   }
 
-  return NSMakeRange(DefaultStartingPort, DefaultPortRange);
+  return NSMakeRange(DefaultRandomStartingPort, DefaultPortRange);
 }
 
 + (BOOL)shouldListenOnUSB


### PR DESCRIPTION
Instead of fixed default port 8100, allow random ports allocation between 8100 - 8200.
Random port allow to use multiple instance at a time for different devices. 
Randomising port is very useful for iOS real device parallel appium Automation.