### PR TITLE
Fix build fail on case sensitive filesystems

### DIFF
--- a/WebDriverAgentLib/Routing/FBHTTPOverUSBServer.m
+++ b/WebDriverAgentLib/Routing/FBHTTPOverUSBServer.m
@@ -12,7 +12,7 @@
 
 #import <RoutingHTTPServer/RoutingHTTPServer.h>
 
-#import <peertalk/PTChannel.h>
+#import <Peertalk/PTChannel.h>
 
 #import "FBLogger.h"
 


### PR DESCRIPTION
If you enabled case sensitive filesystem on your Mac, you can't build WDA, because filepath is be wrong.
It's very small but very important change