### PR TITLE
Support creating a new session without launching an app

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -40,21 +40,28 @@
 + (id<FBResponsePayload>)handleCreateSession:(FBRouteRequest *)request
 {
   NSDictionary *requirements = request.arguments[@"desiredCapabilities"];
-  NSString *bundleID = requirements[@"bundleId"];
-  NSString *appPath = requirements[@"app"];
-  if (!bundleID) {
-    return FBResponseWithErrorFormat(@"'bundleId' desired capability not provided");
-  }
-  FBApplication *app = [[FBApplication alloc] initPrivateWithPath:appPath bundleID:bundleID];
-  app.fb_shouldWaitForQuiescence = [requirements[@"shouldWaitForQuiescence"] boolValue];
-  app.launchArguments = (NSArray<NSString *> *)requirements[@"arguments"] ?: @[];
-  app.launchEnvironment = (NSDictionary <NSString *, NSString *> *)requirements[@"environment"] ?: @{};
-  [app launch];
+  
+  if (requirements)
+  {
+    NSString *bundleID = requirements[@"bundleId"];
+    NSString *appPath = requirements[@"app"];
+    if (bundleID) {
+      FBApplication *app = [[FBApplication alloc] initPrivateWithPath:appPath bundleID:bundleID];
+      app.fb_shouldWaitForQuiescence = [requirements[@"shouldWaitForQuiescence"] boolValue];
+      app.launchArguments = (NSArray<NSString *> *)requirements[@"arguments"] ?: @[];
+      app.launchEnvironment = (NSDictionary <NSString *, NSString *> *)requirements[@"environment"] ?: @{};
+      [app launch];
 
-  if (app.processID == 0) {
-    return FBResponseWithErrorFormat(@"Failed to launch %@ application", bundleID);
+      if (app.processID == 0) {
+        return FBResponseWithErrorFormat(@"Failed to launch %@ application", @"0");
+      }
+        
+      [FBSession sessionWithApplication:app];
+    }
   }
-  [FBSession sessionWithApplication:app];
+  else {
+    [FBSession new];
+  }
   return FBResponseWithObject(FBSessionCommands.sessionInformation);
 }
 


### PR DESCRIPTION
We launch applications on iOS devices using instruments, but wanted to use the WebDriverAgent to automate certain actions (like dismissing alerts).

We found that a session will, in most cases, use the foremost application, and that launching an application when creating a session was not a hard requirement.

This PR changes the `handleCreateSession` method so that if no `desiredCapabilities` are present and/or no `bundleId` is specified, a new session is created but an application is not launched.

A session created without desired capabilities can still be used to automate apps; given that they were either already active or are launched through another channel.

Let me know if this is something that could be merged upstream.