### PR TITLE
Support clicking on a specific alert button

### DIFF
--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -75,7 +75,7 @@
 + (id<FBResponsePayload>)handleGetAlertButtonsCommand:(FBRouteRequest *)request {
   FBSession *session = request.session;
   FBAlert *alert = [FBAlert alertWithApplication:session.application];
-  NSArray *labels = alert.labels;
+  NSArray *labels = alert.buttonLabels;
   
   if (!labels) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -25,6 +25,8 @@
     [[FBRoute GET:@"/alert/text"] respondWithTarget:self action:@selector(handleAlertTextCommand:)],
     [[FBRoute POST:@"/alert/accept"] respondWithTarget:self action:@selector(handleAlertAcceptCommand:)],
     [[FBRoute POST:@"/alert/dismiss"] respondWithTarget:self action:@selector(handleAlertDismissCommand:)],
+    [[FBRoute GET:@"/alert/buttons"] respondWithTarget:self action:@selector(handleGetAlertButtonsCommand:)],
+    [[FBRoute POST:@"/alert/click/:label"] respondWithTarget:self action:@selector(handleClickAlertButtonCommand:)],
   ];
 }
 
@@ -59,4 +61,26 @@
   return FBResponseWithOK();
 }
 
++ (id<FBResponsePayload>)handleGetAlertButtonsCommand:(FBRouteRequest *)request {
+  FBSession *session = request.session;
+  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  NSMutableArray *labels = alert.labels;
+  
+  if (!labels) {
+    return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
+  }
+  return FBResponseWithStatus(FBCommandStatusNoError, labels);
+}
+
++ (id<FBResponsePayload>)handleClickAlertButtonCommand:(FBRouteRequest *)request {
+  FBSession *session = request.session;
+  NSString *label = request.parameters[@"label"];
+  
+  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  
+  if (![alert clickAlertButton:label withError:nil]) {
+    return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
+  }
+  return FBResponseWithOK();
+}
 @end

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -56,7 +56,7 @@
     if (![alert clickAlertButton:name error:&error]) {
       return FBResponseWithError(error);
     }
-  } else if (![alert acceptWithError:nil]) {
+  } else if (![alert acceptWithError:&error]) {
     return FBResponseWithError(error);
   }
   return FBResponseWithOK();
@@ -76,7 +76,7 @@
     if (![alert clickAlertButton:name error:&error]) {
       return FBResponseWithError(error);
     }
-  } else if (![alert dismissWithError:nil]) {
+  } else if (![alert dismissWithError:&error]) {
     return FBResponseWithError(error);
   }
   return FBResponseWithOK();
@@ -85,11 +85,11 @@
 + (id<FBResponsePayload>)handleGetAlertButtonsCommand:(FBRouteRequest *)request {
   FBSession *session = request.session;
   FBAlert *alert = [FBAlert alertWithApplication:session.application];
-  NSArray *labels = alert.buttonLabels;
-  
-  if (!labels) {
+
+  if (!alert.isPresent) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
   }
+  NSArray *labels = alert.buttonLabels;
   return FBResponseWithStatus(FBCommandStatusNoError, labels);
 }
 @end

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -46,13 +46,17 @@
 {
   FBSession *session = request.session;
   NSString *name = request.parameters[@"name"];
+  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  NSError *error;
 
-  if ([name length] != 0) {
-    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name error:nil]) {
-      return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
-    }
-  } else if (![[FBAlert alertWithApplication:session.application] acceptWithError:nil]) {
+  if (!alert.isPresent) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
+  }
+  if ([name length] != 0) {    if (![alert clickAlertButton:name error:&error]) {
+      return FBResponseWithError(error);
+    }
+  } else if (![alert acceptWithError:nil]) {
+    return FBResponseWithError(error);
   }
   return FBResponseWithOK();
 }
@@ -61,13 +65,18 @@
 {
   FBSession *session = request.session;
   NSString *name = request.parameters[@"name"];
-
-  if ([name length] != 0) {
-    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name error:nil]) {
-      return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
-    }
-  } else if (![[FBAlert alertWithApplication:session.application] dismissWithError:nil]) {
+  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  NSError *error;
+    
+  if (!alert.isPresent) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
+  }
+  if ([name length] != 0) {
+    if (![alert clickAlertButton:name error:&error]) {
+      return FBResponseWithError(error);
+    }
+  } else if (![alert dismissWithError:nil]) {
+    return FBResponseWithError(error);
   }
   return FBResponseWithOK();
 }

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -48,7 +48,7 @@
   NSString *name = request.parameters[@"name"];
 
   if ([name length] != 0) {
-    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name withError:nil]) {
+    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name error:nil]) {
       return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
     }
   } else if (![[FBAlert alertWithApplication:session.application] acceptWithError:nil]) {
@@ -63,7 +63,7 @@
   NSString *name = request.parameters[@"name"];
 
   if ([name length] != 0) {
-    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name withError:nil]) {
+    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name error:nil]) {
       return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
     }
   } else if (![[FBAlert alertWithApplication:session.application] dismissWithError:nil]) {
@@ -75,7 +75,7 @@
 + (id<FBResponsePayload>)handleGetAlertButtonsCommand:(FBRouteRequest *)request {
   FBSession *session = request.session;
   FBAlert *alert = [FBAlert alertWithApplication:session.application];
-  NSMutableArray *labels = alert.labels;
+  NSArray *labels = alert.labels;
   
   if (!labels) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -25,8 +25,7 @@
     [[FBRoute GET:@"/alert/text"] respondWithTarget:self action:@selector(handleAlertTextCommand:)],
     [[FBRoute POST:@"/alert/accept"] respondWithTarget:self action:@selector(handleAlertAcceptCommand:)],
     [[FBRoute POST:@"/alert/dismiss"] respondWithTarget:self action:@selector(handleAlertDismissCommand:)],
-    [[FBRoute GET:@"/alert/buttons"] respondWithTarget:self action:@selector(handleGetAlertButtonsCommand:)],
-    [[FBRoute POST:@"/alert/click/:label"] respondWithTarget:self action:@selector(handleClickAlertButtonCommand:)],
+    [[FBRoute GET:@"/wda/alert/buttons"] respondWithTarget:self action:@selector(handleGetAlertButtonsCommand:)],
   ];
 }
 
@@ -46,7 +45,13 @@
 + (id<FBResponsePayload>)handleAlertAcceptCommand:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  if (![[FBAlert alertWithApplication:session.application] acceptWithError:nil]) {
+  NSString *name = request.parameters[@"name"];
+
+  if ([name length] != 0) {
+    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name withError:nil]) {
+      return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
+    }
+  } else if (![[FBAlert alertWithApplication:session.application] acceptWithError:nil]) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
   }
   return FBResponseWithOK();
@@ -55,7 +60,13 @@
 + (id<FBResponsePayload>)handleAlertDismissCommand:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  if (![[FBAlert alertWithApplication:session.application] dismissWithError:nil]) {
+  NSString *name = request.parameters[@"name"];
+
+  if ([name length] != 0) {
+    if (![[FBAlert alertWithApplication:session.application] clickAlertButton:name withError:nil]) {
+      return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
+    }
+  } else if (![[FBAlert alertWithApplication:session.application] dismissWithError:nil]) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
   }
   return FBResponseWithOK();
@@ -70,17 +81,5 @@
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
   }
   return FBResponseWithStatus(FBCommandStatusNoError, labels);
-}
-
-+ (id<FBResponsePayload>)handleClickAlertButtonCommand:(FBRouteRequest *)request {
-  FBSession *session = request.session;
-  NSString *label = request.parameters[@"label"];
-  
-  FBAlert *alert = [FBAlert alertWithApplication:session.application];
-  
-  if (![alert clickAlertButton:label withError:nil]) {
-    return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
-  }
-  return FBResponseWithOK();
 }
 @end

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -52,7 +52,8 @@
   if (!alert.isPresent) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
   }
-  if ([name length] != 0) {    if (![alert clickAlertButton:name error:&error]) {
+  if ([name length] != 0) {
+    if (![alert clickAlertButton:name error:&error]) {
       return FBResponseWithError(error);
     }
   } else if (![alert acceptWithError:nil]) {

--- a/WebDriverAgentLib/FBAlert.h
+++ b/WebDriverAgentLib/FBAlert.h
@@ -40,7 +40,7 @@ extern NSString *const FBAlertObstructingElementException;
 /**
  Gets the labels of the buttons visible in the alert
  */
-- (nullable NSMutableArray *)labels;
+- (nullable NSArray *)labels;
 
 /**
  Returns alert's title and description separated by new lines
@@ -70,7 +70,7 @@ extern NSString *const FBAlertObstructingElementException;
  @param error If there is an error, upon return contains an NSError object that describes the problem.
  @return YES if the operation suceeds, otherwise NO.
  */
-- (BOOL)clickAlertButton:(NSString *)label withError:(NSError **)error;
+- (BOOL)clickAlertButton:(NSString *)label error:(NSError **)error;
 
 /**
  Filters out elements obstructed by alert

--- a/WebDriverAgentLib/FBAlert.h
+++ b/WebDriverAgentLib/FBAlert.h
@@ -38,6 +38,11 @@ extern NSString *const FBAlertObstructingElementException;
 - (BOOL)isPresent;
 
 /**
+ Gets the labels of the buttons visible in the alert
+ */
+- (nullable NSMutableArray *)labels;
+
+/**
  Returns alert's title and description separated by new lines
  */
 - (nullable NSString *)text;
@@ -57,6 +62,15 @@ extern NSString *const FBAlertObstructingElementException;
  @return YES if the operation succeeds, otherwise NO.
  */
 - (BOOL)dismissWithError:(NSError **)error;
+
+/**
+ Clicks on an alert button, if present
+ 
+ @param label The label of the button on which to click.
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if the operation suceeds, otherwise NO.
+ */
+- (BOOL)clickAlertButton:(NSString *)label withError:(NSError **)error;
 
 /**
  Filters out elements obstructed by alert

--- a/WebDriverAgentLib/FBAlert.h
+++ b/WebDriverAgentLib/FBAlert.h
@@ -40,7 +40,7 @@ extern NSString *const FBAlertObstructingElementException;
 /**
  Gets the labels of the buttons visible in the alert
  */
-- (nullable NSArray *)labels;
+- (nullable NSArray *)buttonLabels;
 
 /**
  Returns alert's title and description separated by new lines

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -106,7 +106,7 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   return mText.length > 0 ? mText.copy : [NSNull null];
 }
 
-- (NSArray *) buttonLabels
+- (NSArray *)buttonLabels
 {
   NSMutableArray *value = [NSMutableArray array];
   XCUIElement *alertElement = self.alertElement;

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -106,6 +106,27 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   return mText.length > 0 ? mText.copy : [NSNull null];
 }
 
+- (NSMutableArray *) labels
+{
+  NSMutableArray *value = [NSMutableArray array];
+  
+  XCUIElement *alertElement = self.alertElement;
+  
+  if (!alertElement) {
+    return nil;
+  }
+  
+  NSArray<XCUIElement *> *buttons = [alertElement descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByIndex;
+  
+  for(XCUIElement *button in buttons)
+  {
+    
+    [value addObject:[button wdLabel]];
+  }
+  
+  return value;
+}
+
 - (BOOL)acceptWithError:(NSError **)error
 {
   XCUIElement *alertElement = self.alertElement;
@@ -145,6 +166,29 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
     return NO;
   }
   return [cancelButton fb_tapWithError:error];
+}
+
+- (BOOL)clickAlertButton:(NSString *)label withError:(NSError **)error {
+  
+  XCUIElement *alertElement = self.alertElement;
+  NSArray<XCUIElement *> *buttons = [alertElement descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByIndex;
+  XCUIElement *requestedButton;
+  
+  for(XCUIElement *button in buttons) {
+    if([[button wdLabel] isEqualToString:label]){
+      requestedButton = button;
+      break;
+    }
+  }
+  
+  if(!requestedButton) {
+    return
+    [[[FBErrorBuilder builder]
+      withDescriptionFormat:@"Failed to find button with label %@ for alert: %@", label, alertElement]
+     buildError:error];
+  }
+  
+  return [requestedButton fb_tapWithError:error];
 }
 
 + (BOOL)isElementObstructedByAlertView:(XCUIElement *)element alert:(XCUIElement *)alert

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -109,21 +109,14 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
 - (NSMutableArray *) labels
 {
   NSMutableArray *value = [NSMutableArray array];
-  
   XCUIElement *alertElement = self.alertElement;
-  
   if (!alertElement) {
     return nil;
   }
-  
   NSArray<XCUIElement *> *buttons = [alertElement descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByIndex;
-  
-  for(XCUIElement *button in buttons)
-  {
-    
+  for(XCUIElement *button in buttons) {
     [value addObject:[button wdLabel]];
   }
-  
   return value;
 }
 
@@ -168,7 +161,7 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   return [cancelButton fb_tapWithError:error];
 }
 
-- (BOOL)clickAlertButton:(NSString *)label withError:(NSError **)error {
+- (BOOL)clickAlertButton:(NSString *)label error:(NSError **)error {
   
   XCUIElement *alertElement = self.alertElement;
   NSArray<XCUIElement *> *buttons = [alertElement descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByIndex;

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -106,7 +106,7 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   return mText.length > 0 ? mText.copy : [NSNull null];
 }
 
-- (NSMutableArray *) labels
+- (NSArray *) buttonLabels
 {
   NSMutableArray *value = [NSMutableArray array];
   XCUIElement *alertElement = self.alertElement;

--- a/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
@@ -62,11 +62,11 @@
 - (void)testAlertLabels
 {
   FBAlert* alert = [FBAlert alertWithApplication:self.testedApplication];
-  XCTAssertNil(alert.labels);
+  XCTAssertNil(alert.buttonLabels);
   [self showApplicationAlert];
-  XCTAssertNotNil(alert.labels);
-  XCTAssertEqual(1, alert.labels.count);
-  XCTAssertEqualObjects(@"Will do", alert.labels[0]);
+  XCTAssertNotNil(alert.buttonLabels);
+  XCTAssertEqual(1, alert.buttonLabels.count);
+  XCTAssertEqualObjects(@"Will do", alert.buttonLabels[0]);
 }
 
 - (void)testClickAlertButton

--- a/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAlertTests.m
@@ -59,6 +59,25 @@
   XCTAssertTrue([alert.text containsString:@"Should read"]);
 }
 
+- (void)testAlertLabels
+{
+  FBAlert* alert = [FBAlert alertWithApplication:self.testedApplication];
+  XCTAssertNil(alert.labels);
+  [self showApplicationAlert];
+  XCTAssertNotNil(alert.labels);
+  XCTAssertEqual(1, alert.labels.count);
+  XCTAssertEqualObjects(@"Will do", alert.labels[0]);
+}
+
+- (void)testClickAlertButton
+{
+  FBAlert* alert = [FBAlert alertWithApplication:self.testedApplication];
+  XCTAssertFalse([alert clickAlertButton:@"Invalid" error:nil]);
+  [self showApplicationAlert];
+  XCTAssertFalse([alert clickAlertButton:@"Invalid" error:nil]);
+  XCTAssertTrue([alert clickAlertButton:@"Will do" error:nil]);
+}
+
 - (void)testAcceptingAlert
 {
   NSError *error;


### PR DESCRIPTION
Currently, the WebDriverAgent allows you to either accept or dismiss an alert (a leftover from HTML, where JavaScript alerts only defined two options). 

The logic for deciding on which button to click when accepting or dismissing an alert is based on the location of the button - the web driver agent will click on either the first or the last button in the alert.

This PR attempts to make the webdriveragent a bit more flexible, by adding the following routes:

- `GET /alert/buttons`: this route returns the labels (`wdLabel`, same value as returned by `/element/:elementId/text`) of all buttons shown in the current alert
- `POST /alert/click/:label`: this route will try to close the alert by clicking on the button with label `:label`.

All feedback is welcome.