### PR TITLE
Add device ip to status record

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -15,6 +15,7 @@
 #import "FBApplication.h"
 #import "XCUIDevice.h"
 #import "XCUIDevice+FBHealthCheck.h"
+#import "XCUIDevice+FBHelpers.h"
 
 @implementation FBSessionCommands
 
@@ -84,6 +85,7 @@
       @"ios" :
         @{
           @"simulatorVersion" : [[UIDevice currentDevice] systemVersion],
+          @"ip" : [XCUIDevice sharedDevice].fb_wifiIPAddress,
         },
       @"build" :
         @{


### PR DESCRIPTION
It is useful to know what IP the device has, without needing to parse the log file for the server's startup message.

I'm not sure the best place within the returned data to put this.