### PR TITLE
Width and height values are not exchanged if screen orientation is set to landscape

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -328,12 +328,35 @@
 
 + (id<FBResponsePayload>)handleGetWindowSize:(FBRouteRequest *)request
 {
-  CGRect frame = request.session.application.wdFrame;
-  return FBResponseWithStatus(FBCommandStatusNoError, @{
-    @"width": @(CGRectGetWidth(frame)),
-    @"height": @(CGRectGetHeight(frame)),
-  });
+    CGRect frame = request.session.application.wdFrame;
+
+    NSNumber *width = @(CGRectGetWidth(frame));
+    NSNumber *height = @(CGRectGetHeight(frame));
+    NSNumber *orientationValue = @0;
+
+    UIInterfaceOrientation orientation = request.session.application.interfaceOrientation;
+    if(orientation == UIInterfaceOrientationPortrait) { //Portrait orientation
+        orientationValue = @0;
+    } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {//Portrait orientation
+        orientationValue = @1;
+    } else if(orientation == UIInterfaceOrientationLandscapeRight){ //Landscape orientation
+        height = @(CGRectGetWidth(frame));
+        width = @(CGRectGetHeight(frame));
+        orientationValue = @2;
+    } else if (orientation == UIInterfaceOrientationLandscapeLeft) { //Landscape orientation
+        height = @(CGRectGetWidth(frame));
+        width = @(CGRectGetHeight(frame));
+        orientationValue = @3;
+    } else {
+        orientationValue = @4;
+    }
+    return FBResponseWithStatus(FBCommandStatusNoError, @{
+                                                        @"width": width,
+                                                        @"height": height,
+                                                        @"orientation":orientationValue,
+                                                        });
 }
+
 
 
 #pragma mark - Helpers

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -329,7 +329,6 @@
 + (id<FBResponsePayload>)handleGetWindowSize:(FBRouteRequest *)request
 {
     CGRect frame = request.session.application.wdFrame;
-
     NSNumber *width = @(CGRectGetWidth(frame));
     NSNumber *height = @(CGRectGetHeight(frame));
     NSNumber *orientationValue = @0;
@@ -351,12 +350,11 @@
         orientationValue = @4;
     }
     return FBResponseWithStatus(FBCommandStatusNoError, @{
-                                                        @"width": width,
-                                                        @"height": height,
-                                                        @"orientation":orientationValue,
-                                                        });
+        @"width": width,
+        @"height": height,
+        @"orientation":orientationValue,
+        });
 }
-
 
 
 #pragma mark - Helpers


### PR DESCRIPTION
Width and height values are not exchanged if screen orientation is set to landscape

This issue reported by https://github.com/facebook/WebDriverAgent/issues/303