### PR TITLE
Allowing WDA to scroll to an element in a WebView

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -92,6 +92,7 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
                                @(XCUIElementTypeScrollView),
                                @(XCUIElementTypeCollectionView),
                                @(XCUIElementTypeTable),
+                               @(XCUIElementTypeWebView),
                                ];
     
   XCElementSnapshot *scrollView = [self.lastSnapshot fb_parentMatchingOneOfTypes:acceptedParents


### PR DESCRIPTION
Adding `XCUIElementTypeWebView`s to the list of scrollable parents.

Fixes an issue where the scroll doesn't happen because a valid parent is not found.