### PR TITLE
Element search by 'class chain' locator type 

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -26,6 +26,11 @@
 		71A224E61DE2F56600844D55 /* NSPredicate+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A224E41DE2F56600844D55 /* NSPredicate+FBFormat.m */; };
 		71A224E81DE326C500844D55 /* NSPredicateFBFormatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A224E71DE326C500844D55 /* NSPredicateFBFormatTests.m */; };
 		71E504951DF59BAD0020C32A /* XCUIElementAttributesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */; };
+		71A7EAF51E20516B001DA4F2 /* XCUIElement+FBClassChain.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A7EAF31E20516B001DA4F2 /* XCUIElement+FBClassChain.h */; };
+		71A7EAF61E20516B001DA4F2 /* XCUIElement+FBClassChain.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A7EAF41E20516B001DA4F2 /* XCUIElement+FBClassChain.m */; };
+		71A7EAF91E224648001DA4F2 /* FBClassChainQueryParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */; };
+		71A7EAFA1E224648001DA4F2 /* FBClassChainQueryParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */; };
+		71A7EAFC1E229302001DA4F2 /* FBClassChainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */; };
 		71E95ADF1DC101BA002D0364 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
 		AD35D01A1CF1418E00870A75 /* RoutingHTTPServer.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = AD42DD2B1CF1238500806E5D /* RoutingHTTPServer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AD35D0641CF1C2C300870A75 /* RoutingHTTPServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD42DD2B1CF1238500806E5D /* RoutingHTTPServer.framework */; };
@@ -367,6 +372,11 @@
 		71A224E41DE2F56600844D55 /* NSPredicate+FBFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSPredicate+FBFormat.m"; path = "../Utilities/NSPredicate+FBFormat.m"; sourceTree = "<group>"; };
 		71A224E71DE326C500844D55 /* NSPredicateFBFormatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSPredicateFBFormatTests.m; sourceTree = "<group>"; };
 		71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIElementAttributesTests.m; sourceTree = "<group>"; };
+		71A7EAF31E20516B001DA4F2 /* XCUIElement+FBClassChain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBClassChain.h"; sourceTree = "<group>"; };
+		71A7EAF41E20516B001DA4F2 /* XCUIElement+FBClassChain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBClassChain.m"; sourceTree = "<group>"; };
+		71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBClassChainQueryParser.h; sourceTree = "<group>"; };
+		71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBClassChainQueryParser.m; sourceTree = "<group>"; };
+		71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBClassChainTests.m; sourceTree = "<group>"; };
 		AD35D0651CF1C2CE00870A75 /* Peertalk.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Peertalk.framework; path = Carthage/Build/iOS/Peertalk.framework; sourceTree = "<group>"; };
 		AD35D0691CF1C30700870A75 /* Peertalk.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Peertalk.framework; path = Carthage/Build/Mac/Peertalk.framework; sourceTree = "<group>"; };
 		AD42DD2A1CF121E600806E5D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
@@ -827,6 +837,8 @@
 				EEE3763E1D59F81400ED88DD /* XCUIDevice+FBRotation.m */,
 				EE9AB7451CAEDF0C008C271F /* XCUIElement+FBAccessibility.h */,
 				EE9AB7461CAEDF0C008C271F /* XCUIElement+FBAccessibility.m */,
+				71A7EAF31E20516B001DA4F2 /* XCUIElement+FBClassChain.h */,
+				71A7EAF41E20516B001DA4F2 /* XCUIElement+FBClassChain.m */,
 				EEBBD4891D47746D00656A81 /* XCUIElement+FBFind.h */,
 				EEBBD48A1D47746D00656A81 /* XCUIElement+FBFind.m */,
 				EE9AB7471CAEDF0C008C271F /* XCUIElement+FBIsVisible.h */,
@@ -923,6 +935,8 @@
 		EE9AB78E1CAEDF0C008C271F /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */,
+				71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */,
 				EE9B76A11CF7A43900275851 /* FBConfiguration.h */,
 				EE9B76A21CF7A43900275851 /* FBConfiguration.m */,
 				EE7E27181D06C69F001BEC7B /* FBDebugLogDelegateDecorator.h */,
@@ -953,6 +967,8 @@
 				EE9AB7991CAEDF0C008C271F /* FBXPathCreator.m */,
 				EE6B64FB1D0F86EF00E85F5D /* XCTestPrivateSymbols.h */,
 				EE6B64FC1D0F86EF00E85F5D /* XCTestPrivateSymbols.m */,
+				71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */,
+				71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */,
 			);
 			name = Utilities;
 			path = WebDriverAgentLib/Utilities;
@@ -1008,6 +1024,7 @@
 			children = (
 				ADBC39951D07840300327304 /* Doubles */,
 				EEE16E961D33A25500172525 /* FBConfigurationTests.m */,
+				71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */,
 				ADBC39931D0782CD00327304 /* FBElementCacheTests.m */,
 				719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */,
 				EE3F8CFF1D08B05F006F02CE /* FBElementTypeTransformerTests.m */,
@@ -1302,6 +1319,7 @@
 				EE158AD21CBD456F00A3E3F0 /* FBElementCache.h in Headers */,
 				EE35AD5A1E3B77D600A02D78 /* XCTMetric.h in Headers */,
 				EE35AD461E3B77D600A02D78 /* XCTestContextScope.h in Headers */,
+				71A7EAF51E20516B001DA4F2 /* XCUIElement+FBClassChain.h in Headers */,
 				EE158ADA1CBD456F00A3E3F0 /* FBResponseJSONPayload.h in Headers */,
 				EE35AD3D1E3B77D600A02D78 /* XCTAutomationTarget-Protocol.h in Headers */,
 				EE158AD01CBD456F00A3E3F0 /* FBElement.h in Headers */,
@@ -1353,6 +1371,7 @@
 				AD6C269C1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h in Headers */,
 				EE35AD101E3B77D600A02D78 /* _XCTestObservationCenterImplementation.h in Headers */,
 				AD6C26981CF2481700F8B5FF /* XCUIDevice+FBHelpers.h in Headers */,
+				71A7EAF91E224648001DA4F2 /* FBClassChainQueryParser.h in Headers */,
 				EE9B76AA1CF7A43900275851 /* FBMacros.h in Headers */,
 				EE35AD4A1E3B77D600A02D78 /* XCTestExpectationDelegate-Protocol.h in Headers */,
 				EE35AD641E3B77D600A02D78 /* XCTUIApplicationMonitor-Protocol.h in Headers */,
@@ -1617,6 +1636,7 @@
 				711084451DA3AA7500F913D6 /* FBXPath.m in Sources */,
 				EE158AE71CBD456F00A3E3F0 /* FBWebServer.m in Sources */,
 				EE3A18631CDE618F00DE4205 /* FBErrorBuilder.m in Sources */,
+				71A7EAF61E20516B001DA4F2 /* XCUIElement+FBClassChain.m in Sources */,
 				71555A3E1DEC460A007D4A8B /* NSExpression+FBFormat.m in Sources */,
 				EE158AD71CBD456F00A3E3F0 /* FBHTTPOverUSBServer.m in Sources */,
 				EE158AF21CBD456F00A3E3F0 /* FBXPathCreator.m in Sources */,
@@ -1630,6 +1650,7 @@
 				EE158ADD1CBD456F00A3E3F0 /* FBResponsePayload.m in Sources */,
 				EE158ADF1CBD456F00A3E3F0 /* FBRoute.m in Sources */,
 				EEE9B4731CD02B88009D2030 /* FBRunLoopSpinner.m in Sources */,
+				71A7EAFA1E224648001DA4F2 /* FBClassChainQueryParser.m in Sources */,
 				71A224E61DE2F56600844D55 /* NSPredicate+FBFormat.m in Sources */,
 				EEE376441D59F81400ED88DD /* XCUIDevice+FBRotation.m in Sources */,
 				EE158AE21CBD456F00A3E3F0 /* FBRouteRequest.m in Sources */,
@@ -1700,6 +1721,7 @@
 				ADBC39981D07842800327304 /* XCUIElementDouble.m in Sources */,
 				7139145A1DF01989005896C2 /* XCUIElementHelpersTests.m in Sources */,
 				EE6A89261D0B19E60083E92B /* FBSessionTests.m in Sources */,
+				71A7EAFC1E229302001DA4F2 /* FBClassChainTests.m in Sources */,
 				EE18883D1DA663EB00307AA8 /* FBMathUtilsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! Exception used to notify about invalid class chain query */
+extern NSString *const FBClassChainQueryParseException;
+
+@interface XCUIElement (FBClassChain)
+
+/**
+ Returns an array of descendants matching given class chain query.
+ This query is very similar to xpath, but can only include indexes and valid class names. Only search by direct children elements of
+  the current element is supported. Examples of such requests:
+ XCUIElementTypeWindow/XCUIElementTypeButton[3] - select the third child button of the first child window element
+ XCUIElementTypeWindow - select all the children windows
+ XCUIElementTypeWindow[2] - select the second child window in the hierarchy. Indexing starts at 1
+ XCUIElementTypeWindow/XCUIElementTypeAny[3] - select the third child (of any type) of the first child window
+ XCUIElementTypeWindow[2]/XCUIElementTypeAny - select all the children of the second child window
+ XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2] - select the second last child of the second child window
+ One may use '*' (star) character to substitute the universal 'XCUIElementTypeAny' class name
+ 
+ @param classChainQuery valid class chain query string
+ @param shouldReturnAfterFirstMatch set it to YES if you want only the first found element to be resolved and returned. This will speed up the search significantly if given class name matches multiple nodes in the UI tree
+ @return an array of descendants matching given class chain
+ */
+- (NSArray<XCUIElement *> *)fb_descendantsMatchingClassChain:(NSString *)classChainQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "XCUIElement+FBClassChain.h"
+#import "FBClassChainQueryParser.h"
+#import "FBElementUtils.h"
+#import "FBMacros.h"
+#import "XCElementSnapshot.h"
+#import "XCUIElement+FBUtilities.h"
+
+NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseException";
+
+@implementation XCUIElement (FBClassChain)
+
+- (NSArray <XCUIElement *> *)fb_matchingElementsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots usingChain:(FBClassChain)chain
+{
+  XCUIElementQuery *elementsQuery = [self childrenMatchingType:[chain firstObject].type];
+  for (NSUInteger level = 1; level < chain.count; ++level) {
+    elementsQuery = [elementsQuery childrenMatchingType:[chain objectAtIndex:level].type];
+  }
+  NSMutableArray *candidateElements = [NSMutableArray arrayWithArray:elementsQuery.allElementsBoundByIndex];
+  if ([chain lastObject].position < 0 && candidateElements.count > 1) {
+    // reverse candidates list if the expected element position is negative
+    // to speed up the lookup
+    candidateElements = [[candidateElements reverseObjectEnumerator] allObjects].mutableCopy;
+  }
+  NSMutableArray *result = [NSMutableArray array];
+  NSMutableArray *unmatchedSnapshots = snapshots.mutableCopy;
+  NSUInteger candidateElementIdx = 0;
+  while (candidateElementIdx < candidateElements.count) {
+    XCUIElement *candidateElement = [candidateElements objectAtIndex:candidateElementIdx];
+    NSUInteger snapshotIdx = 0;
+    BOOL isMatchFound = NO;
+    while (snapshotIdx < unmatchedSnapshots.count) {
+      if ([candidateElement.fb_lastSnapshot _matchesElement:[unmatchedSnapshots objectAtIndex:snapshotIdx]]) {
+        [result addObject:candidateElement];
+        [unmatchedSnapshots removeObjectAtIndex:snapshotIdx];
+        isMatchFound = YES;
+        break;
+      }
+      ++snapshotIdx;
+    }
+    if (0 == unmatchedSnapshots.count) {
+      break;
+    }
+    if (isMatchFound) {
+      [candidateElements removeObjectAtIndex:candidateElementIdx];
+    } else {
+      ++candidateElementIdx;
+    }
+  }
+  return result.copy;
+}
+
+- (NSArray<XCUIElement *> *)fb_descendantsMatchingClassChain:(NSString *)classChainQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
+{
+  NSError *error;
+  FBClassChain parsedChain = [FBClassChainQueryParser parseQuery:classChainQuery error:&error];
+  if (nil == parsedChain) {
+    @throw [NSException exceptionWithName:FBClassChainQueryParseException reason:error.localizedDescription userInfo:error.userInfo];
+    return nil;
+  }
+  NSMutableArray *unmatchedSnapshots = [self.class fb_lookupChain:parsedChain inSnapshot:self.fb_lastSnapshot].mutableCopy;
+  if (0 == unmatchedSnapshots.count) {
+    return @[];
+  }
+  if (shouldReturnAfterFirstMatch) {
+    [unmatchedSnapshots removeObjectsInRange:NSMakeRange(1, unmatchedSnapshots.count - 1)];
+  }
+  return [self fb_matchingElementsWithSnapshots:unmatchedSnapshots usingChain:parsedChain];
+}
+
++ (NSArray<XCElementSnapshot *> *)fb_matchingChildrenWithSnapshot:(XCElementSnapshot *)root forChainElement:(FBClassChainElement *)chainElement
+{
+  NSArray *childrenMatchingByType = root.children;
+  if (0 == childrenMatchingByType.count) {
+    return @[];
+  }
+  if (XCUIElementTypeAny != chainElement.type) {
+    childrenMatchingByType = [childrenMatchingByType filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K == %@", FBStringify(XCUIElement, elementType), @(chainElement.type)]];
+  }
+  NSMutableArray *result = [NSMutableArray array];
+  if (0 == chainElement.position) {
+    [result addObjectsFromArray:childrenMatchingByType];
+  } else if (chainElement.position > 0) {
+    if ((NSUInteger)chainElement.position <= childrenMatchingByType.count) {
+      [result addObject:[childrenMatchingByType objectAtIndex:chainElement.position - 1]];
+    }
+  } else {
+    if ((NSUInteger)labs(chainElement.position) <= childrenMatchingByType.count) {
+      [result addObject:[childrenMatchingByType objectAtIndex:childrenMatchingByType.count + chainElement.position]];
+    }
+  }
+  return result.copy;
+}
+
++ (NSArray<XCElementSnapshot *> *)fb_lookupChain:(FBClassChain)query inSnapshot:(XCElementSnapshot *)root
+{
+  NSArray *matchingChildren = [self.class fb_matchingChildrenWithSnapshot:root forChainElement:[query firstObject]];
+  if (0 == matchingChildren.count) {
+    return @[];
+  }
+  NSMutableArray *result = [NSMutableArray array];
+  if (query.count > 1) {
+    for (XCElementSnapshot *matchedChild in matchingChildren) {
+      [result addObjectsFromArray:[self.class fb_lookupChain:[query subarrayWithRange:NSMakeRange(1, query.count - 1)] inSnapshot:matchedChild]];
+    }
+  } else {
+    [result addObjectsFromArray:matchingChildren];
+  }
+  return result.copy;
+}
+
+@end

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -19,6 +19,7 @@
 #import "FBApplication.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBIsVisible.h"
+#import "XCUIElement+FBClassChain.h"
 
 static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteRequest *request)
 {
@@ -123,6 +124,8 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
     elements = [element fb_descendantsMatchingProperty:propertyName value:propertyValue partialSearch:partialSearch];
   } else if ([usingText isEqualToString:@"class name"]) {
     elements = [element fb_descendantsMatchingClassName:value shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
+  } else if ([usingText isEqualToString:@"class chain"]) {
+    elements = [element fb_descendantsMatchingClassChain:value shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if ([usingText isEqualToString:@"xpath"]) {
     elements = [element fb_descendantsMatchingXPathQuery:value shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
   } else if ([usingText isEqualToString:@"predicate string"]) {

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.h
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBClassChainElement : NSObject
+
+/*! Element's position */
+@property (readonly, nonatomic) NSInteger position;
+/*! Element's type */
+@property (readonly, nonatomic) XCUIElementType type;
+
+/**
+ Instance constructor, which allows to set element type and position
+ 
+ @param type on of supoported element types declared in XCUIElementType enum
+ @param position element position relative to its sibling element. Numeration
+   starts with 1. Zero value means that all sibling element should be selected.
+   Negative value means that numeration starts from the last element, for example
+   -1 is the last child element and -2 is the second last element
+ @return FBClassChainElement instance
+ */
+- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position;
+
+@end
+
+/*! Type alias for the product of class chain query parsing */
+typedef NSArray<FBClassChainElement *> * FBClassChain;
+
+@interface FBClassChainQueryParser : NSObject
+
+/**
+ Method used to interpret class chain queries
+ 
+ @param classChainQuery class chain query as string. See the documentation of
+   XCUIElement+FBClassChain category for more details about the expected query format
+ @param error standard NSError object, which is going to be initializaed if
+   there are query parsing errors
+ @return list of parsed primitives packed to FBClassChainElement class or nil in case
+   there was parsing error (the parameter will be initialized with detailed error description in such case)
+ */
++ (nullable FBClassChain)parseQuery:(NSString*)classChainQuery error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
@@ -258,7 +258,7 @@ static NSNumberFormatter *numberFormatter = nil;
 
 + (NSError *)tokenizationErrorWithIndex:(NSUInteger)index originalQuery:(NSString *)originalQuery
 {
-  NSString *description = [NSString stringWithFormat:@"Cannot parse class chain query '%@'. Unexpected character detected at position %lu:\n'%@' <----", originalQuery, index + 1, [originalQuery substringToIndex:index + 1]];
+  NSString *description = [NSString stringWithFormat:@"Cannot parse class chain query '%@'. Unexpected character detected at position %@:\n'%@' <----", originalQuery, @(index + 1), [originalQuery substringToIndex:index + 1]];
   return [[FBErrorBuilder.builder withDescription:description] build];
 }
 

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBExceptionHandler.h"
+#import "FBClassChainQueryParser.h"
+#import "FBErrorBuilder.h"
+#import "FBElementTypeTransformer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBBaseClassChainToken : NSObject
+
+@property (nonatomic) NSString *asString;
+
+- (nullable instancetype)nextTokenWithCharacter:(unichar)character;
+
+@end
+
+
+@interface FBClassNameToken : FBBaseClassChainToken
+
+@end
+
+@interface FBStarToken : FBBaseClassChainToken
+
+@end
+
+
+@interface FBSplitterToken : FBBaseClassChainToken
+
+@end
+
+
+@interface FBOpeningBracketToken : FBBaseClassChainToken
+
+@end
+
+
+@interface FBClosingBracketToken : FBBaseClassChainToken
+
+@end
+
+
+@interface FBNumberToken : FBBaseClassChainToken
+
+@end
+
+
+NS_ASSUME_NONNULL_END
+
+
+@implementation FBBaseClassChainToken
+
+- (id)init
+{
+  self = [super init];
+  if (self) {
+    _asString = @"";
+  }
+  return self;
+}
+
+- (instancetype)initWithStringValue:(NSString *)stringValue
+{
+  self = [super init];
+  if (self) {
+    _asString = stringValue;
+  }
+  return self;
+}
+
++ (NSCharacterSet *)allowedCharacters
+{
+  // This method is expected to be overriden by subclasses
+  return [NSCharacterSet characterSetWithCharactersInString:@""];
+}
+
++ (NSUInteger)maxLength
+{
+  // This method is expected to be overriden by subclasses
+  return ULONG_MAX;
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  // This method is expected to be overriden by subclasses
+  return @[];
+}
+
++ (BOOL)canConsumeCharacter:(unichar)character
+{
+  return [self.allowedCharacters characterIsMember:character];
+}
+
+- (instancetype)nextTokenWithCharacter:(unichar)character
+{
+  if ([self.class canConsumeCharacter:character] && self.asString.length < [self.class maxLength]) {
+    NSMutableString *value = [NSMutableString stringWithString:self.asString];
+    [value appendFormat:@"%C", character];
+    self.asString = value.copy;;
+    return self;
+  }
+  for (Class matchingTokenClass in self.followingTokens) {
+    if ([matchingTokenClass canConsumeCharacter:character]) {
+      return [[[matchingTokenClass alloc] init] nextTokenWithCharacter:character];
+    }
+  }
+  return nil;
+}
+
+@end
+
+
+@implementation FBClassNameToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  return [NSCharacterSet letterCharacterSet];
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBSplitterToken.class, FBOpeningBracketToken.class];
+}
+
+@end
+
+
+@implementation FBStarToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  return [NSCharacterSet characterSetWithCharactersInString:@"*"];
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBSplitterToken.class, FBOpeningBracketToken.class];
+}
+
++ (NSUInteger)maxLength
+{
+  return 1;
+}
+
+@end
+
+
+@implementation FBSplitterToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  return [NSCharacterSet characterSetWithCharactersInString:@"/"];
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBStarToken.class, FBClassNameToken.class];
+}
+
++ (NSUInteger)maxLength
+{
+  return 1;
+}
+
+@end
+
+
+@implementation FBOpeningBracketToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  return [NSCharacterSet characterSetWithCharactersInString:@"["];
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBNumberToken.class];
+}
+
++ (NSUInteger)maxLength
+{
+  return 1;
+}
+
+@end
+
+
+@implementation FBNumberToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  NSMutableCharacterSet *result = [NSMutableCharacterSet new];
+  [result formUnionWithCharacterSet:[NSCharacterSet decimalDigitCharacterSet]];
+  [result addCharactersInString:@"-"];
+  return result.copy;
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBClosingBracketToken.class];
+}
+
+@end
+
+
+@implementation FBClosingBracketToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  return [NSCharacterSet characterSetWithCharactersInString:@"]"];
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBSplitterToken.class];
+}
+
++ (NSUInteger)maxLength
+{
+  return 1;
+}
+
+@end
+
+
+@implementation FBClassChainElement
+
+- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position
+{
+  self = [super init];
+  if (self) {
+    _type = type;
+    _position = position;
+  }
+  return self;
+}
+
+@end
+
+
+@implementation FBClassChainQueryParser
+
+static NSNumberFormatter *numberFormatter = nil;
+
++ (void)initialize {
+  if (nil == numberFormatter) {
+    numberFormatter = [[NSNumberFormatter alloc] init];
+    numberFormatter.numberStyle = NSNumberFormatterDecimalStyle;
+  }
+}
+
++ (NSError *)tokenizationErrorWithIndex:(NSUInteger)index originalQuery:(NSString *)originalQuery
+{
+  NSString *description = [NSString stringWithFormat:@"Cannot parse class chain query '%@'. Unexpected character detected at position %lu:\n'%@' <----", originalQuery, index + 1, [originalQuery substringToIndex:index + 1]];
+  return [[FBErrorBuilder.builder withDescription:description] build];
+}
+
++ (nullable NSArray<FBBaseClassChainToken *> *)tokenizedQueryWithQuery:(NSString*)classChainQuery error:(NSError **)error
+{
+  NSUInteger queryStringLength = classChainQuery.length;
+  FBBaseClassChainToken *token;
+  unichar firstCharacter = [classChainQuery characterAtIndex:0];
+  if ([FBClassNameToken canConsumeCharacter:firstCharacter]) {
+    token = [[FBClassNameToken alloc] initWithStringValue:[NSString stringWithFormat:@"%C", firstCharacter]];
+  } else if ([FBStarToken canConsumeCharacter:firstCharacter]) {
+    token = [[FBStarToken alloc] initWithStringValue:[NSString stringWithFormat:@"%C", firstCharacter]];
+  } else {
+    *error = [self.class tokenizationErrorWithIndex:0 originalQuery:classChainQuery];
+    return nil;
+  }
+  NSMutableArray *result = [NSMutableArray array];
+  FBBaseClassChainToken *nextToken = token;
+  for (NSUInteger charIdx = 1; charIdx < queryStringLength; ++charIdx) {
+    nextToken = [token nextTokenWithCharacter:[classChainQuery characterAtIndex:charIdx]];
+    if (nil == nextToken) {
+      *error = [self.class tokenizationErrorWithIndex:charIdx originalQuery:classChainQuery];
+      return nil;
+    }
+    if (nextToken != token) {
+      [result addObject:token];
+      token = nextToken;
+    }
+  }
+  if (nil != nextToken) {
+    [result addObject:nextToken];
+  }
+  
+  for (NSUInteger tokenIdx = 0; tokenIdx < result.count; ++tokenIdx) {
+    if ([[result objectAtIndex:tokenIdx] isKindOfClass:FBStarToken.class]) {
+      [result replaceObjectAtIndex:tokenIdx withObject:[[FBClassNameToken alloc] initWithStringValue:[FBElementTypeTransformer stringWithElementType:XCUIElementTypeAny]]];
+    }
+  }
+  
+  FBBaseClassChainToken *lastToken = [result lastObject];
+  if (!([lastToken isKindOfClass:FBClosingBracketToken.class] || [lastToken isKindOfClass:FBClassNameToken.class])) {
+    *error = [self.class tokenizationErrorWithIndex:queryStringLength - 1 originalQuery:classChainQuery];
+    return nil;
+  }
+  
+  return result.copy;
+}
+
++ (NSError *)compilationErrorWithQuery:(NSString *)originalQuery description:(NSString *)description
+{
+  NSString *fullDescription = [NSString stringWithFormat:@"Cannot parse class chain query '%@'. %@", originalQuery, description];
+  return [[FBErrorBuilder.builder withDescription:fullDescription] build];
+}
+
++ (nullable FBClassChain)compiledQueryWithTokenizedQuery:(NSArray<FBBaseClassChainToken *> *)tokenizedQuery originalQuery:(NSString *)originalQuery error:(NSError **)error
+{
+  NSMutableArray *result = [NSMutableArray array];
+  XCUIElementType chainElementType;
+  int chainElementPosition = 1;
+  BOOL isPositionSet = NO;
+  for (FBBaseClassChainToken *token in tokenizedQuery) {
+    if ([token isKindOfClass:FBClassNameToken.class]) {
+      @try {
+        chainElementType = [FBElementTypeTransformer elementTypeWithTypeName:token.asString];
+      } @catch (NSException *e) {
+        if ([e.name isEqualToString:FBInvalidArgumentException]) {
+          NSString *description = [NSString stringWithFormat:@"'%@' class name is unknown to WDA", token.asString];
+          *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+          return nil;
+        }
+        @throw e;
+      }
+    } else if ([token isKindOfClass:FBNumberToken.class]) {
+      if (isPositionSet) {
+        NSString *description = [NSString stringWithFormat:@"Position value '%@' is expected to be set only once.", token.asString];
+        *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+        return nil;
+      }
+      NSNumber *position = [numberFormatter numberFromString:token.asString];
+      if (nil == position || 0 == position.intValue) {
+        NSString *description = [NSString stringWithFormat:@"Position value '%@' is expected to be a valid integer number not equal to zero.", token.asString];
+        *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+        return nil;
+      }
+      chainElementPosition = [position intValue];
+      isPositionSet = YES;
+    } else if ([token isKindOfClass:FBSplitterToken.class]) {
+      if (!isPositionSet) {
+        chainElementPosition = 1;
+      }
+      [result addObject:[[FBClassChainElement alloc] initWithType:chainElementType position:chainElementPosition]];
+      isPositionSet = NO;
+    }
+  }
+  if (!isPositionSet) {
+    // pick all siblings by default for the last item in the chain
+    chainElementPosition = 0;
+  }
+  [result addObject:[[FBClassChainElement alloc] initWithType:chainElementType position:chainElementPosition]];
+  return result.copy;
+}
+
++ (FBClassChain)parseQuery:(NSString*)classChainQuery error:(NSError **)error
+{
+  NSAssert(classChainQuery.length > 0, @"Query length should be greater than zero", nil);
+  NSArray *tokenizedQuery = [self.class tokenizedQueryWithQuery:classChainQuery error:error];
+  if (nil == tokenizedQuery) {
+    return nil;
+  }
+  NSArray *compiledQuery = [self.class compiledQueryWithTokenizedQuery:tokenizedQuery originalQuery:classChainQuery error:error];
+  if (nil == compiledQuery) {
+    return nil;
+  }
+  return compiledQuery.copy;
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -187,12 +187,6 @@
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
 }
 
-- (void)testSpecialXPathQuery
-{
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@".//XCUIElementTypeButton[@label=\"Alerts\"]" shouldReturnAfterFirstMatch:NO];
-  XCTAssertEqual(matchingSnapshots.count, 0);
-}
-
 - (void)testDescendantsWithClassChain
 {
   NSArray<XCUIElement *> *matchingSnapshots;

--- a/WebDriverAgentTests/UnitTests/FBClassChainTests.m
+++ b/WebDriverAgentTests/UnitTests/FBClassChainTests.m
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "XCUIElementDouble.h"
+#import "FBClassChainQueryParser.h"
+
+@interface FBClassChainTests : XCTestCase
+@end
+
+@implementation FBClassChainTests
+
+- (void)testValidChain
+{
+  NSError *error;
+  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.count, 2);
+  
+  FBClassChainElement *firstElement = [result firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
+  XCTAssertEqual(firstElement.position, 1);
+
+  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(secondElement.position, 0);
+}
+
+- (void)testValidChainWithStar
+{
+  NSError *error;
+  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton[3]/*[4]/*[5]/XCUIElementTypeAlert" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.count, 5);
+  
+  FBClassChainElement *firstElement = [result firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
+  XCTAssertEqual(firstElement.position, 1);
+  
+  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(secondElement.position, 3);
+  
+  FBClassChainElement *thirdElement = [result objectAtIndex:2];
+  XCTAssertEqual(thirdElement.type, XCUIElementTypeAny);
+  XCTAssertEqual(thirdElement.position, 4);
+  
+  FBClassChainElement *fourthElement = [result objectAtIndex:3];
+  XCTAssertEqual(fourthElement.type, XCUIElementTypeAny);
+  XCTAssertEqual(fourthElement.position, 5);
+  
+  FBClassChainElement *fifthsElement = [result objectAtIndex:4];
+  XCTAssertEqual(fifthsElement.type, XCUIElementTypeAlert);
+  XCTAssertEqual(fifthsElement.position, 0);
+}
+
+- (void)testValidSingleStarChain
+{
+  NSError *error;
+  FBClassChain result = [FBClassChainQueryParser parseQuery:@"*" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.count, 1);
+  
+  FBClassChainElement *firstElement = [result firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeAny);
+  XCTAssertEqual(firstElement.position, 0);
+}
+
+- (void)testValidChainWithNegativeIndex
+{
+  NSError *error;
+  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton[-1]" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.count, 2);
+  
+  FBClassChainElement *firstElement = [result firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
+  XCTAssertEqual(firstElement.position, 1);
+  
+  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(secondElement.position, -1);
+}
+
+- (void)testInvalidChains
+{
+  NSArray *invalidQueries = @[
+    @"/XCUIElementTypeWindow"
+    ,@"XCUIElementTypeWindow/"
+    ,@"XCUIElementTypeWindow//*"
+    ,@"XCUIElementTypeWindow*/*"
+    ,@"**"
+    ,@"XCUIElementTypeWindow[0]"
+    ,@"blabla"
+    ,@"XCUIElementTypeWindow/blabla"
+    ,@" XCUIElementTypeWindow"
+    ,@"XCUIElementTypeWindow[ 2 ]"
+    ,@"XCUIElementTypeWindow[[2]"
+    ,@"XCUIElementTypeWindow[2]]"
+    ,@"XCUIElementType[Window[2]]"
+  ];
+  for (NSString *invalidQuery in invalidQueries) {
+    NSError *error;
+    FBClassChain result = [FBClassChainQueryParser parseQuery:invalidQuery error:&error];
+    XCTAssertNil(result);
+    XCTAssertNotNil(error);
+    NSLog(@"%@", error.localizedDescription);
+  }
+}
+
+@end


### PR DESCRIPTION
The idea for this PR is borrowed from Adobe Flex open-source testing framework, where xpath queries are not supported natively. I did it, because I observe many people still build xpath queries, like this

```
/XCUIElementTypeApplication/XCUIElementTypeWindow/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther[2]/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeTable/XCUIElementTypeCell/XCUIElementTypeStaticText[2]
```

And they are quite slow, since xpath is not natively supported by XCTest.

My implementation uses the same query syntax as xpath (only class names and indexes are supported though), but the search itself takes much less time in comparison to xpath, because it looks for direct child nodes only and uses single native method call (_childrenMatchingType_) for this purpose. Examples of valid class chain queries:

```
XCUIElementTypeWindow/XCUIElementTypeButton[3] - select the third child button of the first child window element (indexing starts from 1. zero index is invalid, negative indexes are allowed)

XCUIElementTypeWindow - select all the children windows

XCUIElementTypeWindow[2] - select the second child window in the hierarchy. Indexing starts at 1

XCUIElementTypeWindow/XCUIElementTypeAny[3] - select the third child (of any type) of the first child window

XCUIElementTypeWindow/*[3] - same as above

XCUIElementTypeWindow[2]/XCUIElementTypeAny - select all the children of the second child window

XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2] - select the second last child of the second child window
```

I've also implemented nice descriptions for syntax errors.