### PR TITLE
Fix parsing of predicate string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Resources/WebDriverAgent.bundle
 
 # Modules map recreated on each build
 Modules/module.modulemap
+
+# test run
+*.trace

--- a/WebDriverAgentLib/Categories/NSExpression+FBFormat.m
+++ b/WebDriverAgentLib/Categories/NSExpression+FBFormat.m
@@ -17,14 +17,14 @@
   if ([input expressionType] != NSKeyPathExpressionType) {
     return input;
   }
-  NSString *actualPropName = [input keyPath];
-  NSUInteger dotPos = [actualPropName rangeOfString:@"."].location;
+  NSString *propName = [input keyPath];
+  NSUInteger dotPos = [propName rangeOfString:@"."].location;
   if (NSNotFound != dotPos) {
-    actualPropName = [actualPropName substringToIndex:dotPos];
-    NSString *suffix = [actualPropName substringFromIndex:dotPos];
+    NSString *actualPropName = [propName substringToIndex:dotPos];
+    NSString *suffix = [propName substringFromIndex:(dotPos + 1)];
     return [NSExpression expressionForKeyPath:[NSString stringWithFormat:@"%@.%@", [FBElementUtils wdAttributeNameForAttributeName:actualPropName], suffix]];
   }
-  return [NSExpression expressionForKeyPath:[FBElementUtils wdAttributeNameForAttributeName:actualPropName]];
+  return [NSExpression expressionForKeyPath:[FBElementUtils wdAttributeNameForAttributeName:propName]];
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/NSExpressionFBFormatTests.m
+++ b/WebDriverAgentTests/UnitTests/NSExpressionFBFormatTests.m
@@ -20,31 +20,36 @@
 - (void)testFormattingForExistingProperty
 {
   NSExpression *expr = [NSExpression expressionWithFormat:@"wdName"];
-  XCTAssertNotNil([NSExpression fb_wdExpressionWithExpression:expr]);
+  NSExpression *prop = [NSExpression fb_wdExpressionWithExpression:expr];
+  XCTAssertEqualObjects([prop keyPath], @"wdName");
 }
 
 - (void)testFormattingForExistingPropertyShortcut
 {
   NSExpression *expr = [NSExpression expressionWithFormat:@"visible"];
-  XCTAssertNotNil([NSExpression fb_wdExpressionWithExpression:expr]);
+  NSExpression *prop = [NSExpression fb_wdExpressionWithExpression:expr];
+  XCTAssertEqualObjects([prop keyPath], @"isWDVisible");
 }
 
 - (void)testFormattingForValidExpressionWOKeys
 {
   NSExpression *expr = [NSExpression expressionWithFormat:@"1"];
-  XCTAssertNotNil([NSExpression fb_wdExpressionWithExpression:expr]);
+  NSExpression *prop = [NSExpression fb_wdExpressionWithExpression:expr];
+  XCTAssertEqualObjects([prop constantValue], [NSNumber numberWithInt:1]);
 }
 
 - (void)testFormattingForExistingComplexProperty
 {
   NSExpression *expr = [NSExpression expressionWithFormat:@"wdRect.x"];
-  XCTAssertNotNil([NSExpression fb_wdExpressionWithExpression:expr]);
+  NSExpression *prop = [NSExpression fb_wdExpressionWithExpression:expr];
+  XCTAssertEqualObjects([prop keyPath], @"wdRect.x");
 }
 
 - (void)testFormattingForExistingComplexPropertyWOPrefix
 {
   NSExpression *expr = [NSExpression expressionWithFormat:@"rect.x"];
-  XCTAssertNotNil([NSExpression fb_wdExpressionWithExpression:expr]);
+  NSExpression *prop = [NSExpression fb_wdExpressionWithExpression:expr];
+  XCTAssertEqualObjects([prop keyPath], @"wdRect.x");
 }
 
 - (void)testFormattingForPredicateWithUnknownKey


### PR DESCRIPTION
This was not able to get the actual suffix, since it modified the property name as it went. Instead it should pull the substrings from the original property name. Also `substringFromIndex` is inclusive, so we need to go from one past the position of the dot.