### PR TITLE
Make the visibility property and XML attribute behaviour configurable via /wda/settings endpoint

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.h
@@ -14,7 +14,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface XCUIElement (FBIsVisible)
 
-/*! Whether or not the element is visible */
+/*! Whether or not the element is visible.
+ The value for this property is equal to
+ element snapshot's fb_isVisible property.
+ */
 @property (atomic, readonly) BOOL fb_isVisible;
 
 @end
@@ -22,7 +25,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface XCElementSnapshot (FBIsVisible)
 
-/*! Whether or not the element is visible */
+/*! Whether or not the element is visible.
+ The current visibility detection algorithm gives almost 100% accuracy,
+ but in some situations it can cause unexpected delays and
+ failures with "Error copying attributes -25202" record in logs.
+ See https://github.com/facebook/WebDriverAgent/issues/372 for more details.
+ 
+ Set 'useAlternativeVisibilityDetection' setting variable to YES
+ using PUT 'wda/settings' API call if you want to use visibility detection based on snapshot frame
+ analysis instead. This method does not cause unexpected test freezes,
+ although it is not able to properly detect visibility value for some UI elements,
+ which are present in the UI tree, but are not really visible in the app interface.
+ */
 @property (atomic, readonly) BOOL fb_isVisible;
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -9,6 +9,8 @@
 
 #import "XCUIElement+FBIsVisible.h"
 
+#import "FBConfiguration.h"
+#import "FBMathUtils.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCTestPrivateSymbols.h"
 
@@ -29,16 +31,11 @@
 - (BOOL)fb_isVisible
 {
   if (CGRectIsEmpty(self.frame) || CGRectIsEmpty(self.visibleFrame)) {
-    /*
-     It turns out, that XCTest triggers
-       Enqueue Failure: UI Testing Failure - Failure fetching attributes for element
-       <XCAccessibilityElement: 0x60000025f9e0> Device element: Error Domain=XCTestManagerErrorDomain Code=13
-       "Error copying attributes -25202" UserInfo={NSLocalizedDescription=Error copying attributes -25202} <unknown> 0 1
-     error in the log if we try to get visibility attribute for an element snapshot, which does not intersect with visible appication area
-     or if it has zero width/height. Also, XCTest waits for 15 seconds after this line appears in the log, which makes /source command
-     execution extremely slow for some applications.
-     */
     return NO;
+  }
+  if (FBConfiguration.sharedInstance.useAlternativeVisibilityDetection) {
+    CGSize screenSize = FBAdjustDimensionsForApplication(self.application.frame.size, self.application.interfaceOrientation);
+    return CGRectIntersectsRect(self.visibleFrame, CGRectMake(0, 0, screenSize.width, screenSize.height));
   }
   return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
 }

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -37,6 +37,10 @@
     [[FBRoute POST:@"/wda/homescreen"].withoutSession respondWithTarget:self action:@selector(handleHomescreenCommand:)],
     [[FBRoute POST:@"/wda/deactivateApp"] respondWithTarget:self action:@selector(handleDeactivateAppCommand:)],
     [[FBRoute POST:@"/wda/keyboard/dismiss"] respondWithTarget:self action:@selector(handleDismissKeyboardCommand:)],
+    
+    [[FBRoute POST:@"/wda/settings/reset"] respondWithTarget:self action:@selector(handleResetSettings:)],
+    [[FBRoute PUT:@"/wda/settings"] respondWithTarget:self action:@selector(handleChangeSettings:)],
+    [[FBRoute GET:@"/wda/settings"] respondWithTarget:self action:@selector(handleGetSettings:)],
 
     // TODO: Those endpoints are deprecated and will die soon
     [[FBRoute POST:@"/homescreen"].withoutSession respondWithTarget:self action:@selector(handleHomescreenCommand:)],
@@ -94,6 +98,23 @@
     return FBResponseWithError(error);
   }
   return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleResetSettings:(FBRouteRequest *)request
+{
+  [FBConfiguration.sharedInstance resetSettings];
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleChangeSettings:(FBRouteRequest *)request
+{
+  [FBConfiguration.sharedInstance changeSettings:request.parameters];
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handleGetSettings:(FBRouteRequest *)request
+{
+  return FBResponseWithStatus(FBCommandStatusNoError, [FBConfiguration.sharedInstance currentSettings]);
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -10,6 +10,7 @@
 #import "FBSessionCommands.h"
 
 #import "FBApplication.h"
+#import "FBConfiguration.h"
 #import "FBRouteRequest.h"
 #import "FBSession.h"
 #import "FBApplication.h"
@@ -59,6 +60,7 @@
     return FBResponseWithErrorFormat(@"Failed to launch %@ application", bundleID);
   }
   [FBSession sessionWithApplication:app];
+  [FBConfiguration.sharedInstance resetSettings];
   return FBResponseWithObject(FBSessionCommands.sessionInformation);
 }
 

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -11,10 +11,48 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/*! Notification used to notify about unknown setting name */
+extern NSString *const FBUnknownSettingNameException;
+
 /**
  Accessors for Global Constants.
  */
 @interface FBConfiguration : NSObject
+
+/*! Whether to add @visible attribute to UI XML representation. Default value is NO */
+@property (atomic) BOOL showVisibilityAttributeForXML;
+
+/*! Whether to use alternative visibility detection. Default value is NO */
+@property (atomic) BOOL useAlternativeVisibilityDetection;
+
+/**
+ Returns a singleton object for the current class
+ */
++ (instancetype)sharedInstance;
+
+/**
+ Reset all setting properties to their default values.
+ This method is automatically invoked upon new session initialization,
+ so all the settings are always set to their default values for each testing session.
+ */
+- (void)resetSettings;
+
+/**
+ Change values of existing instance properties
+ 
+ @param newValues Dictionary containing new property values.
+                  Dictionary keys should be valid property names.
+ @throws FBUnknownSettingException If there is no such property with given name
+ */
+- (void)changeSettings:(NSDictionary<NSString *, id> *)newValues;
+
+/**
+ Returns values of existing instance properties
+ 
+ @return Dictionary containing valid property names as keys and
+         corresponding property values
+ */
+- (NSDictionary<NSString *, id> *)currentSettings;
 
 /**
  Switch for enabling/disabling reporting fake collection view cells by Accessibility framework.

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -42,7 +42,11 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
 @interface FBXPath : NSObject
 
 /**
- Returns an array of descendants matching given xpath query
+ Returns an array of descendants matching given xpath query.
+ Set 'showVisibilityAttributeForXML' setting to YES using PUT 'wda/settings' API call
+ in order to include '@visible' attribute for all XML tree nodes.
+ Note, that this might cause unexpected test feezes, especially if
+ 'useAlternativeVisibilityDetection' setting is set to NO (the default value).
  
  @param root the root element to execute XPath query for
  @param xpathQuery requested xpath query
@@ -53,6 +57,10 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
 /**
  Gets XML representation of XCElementSnapshot with all its descendants. This method generates the same
  representation, which is used for XPath search
+ Set 'showVisibilityAttributeForXML' setting to YES using PUT 'wda/settings' API call
+ in order to include '@visible' attribute for all XML tree nodes.
+ Note, that this might cause unexpected test feezes, especially if
+ 'useAlternativeVisibilityDetection' setting is set to NO (the default value).
  
  @param root the root element
  @return valid XML document as string or nil in case of failure

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -9,6 +9,7 @@
 
 #import "FBXPath.h"
 
+#import "FBConfiguration.h"
 #import "FBLogger.h"
 #import "XCAXClient_iOS.h"
 #import "XCTestDriver.h"
@@ -219,6 +220,13 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   if (element.wdLabel) {
     rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "label",
                                      [FBXPath xmlCharPtrForInput:[element.wdLabel cStringUsingEncoding:NSUTF8StringEncoding]]);
+    if (rc < 0) {
+      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute. Error code: %d", rc];
+      return rc;
+    }
+  }
+  if (FBConfiguration.sharedInstance.showVisibilityAttributeForXML) {
+    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "visible", element.wdVisible ? BAD_CAST "true" : BAD_CAST "false");
     if (rc < 0) {
       [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute. Error code: %d", rc];
       return rc;

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -9,6 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "FBConfiguration.h"
 #import "FBIntegrationTestCase.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBFind.h"
@@ -36,10 +37,16 @@
   XCUIElement *matchingElement = [[self.testedView fb_descendantsMatchingXPathQuery:[NSString stringWithFormat:@"//%@", expectedType] shouldReturnAfterFirstMatch:YES] firstObject];
   XCElementSnapshot *matchingSnapshot = matchingElement.fb_lastSnapshot;
 
-  NSString *xmlStr = [FBXPath xmlStringWithSnapshot:matchingSnapshot];
+  NSString *xmlStr = nil;
+  @try {
+    FBConfiguration.sharedInstance.showVisibilityAttributeForXML = YES;
+    xmlStr = [FBXPath xmlStringWithSnapshot:matchingSnapshot];
+  } @finally {
+    FBConfiguration.sharedInstance.showVisibilityAttributeForXML = NO;
+  }
   XCTAssertNotNil(xmlStr);
 
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, matchingSnapshot.wdName, matchingSnapshot.wdLabel, matchingSnapshot.wdEnabled ? @"true" : @"false", [matchingSnapshot.wdRect[@"x"] stringValue], [matchingSnapshot.wdRect[@"y"] stringValue], [matchingSnapshot.wdRect[@"width"] stringValue], [matchingSnapshot.wdRect[@"height"] stringValue]];
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" visible=\"%@\" enabled=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, matchingSnapshot.wdName, matchingSnapshot.wdLabel, matchingSnapshot.wdVisible ? @"true" : @"false", matchingSnapshot.wdEnabled ? @"true" : @"false", [matchingSnapshot.wdRect[@"x"] stringValue], [matchingSnapshot.wdRect[@"y"] stringValue], [matchingSnapshot.wdRect[@"width"] stringValue], [matchingSnapshot.wdRect[@"height"] stringValue]];
   XCTAssertTrue([xmlStr isEqualToString: expectedXml]);
 }
 

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -9,6 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "FBConfiguration.h"
 #import "FBIntegrationTestCase.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBFind.h"
@@ -132,14 +133,29 @@
                                NSException, XCElementSnapshotInvalidXPathException);
 }
 
-- (void)disabled_testVisibleDescendantWithXPathQuery
+- (void)testVisibleDescendantWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@name='Alerts' and @enabled='true' and @visible='true']" shouldReturnAfterFirstMatch:NO];
-  XCTAssertEqual(matchingSnapshots.count, 1);
-  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
-  XCTAssertTrue(matchingSnapshots.lastObject.isEnabled);
-  XCTAssertTrue(matchingSnapshots.lastObject.fb_isVisible);
-  XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
+  @try {
+    FBConfiguration.sharedInstance.showVisibilityAttributeForXML = YES;
+    NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@name='Alerts' and @enabled='true' and @visible='true']" shouldReturnAfterFirstMatch:NO];
+    XCTAssertEqual(matchingSnapshots.count, 1);
+    XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeButton);
+    XCTAssertTrue(matchingSnapshots.lastObject.isEnabled);
+    XCTAssertTrue(matchingSnapshots.lastObject.fb_isVisible);
+    XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
+  } @finally {
+    FBConfiguration.sharedInstance.showVisibilityAttributeForXML = NO;
+  }
+}
+
+- (void)testVisibleDescendantWithXPathQueryAndAlternativeVisibilityDetection
+{
+  @try {
+    FBConfiguration.sharedInstance.useAlternativeVisibilityDetection = YES;
+    [self testVisibleDescendantWithXPathQuery];
+  } @finally {
+    FBConfiguration.sharedInstance.useAlternativeVisibilityDetection = NO;
+  }
 }
 
 - (void)disabled_testInvisibleDescendantWithXPathQuery

--- a/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
+++ b/WebDriverAgentTests/UnitTests/FBConfigurationTests.m
@@ -46,4 +46,32 @@
   XCTAssertTrue([FBConfiguration verboseLoggingEnabled]);
 }
 
+- (void)testChangingSettings
+{
+  XCTAssertEqual([FBConfiguration sharedInstance].useAlternativeVisibilityDetection, NO);
+  XCTAssertEqual([FBConfiguration sharedInstance].showVisibilityAttributeForXML, NO);
+  @try {
+    NSMutableDictionary<NSString *, id> *newSettings = [NSMutableDictionary dictionary];
+    [newSettings setValue:@(YES) forKey:@"useAlternativeVisibilityDetection"];
+    [[FBConfiguration sharedInstance] changeSettings:newSettings];
+    XCTAssertEqual([FBConfiguration sharedInstance].useAlternativeVisibilityDetection, YES);
+    XCTAssertEqual([FBConfiguration sharedInstance].showVisibilityAttributeForXML, NO);
+    
+    NSDictionary<NSString *, id> *changedSettings = [[FBConfiguration sharedInstance] currentSettings];
+    XCTAssertEqual([[changedSettings valueForKey:@"useAlternativeVisibilityDetection"] boolValue], YES);
+    XCTAssertEqual([[changedSettings valueForKey:@"showVisibilityAttributeForXML"] boolValue], NO);
+  } @finally {
+    [[FBConfiguration sharedInstance] resetSettings];
+  }
+  XCTAssertEqual([FBConfiguration sharedInstance].useAlternativeVisibilityDetection, NO);
+  XCTAssertEqual([FBConfiguration sharedInstance].showVisibilityAttributeForXML, NO);
+}
+
+- (void)testWrongSettingName
+{
+  NSMutableDictionary<NSString *, id> *newSettings = [NSMutableDictionary dictionary];
+  [newSettings setValue:@(YES) forKey:@"blabla"];
+  XCTAssertThrowsSpecificNamed([FBConfiguration.sharedInstance changeSettings:newSettings], NSException, FBUnknownSettingNameException);
+}
+
 @end

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -9,6 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
+#import "FBConfiguration.h"
 #import "FBXPath.h"
 #import "FBXPath-Private.h"
 #import "XCUIElementDouble.h"
@@ -18,7 +19,7 @@
 
 @implementation FBXPathTests
 
-- (void)testInternalSnapshotXPathPresentation
+- (NSString *)uiTreeAsXML
 {
   xmlDocPtr doc;
 
@@ -35,11 +36,29 @@
   xmlFreeDoc(doc);
 
   XCTAssertEqual(rc, 0);
+  XCTAssertEqual(1, [elementStore count]);
 
-  NSString *resultXml = [NSString stringWithCString:(const char *)xmlbuff encoding:NSUTF8StringEncoding];
+  return [NSString stringWithCString:(const char *)xmlbuff encoding:NSUTF8StringEncoding];
+}
+
+- (void)testInternalSnapshotXPathPresentation
+{
+  NSString *resultXml = [self uiTreeAsXML];
   NSString *expectedXml = @"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<XCUIElementTypeOther type=\"XCUIElementTypeOther\" value=\"magicValue\" name=\"testName\" label=\"testLabel\" enabled=\"true\" x=\"0\" y=\"0\" width=\"0\" height=\"0\" private_indexPath=\"top\"/>\n";
   XCTAssertTrue([resultXml isEqualToString: expectedXml]);
-  XCTAssertEqual(1, [elementStore count]);
+}
+
+- (void)testInternalSnapshotXPathPresentationWithVisibility
+{
+  NSString *resultXml = @"";
+  @try {
+    FBConfiguration.sharedInstance.showVisibilityAttributeForXML = YES;
+    resultXml = [self uiTreeAsXML];
+  } @finally {
+    FBConfiguration.sharedInstance.showVisibilityAttributeForXML = NO;
+  }
+  NSString *expectedXml = @"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<XCUIElementTypeOther type=\"XCUIElementTypeOther\" value=\"magicValue\" name=\"testName\" label=\"testLabel\" visible=\"true\" enabled=\"true\" x=\"0\" y=\"0\" width=\"0\" height=\"0\" private_indexPath=\"top\"/>\n";
+  XCTAssertTrue([resultXml isEqualToString: expectedXml]);
 }
 
 - (void)testSnapshotXPathResultsMatching


### PR DESCRIPTION
I hope this is the last commit, which is supposed to finally fix this annoying issue described in #372

Now it is possible to switch visibility detection algorithm explicitly by setting the corresponding environment variable. So, in case there are freezing issues, it's always possible to use less accurate, but stable approach. 
Same with XML/XPath. One may just enable adding 'visible' attribute to XML nodes if he really uses it for XPath lookup.

All new features are disabled by default (which simulates the current _master_ behaviour), so the proposed change should not affect any existing tests.