### PR TITLE
Retry alert button tap by coordinates in non-portrait mode if “classic” tap didn’t work

### DIFF
--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -123,7 +123,14 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
       withDescriptionFormat:@"Failed to find accept button for alert: %@", alertElement]
      buildError:error];
   }
-  return [defaultButton fb_tapWithError:error];
+  [defaultButton tap];
+  if (defaultButton.exists && defaultButton.application.interfaceOrientation != UIDeviceOrientationPortrait) {
+    // Tap method invokation might not work as expected in non-portrait mode
+    // due to a known XCTest bug. That is why we need to retry it using tap
+    // by coordinates if the alert is still visible
+    return [defaultButton fb_tapWithError:error];
+  }
+  return YES;
 }
 
 - (BOOL)dismissWithError:(NSError **)error
@@ -144,7 +151,14 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
      buildError:error];
     return NO;
   }
-  return [cancelButton fb_tapWithError:error];
+  [cancelButton tap];
+  if (cancelButton.exists && cancelButton.application.interfaceOrientation != UIDeviceOrientationPortrait) {
+    // Tap method invokation might not work as expected in non-portrait mode
+    // due to a known XCTest bug. That is why we need to retry it using tap
+    // by coordinates if the alert is still visible
+    return [cancelButton fb_tapWithError:error];
+  }
+  return YES;
 }
 
 + (BOOL)isElementObstructedByAlertView:(XCUIElement *)element alert:(XCUIElement *)alert


### PR DESCRIPTION
It seems like there is difference between how XCTest handles the UI when a system or self-generated alert is visible and the current UI orientation is not portrait. This PR is trying to workaround the bug by doing "classic" tap on alert button and then retrying this by tapping on coordinates if the previous method failed. Otherwise it is not possible to accept system alert properly without manually changing interface orientation to portrait every time such alert appears on the screen.

Addresses https://github.com/appium/appium/issues/7772