### PR TITLE
Add capability to set typing speed

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -68,6 +68,9 @@
     return FBResponseWithErrorFormat(@"'bundleId' desired capability not provided");
   }
   [FBConfiguration setShouldUseTestManagerForVisibilityDetection:[requirements[@"shouldUseTestManagerForVisibilityDetection"] boolValue]];
+  if (requirements[@"maxTypingFrequency"]) {
+    [FBConfiguration setMaxTypingFrequency:[requirements[@"maxTypingFrequency"] integerValue]];
+  }
 
   FBApplication *app = [[FBApplication alloc] initPrivateWithPath:appPath bundleID:bundleID];
   app.fb_shouldWaitForQuiescence = [requirements[@"shouldWaitForQuiescence"] boolValue];

--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -19,6 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! If set to YES will ask TestManagerDaemon for element visibility */
 @property (class, nonatomic, assign) BOOL shouldUseTestManagerForVisibilityDetection;
 
+/* The maximum typing frequency for all typing activities */
+@property (class, nonatomic, assign) NSUInteger maxTypingFrequency;
+
 /**
  Switch for enabling/disabling reporting fake collection view cells by Accessibility framework.
  If set to YES it will report also invisible cells.

--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -20,6 +20,7 @@ static NSUInteger const DefaultStartingPort = 8100;
 static NSUInteger const DefaultPortRange = 100;
 
 static BOOL FBShouldUseTestManagerForVisibilityDetection = NO;
+static NSUInteger FBMaxTypingFrequency = 60;
 
 @implementation FBConfiguration
 
@@ -58,6 +59,16 @@ static BOOL FBShouldUseTestManagerForVisibilityDetection = NO;
 + (BOOL)shouldUseTestManagerForVisibilityDetection
 {
   return FBShouldUseTestManagerForVisibilityDetection;
+}
+
++ (void)setMaxTypingFrequency:(NSUInteger)value
+{
+  FBMaxTypingFrequency = value;
+}
+
++ (NSUInteger)maxTypingFrequency
+{
+  return FBMaxTypingFrequency;
 }
 
 #pragma mark Private

--- a/WebDriverAgentLib/Utilities/FBKeyboard.m
+++ b/WebDriverAgentLib/Utilities/FBKeyboard.m
@@ -18,8 +18,9 @@
 #import "XCElementSnapshot.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCTestDriver.h"
+#import "FBLogger.h"
+#import "FBConfiguration.h"
 
-static const NSUInteger FBTypingFrequency = 60;
 
 @implementation FBKeyboard
 
@@ -28,10 +29,14 @@ static const NSUInteger FBTypingFrequency = 60;
   if (![FBKeyboard waitUntilVisibleWithError:error]) {
     return NO;
   }
+
+  NSUInteger maxTypingFrequency = [FBConfiguration maxTypingFrequency];
+  [FBLogger logFmt:@"Typing with maximum frequency %lu", (unsigned long)maxTypingFrequency];
+
   __block BOOL didSucceed = NO;
   __block NSError *innerError;
   [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)()){
-    [[FBXCTestDaemonsProxy testRunnerProxy] _XCT_sendString:text maximumFrequency:FBTypingFrequency completion:^(NSError *typingError){
+    [[FBXCTestDaemonsProxy testRunnerProxy] _XCT_sendString:text maximumFrequency:maxTypingFrequency completion:^(NSError *typingError){
       didSucceed = (typingError == nil);
       innerError = typingError;
       completion();


### PR DESCRIPTION
Currently the maximum typing frequency is set at `60`. We have been seeing some cases, particularly when running on virtualized hardware, where clashes in the gestures occur and the operation fails (in fact the WebDriverAgent process fails altogether). Slowing down the frequency seems to be of great help.

So adding it as a desired capability, `maxTypingFrequency`, which can be sent in at session initialization time.