### PR TITLE
Silence deprecation error for openUrl

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -53,9 +53,12 @@
       [NSString stringWithFormat:@"%@ is not a valid URL", url]
     );
   }
+  #pragma clang diagnostic push
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (![[UIApplication sharedApplication] openURL:url]) {
     return FBResponseWithErrorFormat(@"Failed to open %@", url);
   }
+  #pragma clang diagnostic pop
   return FBResponseWithOK();
 }
 


### PR DESCRIPTION
A quick down-and-dirty fix for the inability to build in Xcode 8.3 because of the following error:
```
/Users/isaac/code/isaac-WDA/WebDriverAgentLib/Commands/FBSessionCommands.m:56:43: error: 'openURL:' is deprecated: first
      deprecated in iOS 10.0 - Please use openURL:options:completionHandler: instead [-Werror,-Wdeprecated-declarations]
  if (![[UIApplication sharedApplication] openURL:url]) {
                                          ^
In module 'XCTest' imported from /Users/isaac/code/isaac-WDA/PrivateHeaders/XCTest/XCUIApplication.h:7:
In module 'UIKit' imported from /Applications/Xcode-8.3.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks/XCTest.framework/Headers/XCUIElement.h:8:
/Applications/Xcode-8.3.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator10.3.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIApplication.h:125:1: note:
      'openURL:' has been explicitly marked deprecated here
- (BOOL)openURL:(NSURL*)url NS_DEPRECATED_IOS(2_0, 10_0, "Please use openURL:options:completionHandler: instead"...
^
1 error generated.

** TEST BUILD FAILED **
```