### PR TITLE
Replace invalid xml characters to avoid unexpected crashes

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -20,6 +20,9 @@
 		714CA3C71DC23186000F12C9 /* FBXPathIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */; };
 		71555A3D1DEC460A007D4A8B /* NSExpression+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */; };
 		71555A3E1DEC460A007D4A8B /* NSExpression+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */; };
+		716E0BCE1E917E810087A825 /* NSString+FBXMLSafeString.h in Headers */ = {isa = PBXBuildFile; fileRef = 716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */; };
+		716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */; };
+		716E0BD11E917F260087A825 /* FBXMLSafeStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */; };
 		7174AF041D9D39AF008C8AD5 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
 		719FF5B91DAD21F5008E0099 /* FBElementUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */; };
 		71A224E51DE2F56600844D55 /* NSPredicate+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */; };
@@ -358,6 +361,9 @@
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
 		71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSExpression+FBFormat.h"; sourceTree = "<group>"; };
 		71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSExpression+FBFormat.m"; sourceTree = "<group>"; };
+		716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FBXMLSafeString.h"; sourceTree = "<group>"; };
+		716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FBXMLSafeString.m"; sourceTree = "<group>"; };
+		716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXMLSafeStringTests.m; sourceTree = "<group>"; };
 		7174AF031D9D39AF008C8AD5 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
 		719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementUtilitiesTests.m; sourceTree = "<group>"; };
 		71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+FBFormat.h"; path = "../Utilities/NSPredicate+FBFormat.h"; sourceTree = "<group>"; };
@@ -780,6 +786,8 @@
 				71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */,
 				71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */,
 				71A224E41DE2F56600844D55 /* NSPredicate+FBFormat.m */,
+				716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */,
+				716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */,
 				EEE3763B1D59F81400ED88DD /* XCElementSnapshot+FBHelpers.h */,
 				EEE3763C1D59F81400ED88DD /* XCElementSnapshot+FBHelpers.m */,
 				AD6C269A1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h */,
@@ -990,6 +998,7 @@
 				ADEF63AC1D09DCCF0070A7E3 /* FBXPathCreatorTests.m */,
 				EE18883C1DA663EB00307AA8 /* FBMathUtilsTests.m */,
 				713914591DF01989005896C2 /* XCUIElementHelpersTests.m */,
+				716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */,
 				EE9B76581CF7987300275851 /* Info.plist */,
 			);
 			path = UnitTests;
@@ -1298,6 +1307,7 @@
 				EE158ACE1CBD456F00A3E3F0 /* FBCommandHandler.h in Headers */,
 				EE158AC81CBD456F00A3E3F0 /* FBSessionCommands.h in Headers */,
 				EE158AE31CBD456F00A3E3F0 /* FBSession-Private.h in Headers */,
+				716E0BCE1E917E810087A825 /* NSString+FBXMLSafeString.h in Headers */,
 				EE158ACF1CBD456F00A3E3F0 /* FBCommandStatus.h in Headers */,
 				EE35AD2D1E3B77D600A02D78 /* XCElementSnapshot.h in Headers */,
 				EE158AB81CBD456F00A3E3F0 /* FBAlertViewCommands.h in Headers */,
@@ -1582,6 +1592,7 @@
 				EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */,
 				EE158ACB1CBD456F00A3E3F0 /* FBTouchIDCommands.m in Sources */,
 				EE158ABD1CBD456F00A3E3F0 /* FBDebugCommands.m in Sources */,
+				716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */,
 				EE158ACD1CBD456F00A3E3F0 /* FBUnknownCommands.m in Sources */,
 				EE158AC51CBD456F00A3E3F0 /* FBOrientationCommands.m in Sources */,
 				EE158AEB1CBD456F00A3E3F0 /* FBRuntimeUtils.m in Sources */,
@@ -1622,6 +1633,7 @@
 				EEE16E971D33A25500172525 /* FBConfigurationTests.m in Sources */,
 				ADBC39941D0782CD00327304 /* FBElementCacheTests.m in Sources */,
 				719FF5B91DAD21F5008E0099 /* FBElementUtilitiesTests.m in Sources */,
+				716E0BD11E917F260087A825 /* FBXMLSafeStringTests.m in Sources */,
 				ADEF63AD1D09DCCF0070A7E3 /* FBXPathCreatorTests.m in Sources */,
 				ADEF63AF1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m in Sources */,
 				EE9B76591CF7987800275851 /* FBRouteTests.m in Sources */,

--- a/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.h
+++ b/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.h
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSString (FBXMLSafeString)
+
+/**
+ Method used to normalize a string before passing it to XML document
+ 
+ @param replacement The string to be used as a replacement for invalid XML characters
+ @return The string where all characters, which are not members of
+         XML Character Range definition (http://www.w3.org/TR/2008/REC-xml-20081126/#charsets),
+         are replaced
+ */
+- (NSString *)xmlSafeStringWithReplacement:(NSString *)replacement;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.h
+++ b/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
          XML Character Range definition (http://www.w3.org/TR/2008/REC-xml-20081126/#charsets),
          are replaced
  */
-- (NSString *)xmlSafeStringWithReplacement:(NSString *)replacement;
+- (NSString *)fb_xmlSafeStringWithReplacement:(NSString *)replacement;
 
 @end
 

--- a/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.m
+++ b/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.m
@@ -11,7 +11,7 @@
 
 @implementation NSString (FBXMLSafeString)
 
-- (NSString *)xmlSafeStringWithReplacement:(NSString *)replacement
+- (NSString *)fb_xmlSafeStringWithReplacement:(NSString *)replacement
 {
   static NSMutableCharacterSet *invalidSet;
   static dispatch_once_t onceToken;

--- a/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.m
+++ b/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.m
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "NSString+FBXMLSafeString.h"
+
+@implementation NSString (FBXMLSafeString)
+
+- (NSString *)xmlSafeStringWithReplacement:(NSString *)replacement
+{
+  static NSMutableCharacterSet *invalidSet;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    // Char ::= #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+    invalidSet = [NSMutableCharacterSet characterSetWithRange:NSMakeRange(0x9, 1)];
+    [invalidSet addCharactersInRange:NSMakeRange(0xA, 1)];
+    [invalidSet addCharactersInRange:NSMakeRange(0xD, 1)];
+    [invalidSet addCharactersInRange:NSMakeRange(0x20, 0xD7FF - 0x20 + 1)];
+    [invalidSet addCharactersInRange:NSMakeRange(0xE000, 0xFFFD - 0xE000 + 1)];
+    [invalidSet invert];
+  });
+  return [[self componentsSeparatedByCharactersInSet:invalidSet] componentsJoinedByString:replacement];
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -15,6 +15,7 @@
 #import "XCTestPrivateSymbols.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
+#import "NSString+FBXMLSafeString.h"
 
 const static char *_UTF8Encoding = "UTF-8";
 
@@ -183,10 +184,19 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   return xpathObj;
 }
 
++ (xmlChar *)safeXmlStringWithString:(NSString *)str
+{
+  if (nil == str) {
+    return NULL;
+  }
+  
+  NSString *safeString = [str xmlSafeStringWithReplacement:@""];
+  return [self.class xmlCharPtrForInput:[safeString cStringUsingEncoding:NSUTF8StringEncoding]];
+}
+
 + (int)recordElementAttributes:(xmlTextWriterPtr)writer forElement:(XCElementSnapshot *)element indexPath:(nullable NSString *)indexPath
 {
-  int rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "type",
-                                       [FBXPath xmlCharPtrForInput:[element.wdType cStringUsingEncoding:NSUTF8StringEncoding]]);
+  int rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "type", [self.class safeXmlStringWithString:element.wdType]);
   if (rc < 0) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(type='%@'). Error code: %d", element.wdType, rc];
     return rc;
@@ -201,24 +211,21 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     } else {
       stringValue = [value description];
     }
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "value",
-                                     [FBXPath xmlCharPtrForInput:[stringValue cStringUsingEncoding:NSUTF8StringEncoding]]);
+    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "value", [self.class safeXmlStringWithString:stringValue]);
     if (rc < 0) {
       [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(value='%@'). Error code: %d", stringValue, rc];
       return rc;
     }
   }
   if (element.wdName) {
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "name",
-                                     [FBXPath xmlCharPtrForInput:[element.wdName cStringUsingEncoding:NSUTF8StringEncoding]]);
+    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "name", [self.class safeXmlStringWithString:element.wdName]);
     if (rc < 0) {
       [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(name='%@'). Error code: %d", element.wdName, rc];
       return rc;
     }
   }
   if (element.wdLabel) {
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "label",
-                                     [FBXPath xmlCharPtrForInput:[element.wdLabel cStringUsingEncoding:NSUTF8StringEncoding]]);
+    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "label", [self.class safeXmlStringWithString:element.wdLabel]);
     if (rc < 0) {
       [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(label='%@'). Error code: %d", element.wdLabel, rc];
       return rc;
@@ -230,8 +237,8 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     return rc;
   }
   for (NSString *attrName in @[@"x", @"y", @"width", @"height"]) {
-    rc = xmlTextWriterWriteAttribute(writer, [FBXPath xmlCharPtrForInput:[attrName cStringUsingEncoding:NSUTF8StringEncoding]],
-                                     [FBXPath xmlCharPtrForInput:[[element.wdRect[attrName] stringValue] cStringUsingEncoding:NSUTF8StringEncoding]]);
+    rc = xmlTextWriterWriteAttribute(writer, [self.class safeXmlStringWithString:attrName],
+                                     [self.class safeXmlStringWithString:[element.wdRect[attrName] stringValue]]);
     if (rc < 0) {
       [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(%@). Error code: %d", attrName, rc];
       return rc;
@@ -239,8 +246,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   }
 
   if (nil != indexPath) {
-    rc = xmlTextWriterWriteAttribute(writer, [FBXPath xmlCharPtrForInput:[kXMLIndexPathKey cStringUsingEncoding:NSUTF8StringEncoding]],
-                                     [FBXPath xmlCharPtrForInput:[indexPath cStringUsingEncoding:NSUTF8StringEncoding]]);
+    rc = xmlTextWriterWriteAttribute(writer, [self.class safeXmlStringWithString:kXMLIndexPathKey], [self.class safeXmlStringWithString:indexPath]);
     if (rc < 0) {
       [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(indexPath='%@'). Error code: %d", indexPath, rc];
       return rc;

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -190,7 +190,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     return NULL;
   }
   
-  NSString *safeString = [str xmlSafeStringWithReplacement:@""];
+  NSString *safeString = [str fb_xmlSafeStringWithReplacement:@""];
   return [self.class xmlCharPtrForInput:[safeString cStringUsingEncoding:NSUTF8StringEncoding]];
 }
 

--- a/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
@@ -20,7 +20,7 @@
   NSString *withInvalidChar = [NSString stringWithFormat:@"bla%@", @"\uFFFF"];
   NSString *withoutInvalidChar = @"bla";
   XCTAssertNotEqualObjects(withInvalidChar, withoutInvalidChar);
-  XCTAssertEqualObjects([withInvalidChar xmlSafeStringWithReplacement:@""], withInvalidChar);
+  XCTAssertEqualObjects([withInvalidChar xmlSafeStringWithReplacement:@""], withoutInvalidChar);
 }
 
 - (void)testSafeXmlStringTransformationWithNonEmptyReplacement {

--- a/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "NSString+FBXMLSafeString.h"
+
+@interface FBXMLSafeStringTests : XCTestCase
+@end
+
+@implementation FBXMLSafeStringTests
+
+- (void)testSafeXmlStringTransformationWithEmptyReplacement {
+  NSString *withInvalidChar = [NSString stringWithFormat:@"bla%@", @"\uFFFF"];
+  NSString *withoutInvalidChar = @"bla";
+  XCTAssertNotEqualObjects(withInvalidChar, withoutInvalidChar);
+  XCTAssertEqualObjects([withInvalidChar xmlSafeStringWithReplacement:@""], withInvalidChar);
+}
+
+- (void)testSafeXmlStringTransformationWithNonEmptyReplacement {
+  NSString *withInvalidChar = [NSString stringWithFormat:@"bla%@", @"\uFFFF"];
+  XCTAssertEqualObjects([withInvalidChar xmlSafeStringWithReplacement:@"1"], @"bla1");
+}
+
+@end

--- a/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
@@ -20,12 +20,12 @@
   NSString *withInvalidChar = [NSString stringWithFormat:@"bla%@", @"\uFFFF"];
   NSString *withoutInvalidChar = @"bla";
   XCTAssertNotEqualObjects(withInvalidChar, withoutInvalidChar);
-  XCTAssertEqualObjects([withInvalidChar xmlSafeStringWithReplacement:@""], withoutInvalidChar);
+  XCTAssertEqualObjects([withInvalidChar fb_xmlSafeStringWithReplacement:@""], withoutInvalidChar);
 }
 
 - (void)testSafeXmlStringTransformationWithNonEmptyReplacement {
   NSString *withInvalidChar = [NSString stringWithFormat:@"bla%@", @"\uFFFF"];
-  XCTAssertEqualObjects([withInvalidChar xmlSafeStringWithReplacement:@"1"], @"bla1");
+  XCTAssertEqualObjects([withInvalidChar fb_xmlSafeStringWithReplacement:@"1"], @"bla1");
 }
 
 @end


### PR DESCRIPTION
This resolves the issue when application under test contains some characters in resources, which are unsupported in XML, and causes WDA to throw an exception, for example https://github.com/appium/appium/issues/8084

With this patch WDA will be able to build page source tree properly by simply cutting off all unsupported characters. 