### PR TITLE
Switch from class property to methods

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.h
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.h
@@ -17,10 +17,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBConfiguration : NSObject
 
 /*! If set to YES will ask TestManagerDaemon for element visibility */
-@property (class, nonatomic, assign) BOOL shouldUseTestManagerForVisibilityDetection;
++ (void)setShouldUseTestManagerForVisibilityDetection:(BOOL)value;
++ (BOOL)shouldUseTestManagerForVisibilityDetection;
 
 /* The maximum typing frequency for all typing activities */
-@property (class, nonatomic, assign) NSUInteger maxTypingFrequency;
++ (void)setMaxTypingFrequency:(NSUInteger)value;
++ (NSUInteger)maxTypingFrequency;
 
 /**
  Switch for enabling/disabling reporting fake collection view cells by Accessibility framework.


### PR DESCRIPTION
Some recent changes use class properties, which break building with Xcode 7. This exposes the same API without the new syntax.