### PR TITLE
Make the offset configurable

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBPickerWheel.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBPickerWheel.h
@@ -16,20 +16,30 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Selects the next available option in Picker Wheel
  
+ @param offset the value in range [0.01, 0.5]. It defines how far from picker
+   wheel's center the click should happen. The actual distance is culculated by
+   multiplying this value to the actual picker wheel height. Too small offset value
+   may not change the picker wheel value and too high value may cause the wheel to switch
+   two or more values at once. Usually the optimal value is located in range [0.15, 0.3]
  @param error returns error object if there was an error while selecting the
    next picker value
  @return YES if the current option has been successfully switched. Otherwise NO
  */
-- (BOOL)fb_selectNextOptionWithError:(NSError **)error;
+- (BOOL)fb_selectNextOptionWithOffset:(CGFloat)offset error:(NSError **)error;
 
 /**
  Selects the previous available option in Picker Wheel
  
- @param error returns error object if there was an error while selecting the 
+ @param offset the value in range [0.01, 0.5]. It defines how far from picker
+   wheel's center the click should happen. The actual distance is culculated by
+   multiplying this value to the actual picker wheel height. Too small offset value
+   may not change the picker wheel value and too high value may cause the wheel to switch
+   two or more values at once. Usually the optimal value is located in range [0.15, 0.3]
+ @param error returns error object if there was an error while selecting the
    previous picker value
  @return YES if the current option has been successfully switched. Otherwise NO
  */
-- (BOOL)fb_selectPreviousOptionWithError:(NSError **)error;
+- (BOOL)fb_selectPreviousOptionWithOffset:(CGFloat)offset error:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBPickerWheel.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBPickerWheel.m
@@ -14,7 +14,6 @@
 
 @implementation XCUIElement (FBPickerWheel)
 
-static const CGFloat RELATIVE_OFFSET = (CGFloat)0.2;
 static const NSTimeInterval VALUE_CHANGE_TIMEOUT = 2;
 
 - (BOOL)fb_scrollWithOffset:(CGFloat)relativeHeightOffset error:(NSError **)error
@@ -33,14 +32,14 @@ static const NSTimeInterval VALUE_CHANGE_TIMEOUT = 2;
    error:error];
 }
 
-- (BOOL)fb_selectNextOptionWithError:(NSError **)error
+- (BOOL)fb_selectNextOptionWithOffset:(CGFloat)offset error:(NSError **)error
 {
-  return [self fb_scrollWithOffset:(CGFloat)RELATIVE_OFFSET error:error];
+  return [self fb_scrollWithOffset:offset error:error];
 }
 
-- (BOOL)fb_selectPreviousOptionWithError:(NSError **)error
+- (BOOL)fb_selectPreviousOptionWithOffset:(CGFloat)offset error:(NSError **)error
 {
-  return [self fb_scrollWithOffset:(CGFloat)-RELATIVE_OFFSET error:error];
+  return [self fb_scrollWithOffset:-offset error:error];
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -379,12 +379,19 @@
     return FBResponseWithErrorFormat(@"The element is expected to be a valid Picker Wheel control. '%@' was given instead", element.wdType);
   }
   NSString* order = [request.arguments[@"order"] lowercaseString];
+  CGFloat offset = (CGFloat)0.2;
+  if (request.arguments[@"offset"]) {
+    offset = (CGFloat)[request.arguments[@"offset"] doubleValue];
+    if (offset <= 0.0 || offset > 0.5) {
+      return FBResponseWithErrorFormat(@"'offset' value is expected to be in range (0.0, 0.5]. '%@' was given instead", request.arguments[@"offset"]);
+    }
+  }
   BOOL isSuccessful = false;
   NSError *error;
   if ([order isEqualToString:@"next"]) {
-    isSuccessful = [element fb_selectNextOptionWithError:&error];
+    isSuccessful = [element fb_selectNextOptionWithOffset:offset error:&error];
   } else if ([order isEqualToString:@"previous"]) {
-    isSuccessful = [element fb_selectPreviousOptionWithError:&error];
+    isSuccessful = [element fb_selectPreviousOptionWithOffset:offset error:&error];
   } else {
     return FBResponseWithErrorFormat(@"Only 'previous' and 'next' order values are supported. '%@' was given instead", request.arguments[@"order"]);
   }

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -371,6 +371,8 @@
   });
 }
 
+static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
+
 + (id<FBResponsePayload>)handleWheelSelect:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
@@ -379,9 +381,9 @@
     return FBResponseWithErrorFormat(@"The element is expected to be a valid Picker Wheel control. '%@' was given instead", element.wdType);
   }
   NSString* order = [request.arguments[@"order"] lowercaseString];
-  CGFloat offset = (CGFloat)0.2;
+  CGFloat offset = DEFAULT_OFFSET;
   if (request.arguments[@"offset"]) {
-    offset = (CGFloat)[request.arguments[@"offset"] doubleValue];
+    offset = [request.arguments[@"offset"] doubleValue];
     if (offset <= 0.0 || offset > 0.5) {
       return FBResponseWithErrorFormat(@"'offset' value is expected to be in range (0.0, 0.5]. '%@' was given instead", request.arguments[@"offset"]);
     }

--- a/WebDriverAgentTests/IntegrationTests/FBPickerWheelSelectTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBPickerWheelSelectTests.m
@@ -18,6 +18,8 @@
 
 @implementation FBPickerWheelSelectTests
 
+static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
+
 - (void)setUp
 {
   [super setUp];
@@ -31,7 +33,7 @@
   XCTAssertEqualObjects(element.wdType, @"XCUIElementTypePickerWheel");
   NSError *error;
   NSString *previousValue = element.wdValue;
-  XCTAssertTrue([element fb_selectNextOptionWithError:&error]);
+  XCTAssertTrue([element fb_selectNextOptionWithOffset:DEFAULT_OFFSET error:&error]);
   XCTAssertNotEqualObjects(previousValue, element.wdValue);
 }
 
@@ -42,7 +44,7 @@
   XCTAssertEqualObjects(element.wdType, @"XCUIElementTypePickerWheel");
   NSError *error;
   NSString *previousValue = element.wdValue;
-  XCTAssertTrue([element fb_selectPreviousOptionWithError:&error]);
+  XCTAssertTrue([element fb_selectPreviousOptionWithOffset:DEFAULT_OFFSET error:&error]);
   XCTAssertNotEqualObjects(previousValue, element.wdValue);
 }
 


### PR DESCRIPTION
This PR adds an optional _offset_ attribute to _/wda/pickerwheel/:uuid/select_ API call. This is done, because the default offset, which was previously equal to 0.2 may not work as expected for some picker wheel implementations and make the wheel to switch more than one value at once. Now this behaviour is configurable.