### PR TITLE
Add missing XML range

### DIFF
--- a/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.m
+++ b/WebDriverAgentLib/Categories/NSString+FBXMLSafeString.m
@@ -22,6 +22,7 @@
     [invalidSet addCharactersInRange:NSMakeRange(0xD, 1)];
     [invalidSet addCharactersInRange:NSMakeRange(0x20, 0xD7FF - 0x20 + 1)];
     [invalidSet addCharactersInRange:NSMakeRange(0xE000, 0xFFFD - 0xE000 + 1)];
+    [invalidSet addCharactersInRange:NSMakeRange(0x10000, 0x10FFFF - 0x10000 + 1)];
     [invalidSet invert];
   });
   return [[self componentsSeparatedByCharactersInSet:invalidSet] componentsJoinedByString:replacement];

--- a/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXMLSafeStringTests.m
@@ -28,4 +28,9 @@
   XCTAssertEqualObjects([withInvalidChar fb_xmlSafeStringWithReplacement:@"1"], @"bla1");
 }
 
+- (void)testSafeXmlStringTransformationWithSmileys {
+  NSString *validString = @"Yo👿";
+  XCTAssertEqualObjects([validString fb_xmlSafeStringWithReplacement:@""], validString);
+}
+
 @end


### PR DESCRIPTION
Forgot to add one more unicode range to the set of valid chars for XML replacement. Now it is fixed