### PR TITLE
WebdriverAgent change port with parameter

### DIFF
--- a/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
+++ b/WebDriverAgent.xcodeproj/xcshareddata/xcschemes/WebDriverAgentRunner.xcscheme
@@ -61,6 +61,13 @@
             ReferencedContainer = "container:WebDriverAgent.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "USE_PORT"
+            value = "$(WDA_PORT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>


### PR DESCRIPTION
I edit WebDriverAgentRunner in order to change port which WebDriverAgent runs. I added environment variable.

Main purpose of change port, in Appium side, we trying to run parallel tests on a macOS. With the these both change (https://github.com/appium/appium-xcuitest-driver/pull/435/) it is going to be possible

https://github.com/appium/appium-xcuitest-driver/pull/435/