### PR TITLE
Add animation timeout before getting element snapshot to avoid most occurrences of “Error copying attributes -25202” issues

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -16,6 +16,7 @@
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
 #import "XCUIElement+FBIsVisible.h"
+#import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 
 const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
@@ -45,11 +46,13 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 
 - (NSDictionary *)fb_tree
 {
+  [self fb_waitUntilSnapshotIsStable];
   return [self.class dictionaryForElement:self.lastSnapshot];
 }
 
 - (NSDictionary *)fb_accessibilityTree
 {
+  [self fb_waitUntilSnapshotIsStable];
   // We ignore all elements except for the main window for accessibility tree
   return [self.class accessibilityInfoForElement:self.fb_mainWindowSnapshot];
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -102,6 +102,7 @@
 {
   // XPath will try to match elements only class name, so requesting elements by XCUIElementTypeAny will not work. We should use '*' instead.
   xpathQuery = [xpathQuery stringByReplacingOccurrencesOfString:@"XCUIElementTypeAny" withString:@"*"];
+  [self waitUntilSnapshotIsStable];
   return [self.lastSnapshot fb_descendantsMatchingXPathQuery:xpathQuery];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -102,7 +102,7 @@
 {
   // XPath will try to match elements only class name, so requesting elements by XCUIElementTypeAny will not work. We should use '*' instead.
   xpathQuery = [xpathQuery stringByReplacingOccurrencesOfString:@"XCUIElementTypeAny" withString:@"*"];
-  [self waitUntilSnapshotIsStable];
+  [self fb_waitUntilSnapshotIsStable];
   return [self.lastSnapshot fb_descendantsMatchingXPathQuery:xpathQuery];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -22,7 +22,7 @@
 
 - (BOOL)fb_isVisible
 {
-  [self waitUntilSnapshotIsStable];
+  [self fb_waitUntilSnapshotIsStable];
   return self.fb_lastSnapshot.fb_isVisible;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -13,6 +13,7 @@
 #import "FBConfiguration.h"
 #import "FBMathUtils.h"
 #import "XCElementSnapshot+FBHelpers.h"
+#import "XCUIElement+FBUtilities.h"
 #import "XCTestPrivateSymbols.h"
 #import <XCTest/XCUIDevice.h>
 #import "XCElementSnapshot+FBHitPoint.h"
@@ -21,10 +22,8 @@
 
 - (BOOL)fb_isVisible
 {
-  if (!self.lastSnapshot) {
-    [self resolve];
-  }
-  return self.lastSnapshot.fb_isVisible;
+  [self waitUntilSnapshotIsStable];
+  return self.fb_lastSnapshot.fb_isVisible;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -22,7 +22,6 @@
 
 - (BOOL)fb_isVisible
 {
-  [self fb_waitUntilSnapshotIsStable];
   return self.fb_lastSnapshot.fb_isVisible;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -62,6 +62,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (NSArray<XCUIElement *> *)fb_filterElements:(NSDictionary<NSNumber *, NSArray<XCUIElement *> *> *)elementsMap matchingSnapshots:(NSArray<XCElementSnapshot *> *)snapshots useReversedOrder:(BOOL)useReversedOrder;
 
+/**
+ Waits until element snapshot is stable to avoid "Error copying attributes -25202 error".
+ This error usually happens for testmanagerd if there is an active UI animation in progress and
+ causes 15-seconds delay while getting hitpoint value of element's snapshot.
+
+ @return YES if wait succeeded ortherwise NO if there is still some active animation in progress
+*/
+- (BOOL)waitUntilSnapshotIsStable;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -69,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @return YES if wait succeeded ortherwise NO if there is still some active animation in progress
 */
-- (BOOL)waitUntilSnapshotIsStable;
+- (BOOL)fb_waitUntilSnapshotIsStable;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -18,7 +18,7 @@
 
 @implementation XCUIElement (FBUtilities)
 
-const NSTimeInterval ANIMATION_TIMEOUT = 5.0;
+static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 
 - (BOOL)fb_waitUntilFrameIsStable
 {
@@ -109,10 +109,10 @@ const NSTimeInterval ANIMATION_TIMEOUT = 5.0;
 {
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   [[XCAXClient_iOS sharedClient] notifyWhenNoAnimationsAreActiveForApplication:self.application reply:^{dispatch_semaphore_signal(sem);}];
-  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(ANIMATION_TIMEOUT * NSEC_PER_SEC));
+  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(FBANIMATION_TIMEOUT * NSEC_PER_SEC));
   BOOL result = 0 == dispatch_semaphore_wait(sem, timeout);
   if (!result) {
-    [FBLogger logFmt:@"There are still some active animations in progress after %.2f seconds timeout. Visibility detection may cause unexpected delays.", ANIMATION_TIMEOUT];
+    [FBLogger logFmt:@"There are still some active animations in progress after %.2f seconds timeout. Visibility detection may cause unexpected delays.", FBANIMATION_TIMEOUT];
   }
   return result;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -105,7 +105,7 @@ const NSTimeInterval ANIMATION_TIMEOUT = 5.0;
   return matchingElements.copy;
 }
 
-- (BOOL)waitUntilSnapshotIsStable
+- (BOOL)fb_waitUntilSnapshotIsStable
 {
   dispatch_semaphore_t sem = dispatch_semaphore_create(0);
   [[XCAXClient_iOS sharedClient] notifyWhenNoAnimationsAreActiveForApplication:self.application reply:^{dispatch_semaphore_signal(sem);}];

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -13,6 +13,7 @@
 #import "FBRouteRequest.h"
 #import "FBSession.h"
 #import "XCUIApplication+FBHelpers.h"
+#import "XCUIElement+FBUtilities.h"
 #import "FBXPath.h"
 
 @implementation FBDebugCommands
@@ -33,24 +34,16 @@
 
 #pragma mark - Commands
 
-+ (id<FBResponsePayload>)handleGetTreeCommand:(FBRouteRequest *)request
-{
-  FBApplication *application = request.session.application ?: [FBApplication fb_activeApplication];
-  if (!application) {
-    return FBResponseWithErrorFormat(@"There is no active application");
-  }
-  const BOOL accessibleTreeType = [request.arguments[@"accessible"] boolValue];
-  return FBResponseWithObject(@{ @"tree": (accessibleTreeType ? application.fb_accessibilityTree : application.fb_tree) ?: @{}});
-}
-
 + (id<FBResponsePayload>)handleGetSourceCommand:(FBRouteRequest *)request
 {
   FBApplication *application = request.session.application ?: [FBApplication fb_activeApplication];
   NSString *sourceType = request.parameters[@"format"];
   id result;
   if (!sourceType || [sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
+    [application waitUntilSnapshotIsStable];
     result = [FBXPath xmlStringWithSnapshot:application.lastSnapshot];
   } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {
+    [application waitUntilSnapshotIsStable];
     result = application.fb_tree;
   } else {
     return FBResponseWithStatus(

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -43,7 +43,6 @@
     [application fb_waitUntilSnapshotIsStable];
     result = [FBXPath xmlStringWithSnapshot:application.lastSnapshot];
   } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {
-    [application fb_waitUntilSnapshotIsStable];
     result = application.fb_tree;
   } else {
     return FBResponseWithStatus(

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -40,10 +40,10 @@
   NSString *sourceType = request.parameters[@"format"];
   id result;
   if (!sourceType || [sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
-    [application waitUntilSnapshotIsStable];
+    [application fb_waitUntilSnapshotIsStable];
     result = [FBXPath xmlStringWithSnapshot:application.lastSnapshot];
   } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {
-    [application waitUntilSnapshotIsStable];
+    [application fb_waitUntilSnapshotIsStable];
     result = application.fb_tree;
   } else {
     return FBResponseWithStatus(

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -134,7 +134,7 @@
                                NSException, XCElementSnapshotInvalidXPathException);
 }
 
-- (void)disabled_testVisibleDescendantWithXPathQuery
+- (void)testVisibleDescendantWithXPathQuery
 {
   NSArray<XCUIElement *> *matchingSnapshots = [self.testedView fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeButton[@name='Alerts' and @enabled='true' and @visible='true']" shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
@@ -144,13 +144,13 @@
   XCTAssertEqualObjects(matchingSnapshots.lastObject.label, @"Alerts");
 }
 
-- (void)disabled_testInvisibleDescendantWithXPathQuery
+- (void)testInvisibleDescendantWithXPathQuery
 {
   [self goToAttributesPage];
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypePageIndicator[@visible='true']" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypePageIndicator[@visible='false']" shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
   XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypePageIndicator);
-  XCTAssertTrue(matchingSnapshots.lastObject.fb_isVisible);
+  XCTAssertFalse(matchingSnapshots.lastObject.fb_isVisible);
 }
 
 - (void)testDescendantsWithPredicateString


### PR DESCRIPTION
This patch helps to solve "Error copying attributes -25202" error and hardcoded 15-second delay caused by this error by taking element snapshot for XML tree building and XCElement visibility detection while UI animations (usually these are transitions between views or loading screens) are in progress.