### PR TITLE
Add element class to the /source route

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		ADDA07241D6BB2BF001700AC /* FBScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADDA07231D6BB2BF001700AC /* FBScrollViewController.m */; };
 		ADEF63AD1D09DCCF0070A7E3 /* FBXPathCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEF63AC1D09DCCF0070A7E3 /* FBXPathCreatorTests.m */; };
 		ADEF63AF1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */; };
+		E4E64D601ED23B8E00906528 /* XCUIElement+FBClass.m in Sources */ = {isa = PBXBuildFile; fileRef = E4E64D5F1ED23B8E00906528 /* XCUIElement+FBClass.m */; };
 		EE006EAD1EB99B15006900A4 /* FBElementVisibilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = EE006EAC1EB99B15006900A4 /* FBElementVisibilityTests.m */; };
 		EE006EB01EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = EE006EAE1EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.h */; };
 		EE006EB11EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.m in Sources */ = {isa = PBXBuildFile; fileRef = EE006EAF1EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.m */; };
@@ -439,6 +440,8 @@
 		ADDA07231D6BB2BF001700AC /* FBScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBScrollViewController.m; sourceTree = "<group>"; };
 		ADEF63AC1D09DCCF0070A7E3 /* FBXPathCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathCreatorTests.m; sourceTree = "<group>"; };
 		ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBRuntimeUtilsTests.m; sourceTree = "<group>"; };
+		E4E64D5E1ED23B7400906528 /* XCUIElement+FBClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBClass.h"; sourceTree = "<group>"; };
+		E4E64D5F1ED23B8E00906528 /* XCUIElement+FBClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBClass.m"; sourceTree = "<group>"; };
 		EE006EAC1EB99B15006900A4 /* FBElementVisibilityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementVisibilityTests.m; sourceTree = "<group>"; };
 		EE006EAE1EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCElementSnapshot+FBHitPoint.h"; sourceTree = "<group>"; };
 		EE006EAF1EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCElementSnapshot+FBHitPoint.m"; sourceTree = "<group>"; };
@@ -899,6 +902,8 @@
 				EEE376401D59F81400ED88DD /* XCUIElement+FBUtilities.m */,
 				EEE376471D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.h */,
 				EEE376481D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m */,
+				E4E64D5E1ED23B7400906528 /* XCUIElement+FBClass.h */,
+				E4E64D5F1ED23B8E00906528 /* XCUIElement+FBClass.m */,
 			);
 			name = Categories;
 			path = WebDriverAgentLib/Categories;
@@ -1758,6 +1763,7 @@
 				EE006EB11EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.m in Sources */,
 				EE9B76A71CF7A43900275851 /* FBConfiguration.m in Sources */,
 				EE158AD31CBD456F00A3E3F0 /* FBElementCache.m in Sources */,
+				E4E64D601ED23B8E00906528 /* XCUIElement+FBClass.m in Sources */,
 				AD6C26951CF2379700F8B5FF /* FBAlert.m in Sources */,
 				EE158ABF1CBD456F00A3E3F0 /* FBElementCommands.m in Sources */,
 				EE158AD51CBD456F00A3E3F0 /* FBExceptionHandler.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClass.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClass.h
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <WebDriverAgentLib/XCElementSnapshot.h>
+#import <WebDriverAgentLib/XCUIElement.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIElement (FBClass)
+
+/*! Element's class (UIView or derived) */
+@property (nonatomic, readonly, copy) NSString *fb_class;
+
+@end
+
+
+@interface XCElementSnapshot (FBClass)
+
+/*! Element's class (UIView or derived) */
+@property (nonatomic, readonly, copy) NSString *fb_class;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClass.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClass.m
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "XCUIElement+FBClass.h"
+
+@implementation XCUIElement (FBClass)
+
+- (NSString*)fb_class
+{
+  if (!self.lastSnapshot) {
+    [self resolve];
+  }
+  return [self.lastSnapshot fb_class];
+}
+
+@end
+
+@implementation XCElementSnapshot (FBClass)
+
+- (NSString*)fb_class
+{
+  NSNumber* classId = [NSNumber numberWithInt:5004];
+  NSObject* class = [self.additionalAttributes objectForKey:classId];
+  if([class isKindOfClass:[NSString class]]){
+    return (NSString*)class;
+  } else {
+    return nil;
+  }
+}
+
+@end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClass.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClass.m
@@ -30,7 +30,7 @@
   if([class isKindOfClass:[NSString class]]){
     return (NSString*)class;
   } else {
-    return nil;
+    return @"";
   }
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -15,6 +15,7 @@
 #import "FBMacros.h"
 #import "XCUIElement+FBAccessibility.h"
 #import "XCUIElement+FBIsVisible.h"
+#import "XCUIElement+FBClass.h"
 #import "XCUIElement.h"
 #import "FBElementUtils.h"
 
@@ -88,6 +89,11 @@
 - (NSString *)wdType
 {
   return [FBElementTypeTransformer stringWithElementType:self.elementType];
+}
+
+- (NSString *)wdClass
+{
+  return FBTransferEmptyStringToNil(self.fb_class);
 }
 
 - (CGRect)wdFrame

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -32,6 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Element's type */
 @property (nonatomic, readonly, copy) NSString *wdType;
 
+/*! Element's class (UIView or derived) */
+@property (nonatomic, readonly, copy) NSString *wdClass;
+
 /*! Element's value */
 @property (nonatomic, readonly, strong, nullable) id wdValue;
 

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -224,14 +224,10 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       return rc;
     }
   }
-  
-  NSNumber* classId = [NSNumber numberWithInt:5004];
-  NSString* className = [element.additionalAttributes objectForKey:classId];
-  
-  if (className) {
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "class", [self.class safeXmlStringWithString:className]);
+  if (element.wdClass) {
+    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "class", [self.class safeXmlStringWithString:element.wdClass]);
     if (rc < 0) {
-      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(class='%@'). Error code: %d", className, rc];
+      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(class='%@'). Error code: %d", element.wdClass, rc];
       return rc;
     }
   }

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -224,6 +224,17 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       return rc;
     }
   }
+  
+  NSNumber* classId = [NSNumber numberWithInt:5004];
+  NSString* className = [element.additionalAttributes objectForKey:classId];
+  
+  if (className) {
+    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "class", [self.class safeXmlStringWithString:className]);
+    if (rc < 0) {
+      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(class='%@'). Error code: %d", className, rc];
+      return rc;
+    }
+  }
   if (element.wdLabel) {
     rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "label", [self.class safeXmlStringWithString:element.wdLabel]);
     if (rc < 0) {


### PR DESCRIPTION
Adds support for retrieving the underlying element class (such as `UIView` and its derivates) and adding it to the `source`.