### PR TITLE
Make /source about 3x faster (by making visible less accurate)

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.h
@@ -25,6 +25,9 @@ NS_ASSUME_NONNULL_BEGIN
 /*! Whether or not the element is visible */
 @property (atomic, readonly) BOOL fb_isVisible;
 
+/*! Whether or not the element is visible, optionally using a 
+ *  less precise heuristic o bypass a very expensive hittest */
+- (BOOL)fb_isVisible:(BOOL)useHeuristic;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -30,10 +30,19 @@
 @end
 
 @implementation XCElementSnapshot (FBIsVisible)
-
 - (BOOL)fb_isVisible
 {
-  if (CGRectIsEmpty(self.frame) || CGRectIsEmpty(self.visibleFrame)) {
+  return [self fb_isVisible:NO];
+}
+
+- (BOOL)fb_isVisible: (BOOL)useHeuristic
+{
+  CGRect frame = self.frame;
+  if (CGRectIsEmpty(frame)) {
+    return NO;
+  }
+  CGRect visibleFrame = useHeuristic ? frame : self.visibleFrame;
+  if (CGRectIsEmpty(visibleFrame)) {
     return NO;
   }
   if ([FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
@@ -42,8 +51,8 @@
   XCElementSnapshot *app = [self _rootElement];
   CGSize screenSize = FBAdjustDimensionsForApplication(app.frame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
   CGRect screenFrame = CGRectMake(0, 0, screenSize.width, screenSize.height);
-  BOOL rectIntersects = CGRectIntersectsRect(self.visibleFrame, screenFrame);
-  BOOL isActionable = CGRectContainsPoint(app.frame, self.fb_hitPoint);
+  BOOL rectIntersects = CGRectIntersectsRect(visibleFrame, screenFrame);
+  BOOL isActionable = useHeuristic ? YES : CGRectContainsPoint(app.frame, self.fb_hitPoint);
   return rectIntersects && isActionable;
 }
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -100,6 +100,11 @@
   return self.fb_isVisible;
 }
 
+- (BOOL)isWDVisible:(BOOL)useHeuristic
+{
+  return [self fb_isVisible:useHeuristic];
+}
+
 - (BOOL)isWDAccessible
 {
   // Special cases:

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -58,6 +58,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable id)fb_valueForWDAttributeName:(NSString *__nullable)name;
 
+- (BOOL) isWDVisible:(BOOL)useHeuristic;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -236,7 +236,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(wdEnabled). Error code: %d", rc];
     return rc;
   }
-  rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "visible", element.wdVisible ? BAD_CAST "true" : BAD_CAST "false");
+  rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "visible", [element isWDVisible:YES] ? BAD_CAST "true" : BAD_CAST "false");
   if (rc < 0) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(wdVisible). Error code: %d", rc];
     return rc;


### PR DESCRIPTION
The `/source` route is very slow; on older devices (iPhone 5S), I get response times of approx 3.7s for retrieving the source of a home page; on newer devices (iPhone 7), the response times are about 1s but still slow.

Most of the time is spent in:
- Getting the active application
- Determining the visibility of the individual elements

I didn't dig into fetching the application yet, but when determining the visibility, the visible rectangle and hitpoint are determined for each element with a non-zero size and this is a *very* expensive operation, especially in a tight loop.

This PR adds a "heuristic" flag to isVisible; if this flag is set:
- `visibleFrame` is assumed to be equal to `frame`
- the hit point is always assumed to be inside the application frame.

This flag is *only* used inside the `/source` route, not in other routes.

The reasoning is that when you want to get the `/source`, you are usually a bit less strict about the accuracy of the visibility and can always call isVisible for elements about which you care. Other options exist as well - we could make it a configuration flag, add a toggle to the route or create a newer route.

Here are the response times for the `/source` route before and after, on iOS 10:

| Device         | Before                  | After
|------------|-------------------|-------
| iPhone 5S  | 3770ms                  | 850ms
| iPhone 7     | 1000ms                  | 350ms

In the after time, most time is spend getting the active application, we still may be able to optimize that further.