### PR TITLE
Do not try to calculate hitpoint for elements outside of the screen rect

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -33,18 +33,23 @@
 
 - (BOOL)fb_isVisible
 {
-  if (CGRectIsEmpty(self.frame) || CGRectIsEmpty(self.visibleFrame)) {
+  if (CGRectIsEmpty(self.frame)) {
+    return NO;
+  }
+  CGRect visibleFrame = self.visibleFrame;
+  if (CGRectIsEmpty(visibleFrame)) {
     return NO;
   }
   if ([FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
     return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
   }
-  XCElementSnapshot *app = [self _rootElement];
-  CGSize screenSize = FBAdjustDimensionsForApplication(app.frame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
+  CGRect appFrame = [self _rootElement].frame;
+  CGSize screenSize = FBAdjustDimensionsForApplication(appFrame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
   CGRect screenFrame = CGRectMake(0, 0, screenSize.width, screenSize.height);
-  BOOL rectIntersects = CGRectIntersectsRect(self.visibleFrame, screenFrame);
-  BOOL isActionable = CGRectContainsPoint(app.frame, self.fb_hitPoint);
-  return rectIntersects && isActionable;
+  if (!CGRectIntersectsRect(visibleFrame, screenFrame)) {
+    return NO;
+  }
+  return CGRectContainsPoint(appFrame, self.fb_hitPoint);
 }
 
 @end


### PR DESCRIPTION
This is one of these cases where everything good should be simple. 
**self.fb_hitPoint** call is expensive and there is no point to call it if we already know that rectIntersects verification failed