### PR TITLE
Avoid xpath usage for alert text lookup

### DIFF
--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -102,7 +102,8 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   if (resultText.count) {
     return [resultText componentsJoinedByString:@"\n"];
   }
-  return nil;
+  // return null to reflect the fact there is an alert, but it does not contain any text
+  return (id)[NSNull null];
 }
 
 - (NSArray *)buttonLabels

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -92,9 +92,9 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   if (!alert) {
     return nil;
   }
-  NSArray<XCElementSnapshot *> *staticTextList = [alert.lastSnapshot fb_descendantsMatchingType:XCUIElementTypeStaticText];
+  NSArray<XCUIElement *> *staticTextList = [alert descendantsMatchingType:XCUIElementTypeStaticText].allElementsBoundByIndex;
   NSMutableString *mText = [NSMutableString string];
-  for (XCElementSnapshot *staticText in staticTextList) {
+  for (XCUIElement *staticText in staticTextList) {
     if (staticText.wdLabel && staticText.isWDVisible) {
       [mText appendFormat:@"%@\n", staticText.wdLabel];
     }

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -93,17 +93,16 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
     return nil;
   }
   NSArray<XCUIElement *> *staticTextList = [alert descendantsMatchingType:XCUIElementTypeStaticText].allElementsBoundByIndex;
-  NSMutableString *mText = [NSMutableString string];
+  NSMutableArray<NSString *> *resultText = [NSMutableArray array];
   for (XCUIElement *staticText in staticTextList) {
     if (staticText.wdLabel && staticText.isWDVisible) {
-      [mText appendFormat:@"%@\n", staticText.wdLabel];
+      [resultText addObject:[NSString stringWithFormat:@"%@", staticText.wdLabel]];
     }
   }
-  // Removing last '\n'
-  if (mText.length > 0) {
-    [mText replaceCharactersInRange:NSMakeRange(mText.length - @"\n".length, @"\n".length) withString:@""];
+  if (resultText.count) {
+    return [resultText componentsJoinedByString:@"\n"];
   }
-  return mText.length > 0 ? mText.copy : [NSNull null];
+  return nil;
 }
 
 - (NSArray *)buttonLabels


### PR DESCRIPTION
The implementation of fb_descendantsMatchingType is slow and implicitly uses slower xpath lookup (which sometimes causes unexpected 'Copy attribute error' 15s delays). It would be nice to get rid of _fb_descendantsMatchingType_ and _fb_descendantsMatchingXPathQuery_ extension methods from **XCElementSnapshot+FBHelpers** category and I'd like to take care about it after https://github.com/facebook/WebDriverAgent/pull/569 is merged