### PR TITLE
Add descendants lookup feature for class chain search

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.h
@@ -18,24 +18,35 @@ extern NSString *const FBClassChainQueryParseException;
 
 /**
  Returns an array of descendants matching given class chain query.
- This query is similar to xpath, but can only include indexes, predicates and valid class names. Only search by direct children elements of
-  the current element is supported. Examples of such requests:
- XCUIElementTypeWindow/XCUIElementTypeButton[3] - select the third child button of the first child window element
- XCUIElementTypeWindow - select all the children windows
- XCUIElementTypeWindow[2] - select the second child window in the hierarchy. Indexing starts at 1
- XCUIElementTypeWindow/XCUIElementTypeAny[3] - select the third child (of any type) of the first child window
- XCUIElementTypeWindow[2]/XCUIElementTypeAny - select all the children of the second child window
- XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2] - select the second last child of the second child window
- One may use '*' (star) character to substitute the universal 'XCUIElementTypeAny' class name
- XCUIElementTypeWindow[`name CONTAINS[cd] "blabla"`] - select all windows, where name attribute starts with "blabla" or "BlAbla"
- XCUIElementTypeWindow[`label BEGINSWITH "blabla"`][-1] - select the last window, where label text begins with "blabla"
- XCUIElementTypeWindow/XCUIElementTypeAny[`value == "bla1" OR label == "bla2"`] - select all children of the first window, where value is "bla1" or label is "bla2"
- XCUIElementTypeWindow[`name == "you're the winner"`]/XCUIElementTypeAny[`visible == 1`] - select all visible children of the first window named "you're the winner"
+ This query is similar to xpath, but can only include indexes, predicates and valid class names. Search by direct children and descendant elements is supported. Examples of direct search requests:
+ XCUIElementTypeWindow/XCUIElementTypeButton[3] - select the third child button of the first child window element.
+ XCUIElementTypeWindow - select all the children windows.
+ XCUIElementTypeWindow[2] - select the second child window in the hierarchy. Indexing starts at 1.
+ XCUIElementTypeWindow/XCUIElementTypeAny[3] - select the third child (of any type) of the first child. window
+ XCUIElementTypeWindow[2]/XCUIElementTypeAny - select all the children of the second child window.
+ XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2] - select the second last child of the second child window.
+ One may use '*' (star) character to substitute the universal 'XCUIElementTypeAny' class name.
+ XCUIElementTypeWindow[`name CONTAINS[cd] "blabla"`] - select all windows, where name attribute starts with "blabla" or "BlAbla".
+ XCUIElementTypeWindow[`label BEGINSWITH "blabla"`][-1] - select the last window, where label text begins with "blabla".
+ XCUIElementTypeWindow/XCUIElementTypeAny[`value == "bla1" OR label == "bla2"`] - select all children of the first window, where value is "bla1" or label is "bla2".
+ XCUIElementTypeWindow[`name == "you're the winner"`]/XCUIElementTypeAny[`visible == 1`] - select all visible children of the first window named "you're the winner".
  Predicate string should be always enclosed into ` characters inside square brackets. Use `` to escape a single ` character inside predicate expression.
  Predicate expression should be always put before the index, but never after it.
+ It is not recommended to set explicit indexes for intermediate chain elements, because it slows down the lookup speed.
+ 
+ Indirect descendant search requests are pretty similar to requests above:
+ ** /XCUIElementTypeCell[`name BEGINSWITH "A"`][-1]/XCUIElementTypeButton[10] - select the 10-th child button of the very last cell in the tree, whose name starts with 'A'.
+ ** /XCUIElementTypeCell[`name BEGINSWITH "B"`] - select all cells in the tree, where name starts with 'B'
+ ** /XCUIElementTypeCell[`name BEGINSWITH "C"`]/XCUIElementTypeButton[10] - select the 10-th child button of the first cell in the tree, whose name starts with 'C' and which has at least ten direct children of type XCUIElementTypeButton.
+ ** /XCUIElementTypeCell[`name BEGINSWITH "D"`]/ ** /XCUIElementTypeButton - select the all descendant buttons of the first cell in the tree, whose name starts with 'D'.
 
+ Double star and slash is the marker of the fact, that the next following item is the descendant of the previous chain item, rather than its child.
+ 
+ The matching result is similar to what XCTest's children... and descendants... selector calls of XCUIElement class instances produce when combined into a chain.
+ 
  @param classChainQuery valid class chain query string
- @param shouldReturnAfterFirstMatch set it to YES if you want only the first found element to be resolved and returned. This will speed up the search significantly if given class name matches multiple nodes in the UI tree
+ @param shouldReturnAfterFirstMatch set it to YES if you want only the first found element to be resolved and returned. 
+   This will speed up the search significantly if the given chain matches multiple nodes in the UI tree
  @return an array of descendants matching given class chain
  @throws FBUnknownAttributeException if any of predicates in the chain contains unknown attribute(s)
  */

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -30,7 +30,7 @@ NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseExcept
   [lookupChain removeObjectAtIndex:0];
   while (lookupChain.count > 0) {
     BOOL isRootChanged = NO;
-    if (chainItem.position > 1) {
+    if (chainItem.position < 0 || chainItem.position > 1) {
       // It is necessary to resolve the query if intermediate element index is greater than 1
       // because predicates don't support search by indexes
       NSArray<XCUIElement *> *currentRootMatch = [self.class fb_matchingElementsWithItem:chainItem query:query shouldReturnAfterFirstMatch:NO];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -31,7 +31,7 @@ NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseExcept
   while (lookupChain.count > 0) {
     BOOL isRootChanged = NO;
     if (chainItem.position < 0 || chainItem.position > 1) {
-      // It is necessary to resolve the query if intermediate element index is greater than 1
+      // It is necessary to resolve the query if intermediate element index is not zero or one,
       // because predicates don't support search by indexes
       NSArray<XCUIElement *> *currentRootMatch = [self.class fb_matchingElementsWithItem:chainItem query:query shouldReturnAfterFirstMatch:NO];
       if (0 == currentRootMatch.count) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -10,11 +10,6 @@
 #import "XCUIElement+FBClassChain.h"
 
 #import "FBClassChainQueryParser.h"
-#import "FBElementUtils.h"
-#import "FBMacros.h"
-#import "XCElementSnapshot.h"
-#import "XCUIElement+FBUtilities.h"
-#import "XCUIElement+FBWebDriverAttributes.h"
 
 NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseException";
 
@@ -23,64 +18,76 @@ NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseExcept
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingClassChain:(NSString *)classChainQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   NSError *error;
-  FBClassChain parsedChain = [FBClassChainQueryParser parseQuery:classChainQuery error:&error];
+  FBClassChain *parsedChain = [FBClassChainQueryParser parseQuery:classChainQuery error:&error];
   if (nil == parsedChain) {
     @throw [NSException exceptionWithName:FBClassChainQueryParseException reason:error.localizedDescription userInfo:error.userInfo];
     return nil;
   }
-  NSArray<XCElementSnapshot *> *snapshots = [self.class fb_lookupChain:parsedChain inSnapshot:self.fb_lastSnapshot];
-  if (0 == snapshots.count) {
-    return @[];
+  NSMutableArray<FBClassChainItem *> *lookupChain = parsedChain.elements.mutableCopy;
+  FBClassChainItem *chainItem = lookupChain.firstObject;
+  XCUIElement *currentRoot = self;
+  XCUIElementQuery *query = [currentRoot fb_queryWithChainItem:chainItem query:nil];
+  [lookupChain removeObjectAtIndex:0];
+  while (lookupChain.count > 0) {
+    BOOL isRootChanged = NO;
+    if (chainItem.position > 1) {
+      // It is necessary to resolve the query if intermediate element index is greater than 1
+      // because predicates don't support search by indexes
+      NSArray<XCUIElement *> *currentRootMatch = [self.class fb_matchingElementsWithItem:chainItem query:query shouldReturnAfterFirstMatch:NO];
+      if (0 == currentRootMatch.count) {
+        return @[];
+      }
+      currentRoot = currentRootMatch.firstObject;
+      isRootChanged = YES;
+    }
+    chainItem = [lookupChain firstObject];
+    query = [currentRoot fb_queryWithChainItem:chainItem query:isRootChanged ? nil : query];
+    [lookupChain removeObjectAtIndex:0];
   }
-  if (shouldReturnAfterFirstMatch) {
-    XCElementSnapshot *snapshot = snapshots.firstObject;
-    snapshots = @[snapshot];
-  }
-  return [self fb_filterDescendantsWithSnapshots:snapshots];
+  return [self.class fb_matchingElementsWithItem:chainItem query:query shouldReturnAfterFirstMatch:shouldReturnAfterFirstMatch];
 }
 
-+ (NSArray<XCElementSnapshot *> *)fb_matchingChildrenWithSnapshot:(XCElementSnapshot *)root forChainElement:(FBClassChainElement *)chainElement
+- (XCUIElementQuery *)fb_queryWithChainItem:(FBClassChainItem *)item query:(nullable XCUIElementQuery *)query
 {
-  NSArray *childrenMatches = root.children;
-  if (0 == childrenMatches.count) {
-    return @[];
-  }
-  if (XCUIElementTypeAny != chainElement.type) {
-    childrenMatches = [childrenMatches filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"%K == %@", FBStringify(XCUIElement, elementType), @(chainElement.type)]];
-  }
-  if (nil != chainElement.predicate) {
-    childrenMatches = [childrenMatches filteredArrayUsingPredicate:(NSPredicate  * _Nonnull)chainElement.predicate];
-  }
-  NSMutableArray *result = [NSMutableArray array];
-  if (0 == chainElement.position) {
-    [result addObjectsFromArray:childrenMatches];
-  } else if (chainElement.position > 0) {
-    if ((NSUInteger)chainElement.position <= childrenMatches.count) {
-      [result addObject:[childrenMatches objectAtIndex:chainElement.position - 1]];
+  if (item.isDescendant) {
+    if (query) {
+      query = [query descendantsMatchingType:item.type];
+    } else {
+      query = [self descendantsMatchingType:item.type];
     }
   } else {
-    if ((NSUInteger)labs(chainElement.position) <= childrenMatches.count) {
-      [result addObject:[childrenMatches objectAtIndex:childrenMatches.count + chainElement.position]];
+    if (query) {
+      query = [query childrenMatchingType:item.type];
+    } else {
+      query = [self childrenMatchingType:item.type];
     }
   }
-  return result.copy;
+  if (item.predicate) {
+    query = [query matchingPredicate:(id)item.predicate];
+  }
+  return query;
 }
 
-+ (NSArray<XCElementSnapshot *> *)fb_lookupChain:(FBClassChain)query inSnapshot:(XCElementSnapshot *)root
++ (NSArray<XCUIElement *> *)fb_matchingElementsWithItem:(FBClassChainItem *)item query:(XCUIElementQuery *)query shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSArray *matchingChildren = [self.class fb_matchingChildrenWithSnapshot:root forChainElement:[query firstObject]];
-  if (0 == matchingChildren.count) {
-    return @[];
-  }
-  NSMutableArray *result = [NSMutableArray array];
-  if (query.count > 1) {
-    for (XCElementSnapshot *matchedChild in matchingChildren) {
-      [result addObjectsFromArray:[self.class fb_lookupChain:[query subarrayWithRange:NSMakeRange(1, query.count - 1)] inSnapshot:matchedChild]];
+  if (shouldReturnAfterFirstMatch && (item.position == 0 || item.position == 1)) {
+    // TODO: Add support for the iOS 11+ short-circuit first match
+    if (!query.element.exists) {
+      return @[];
     }
-  } else {
-    [result addObjectsFromArray:matchingChildren];
+    return @[[query elementBoundByIndex:0]];
   }
-  return result.copy;
+  NSArray<XCUIElement *> *allMatches = query.allElementsBoundByIndex;
+  if (0 == item.position) {
+    return allMatches;
+  }
+  if (item.position > 0 && allMatches.count >= (NSUInteger)ABS(item.position)) {
+    return @[[allMatches objectAtIndex:item.position - 1]];
+  }
+  if (item.position < 0 && allMatches.count >= (NSUInteger)ABS(item.position)) {
+    return @[[allMatches objectAtIndex:allMatches.count + item.position]];
+  }
+  return @[];
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.h
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FBClassChainElement : NSObject
+@interface FBClassChainItem : NSObject
 
 /*! Element's position */
 @property (readonly, nonatomic) NSInteger position;
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) XCUIElementType type;
 /*! Element's predicate */
 @property (nullable, readonly, nonatomic) NSPredicate *predicate;
+/*! Whether an element is a descendant of the previos element */
+@property (readonly, nonatomic) BOOL isDescendant;
 
 /**
  Instance constructor, which allows to set element type and position
@@ -30,14 +32,29 @@ NS_ASSUME_NONNULL_BEGIN
    Negative value means that numeration starts from the last element, for example
    -1 is the last child element and -2 is the second last element
  @param predicate valid predicate expession for element search. Can be nil
+ @param isDescendant equals to YES if the element is a descendantt element of
+   the previous element in the chain. NO value maens the element is the direct
+   child of the previous element
  @return FBClassChainElement instance
  */
-- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicate:(NSPredicate *)predicate;
+- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicate:(NSPredicate *)predicate isDescendant:(BOOL)isDescendant;
 
 @end
 
-/*! Type alias for the product of class chain query parsing */
-typedef NSArray<FBClassChainElement *> * FBClassChain;
+@interface FBClassChain : NSObject
+
+/*! Array of parsed chain items */
+@property (readonly, nonatomic, copy) NSArray<FBClassChainItem *> *elements;
+
+/**
+ Instance constructor for parsed class chain instance
+ 
+ @param elements an array of parsed chains elements
+ @return FBClassChain instance
+ */
+- (instancetype)initWithElements:(NSArray<FBClassChainItem *> *)elements;
+
+@end
 
 @interface FBClassChainQueryParser : NSObject
 
@@ -52,7 +69,7 @@ typedef NSArray<FBClassChainElement *> * FBClassChain;
    there was parsing error (the parameter will be initialized with detailed error description in such case)
  @throws FBUnknownAttributeException if any of predicates in the chain contains unknown attribute 
  */
-+ (nullable FBClassChain)parseQuery:(NSString*)classChainQuery error:(NSError **)error;
++ (nullable FBClassChain*)parseQuery:(NSString*)classChainQuery error:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBBaseClassChainToken : NSObject
 
 @property (nonatomic) NSString *asString;
+@property (nonatomic) NSUInteger previousItemsCountToOverride;
 
 @end
 
@@ -30,6 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface FBDescendantMarkerToken : FBBaseClassChainToken
+
+@end
 
 @interface FBSplitterToken : FBBaseClassChainToken
 
@@ -44,7 +48,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBClosingBracketToken : FBBaseClassChainToken
 
 @end
-
 
 @interface FBNumberToken : FBBaseClassChainToken
 
@@ -67,6 +70,7 @@ NS_ASSUME_NONNULL_END
   self = [super init];
   if (self) {
     _asString = @"";
+    _previousItemsCountToOverride = 0;
   }
   return self;
 }
@@ -110,7 +114,7 @@ NS_ASSUME_NONNULL_END
   self.asString = value.copy;;
 }
 
-- (nullable instancetype)followingTokenBasedOn:(unichar)character
+- (nullable FBBaseClassChainToken*)followingTokenBasedOn:(unichar)character
 {
   for (Class matchingTokenClass in self.followingTokens) {
     if ([matchingTokenClass canConsumeCharacter:character]) {
@@ -120,7 +124,7 @@ NS_ASSUME_NONNULL_END
   return nil;
 }
 
-- (nullable instancetype)nextTokenWithCharacter:(unichar)character
+- (nullable FBBaseClassChainToken*)nextTokenWithCharacter:(unichar)character
 {
   if ([self.class canConsumeCharacter:character] && self.asString.length < [self.class maxLength]) {
     [self appendChar:character];
@@ -146,12 +150,12 @@ NS_ASSUME_NONNULL_END
 
 @end
 
-
+static NSString *const STAR_TOKEN = @"*";
 @implementation FBStarToken
 
 + (NSCharacterSet *)allowedCharacters
 {
-  return [NSCharacterSet characterSetWithCharactersInString:@"*"];
+  return [NSCharacterSet characterSetWithCharactersInString:STAR_TOKEN];
 }
 
 - (NSArray<Class> *)followingTokens
@@ -159,9 +163,53 @@ NS_ASSUME_NONNULL_END
   return @[FBSplitterToken.class, FBOpeningBracketToken.class];
 }
 
+- (nullable FBBaseClassChainToken*)nextTokenWithCharacter:(unichar)character
+{
+  if ([self.class.allowedCharacters characterIsMember:character]) {
+    if (self.asString.length >= 1) {
+      FBDescendantMarkerToken *nextToken = [[FBDescendantMarkerToken alloc] initWithStringValue:STAR_TOKEN];
+      nextToken.previousItemsCountToOverride = 1;
+      return nextToken;
+    }
+    [self appendChar:character];
+    return self;
+  }
+  return [self followingTokenBasedOn:character];
+}
+
+@end
+
+
+static NSString *const DESCENDANT_MARKER = @"**/";
+@implementation FBDescendantMarkerToken
+
++ (NSCharacterSet *)allowedCharacters
+{
+  return [NSCharacterSet characterSetWithCharactersInString:@"*/"];
+}
+
+- (NSArray<Class> *)followingTokens
+{
+  return @[FBClassNameToken.class, FBStarToken.class];
+}
+
 + (NSUInteger)maxLength
 {
-  return 1;
+  return 3;
+}
+
+- (nullable FBBaseClassChainToken*)nextTokenWithCharacter:(unichar)character
+{
+  if ([self.class.allowedCharacters characterIsMember:character] && self.asString.length <= self.class.maxLength) {
+    if (self.asString.length > 0 && ![DESCENDANT_MARKER hasPrefix:self.asString]) {
+      return nil;
+    }
+    if (self.asString.length < self.class.maxLength) {
+      [self appendChar:character];
+      return self;
+    }
+  }
+  return [self followingTokenBasedOn:character];
 }
 
 @end
@@ -280,7 +328,7 @@ static NSString* const ENCLOSING_MARKER = @"`";
   }
 }
 
-- (nullable instancetype)nextTokenWithCharacter:(unichar)character
+- (nullable FBBaseClassChainToken*)nextTokenWithCharacter:(unichar)character
 {
   NSString *currentChar = [NSString stringWithFormat:@"%C", character];
   if (!self.isParsingCompleted && [self.class.allowedCharacters characterIsMember:character]) {
@@ -313,15 +361,30 @@ static NSString* const ENCLOSING_MARKER = @"`";
 @end
 
 
-@implementation FBClassChainElement
+@implementation FBClassChainItem
 
-- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicate:(NSPredicate *)predicate
+- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicate:(NSPredicate *)predicate isDescendant:(BOOL)isDescendant
 {
   self = [super init];
   if (self) {
     _type = type;
     _position = position;
     _predicate = predicate;
+    _isDescendant = isDescendant;
+  }
+  return self;
+}
+
+@end
+
+
+@implementation FBClassChain
+
+- (instancetype)initWithElements:(NSArray<FBClassChainItem *> *)elements
+{
+  self = [super init];
+  if (self) {
+    _elements = elements;
   }
   return self;
 }
@@ -351,7 +414,9 @@ static NSNumberFormatter *numberFormatter = nil;
   NSUInteger queryStringLength = classChainQuery.length;
   FBBaseClassChainToken *token;
   unichar firstCharacter = [classChainQuery characterAtIndex:0];
-  if ([FBClassNameToken canConsumeCharacter:firstCharacter]) {
+  if ([classChainQuery hasPrefix:DESCENDANT_MARKER]) {
+    token = [[FBDescendantMarkerToken alloc] initWithStringValue:DESCENDANT_MARKER];
+  } else if ([FBClassNameToken canConsumeCharacter:firstCharacter]) {
     token = [[FBClassNameToken alloc] initWithStringValue:[NSString stringWithFormat:@"%C", firstCharacter]];
   } else if ([FBStarToken canConsumeCharacter:firstCharacter]) {
     token = [[FBStarToken alloc] initWithStringValue:[NSString stringWithFormat:@"%C", firstCharacter]];
@@ -363,7 +428,7 @@ static NSNumberFormatter *numberFormatter = nil;
   }
   NSMutableArray *result = [NSMutableArray array];
   FBBaseClassChainToken *nextToken = token;
-  for (NSUInteger charIdx = 1; charIdx < queryStringLength; ++charIdx) {
+  for (NSUInteger charIdx = token.asString.length; charIdx < queryStringLength; ++charIdx) {
     nextToken = [token nextTokenWithCharacter:[classChainQuery characterAtIndex:charIdx]];
     if (nil == nextToken) {
       if (error) {
@@ -373,21 +438,25 @@ static NSNumberFormatter *numberFormatter = nil;
     }
     if (nextToken != token) {
       [result addObject:token];
+      if (nextToken.previousItemsCountToOverride > 0 && result.count > 0) {
+        NSUInteger itemsCountToOverride = nextToken.previousItemsCountToOverride <= result.count ? nextToken.previousItemsCountToOverride : result.count;
+        [result removeObjectsInRange:NSMakeRange(result.count - itemsCountToOverride, itemsCountToOverride)];
+      }
       token = nextToken;
     }
   }
-  if (nil != nextToken) {
+  if (nextToken) {
+    if (nextToken.previousItemsCountToOverride > 0 && result.count > 0) {
+      NSUInteger itemsCountToOverride = nextToken.previousItemsCountToOverride <= result.count ? nextToken.previousItemsCountToOverride : result.count;
+      [result removeObjectsInRange:NSMakeRange(result.count - itemsCountToOverride, itemsCountToOverride)];
+    }
     [result addObject:nextToken];
   }
   
-  for (NSUInteger tokenIdx = 0; tokenIdx < result.count; ++tokenIdx) {
-    if ([[result objectAtIndex:tokenIdx] isKindOfClass:FBStarToken.class]) {
-      [result replaceObjectAtIndex:tokenIdx withObject:[[FBClassNameToken alloc] initWithStringValue:[FBElementTypeTransformer stringWithElementType:XCUIElementTypeAny]]];
-    }
-  }
-  
   FBBaseClassChainToken *lastToken = [result lastObject];
-  if (!([lastToken isKindOfClass:FBClosingBracketToken.class] || [lastToken isKindOfClass:FBClassNameToken.class])) {
+  if (!([lastToken isKindOfClass:FBClosingBracketToken.class] ||
+        [lastToken isKindOfClass:FBClassNameToken.class] ||
+        [lastToken isKindOfClass:FBStarToken.class])) {
     if (error) {
       *error = [self.class tokenizationErrorWithIndex:queryStringLength - 1 originalQuery:classChainQuery];
     }
@@ -403,18 +472,26 @@ static NSNumberFormatter *numberFormatter = nil;
   return [[FBErrorBuilder.builder withDescription:fullDescription] build];
 }
 
-+ (nullable FBClassChain)compiledQueryWithTokenizedQuery:(NSArray<FBBaseClassChainToken *> *)tokenizedQuery originalQuery:(NSString *)originalQuery error:(NSError **)error
++ (nullable FBClassChain*)compiledQueryWithTokenizedQuery:(NSArray<FBBaseClassChainToken *> *)tokenizedQuery originalQuery:(NSString *)originalQuery error:(NSError **)error
 {
   NSMutableArray *result = [NSMutableArray array];
-  XCUIElementType chainElementType;
+  XCUIElementType chainElementType = XCUIElementTypeAny;
   int chainElementPosition = 1;
+  BOOL isTypeSet = NO;
   BOOL isPositionSet = NO;
+  BOOL isDescendantSet = NO;
   BOOL isPredicateSet = NO;
   NSPredicate *predicate = nil;
   for (FBBaseClassChainToken *token in tokenizedQuery) {
     if ([token isKindOfClass:FBClassNameToken.class]) {
+      if (isTypeSet) {
+        NSString *description = [NSString stringWithFormat:@"Unexpected token '%@'. The type name can be set only once.", token.asString];
+        *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+        return nil;
+      }
       @try {
         chainElementType = [FBElementTypeTransformer elementTypeWithTypeName:token.asString];
+        isTypeSet = YES;
       } @catch (NSException *e) {
         if ([e.name isEqualToString:FBInvalidArgumentException]) {
           NSString *description = [NSString stringWithFormat:@"'%@' class name is unknown to WDA", token.asString];
@@ -423,6 +500,25 @@ static NSNumberFormatter *numberFormatter = nil;
         }
         @throw e;
       }
+    } else if ([token isKindOfClass:FBStarToken.class]) {
+      if (isTypeSet) {
+        NSString *description = [NSString stringWithFormat:@"Unexpected token '%@'. The type name can be set only once.", token.asString];
+        *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+        return nil;
+      }
+      chainElementType = XCUIElementTypeAny;
+      isTypeSet = YES;
+    } else if ([token isKindOfClass:FBDescendantMarkerToken.class]) {
+      if (isDescendantSet) {
+        NSString *description = [NSString stringWithFormat:@"Unexpected token '%@'. Descendant markers cannot be duplicated.", token.asString];
+        *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+        return nil;
+      }
+      isTypeSet = NO;
+      isPositionSet = NO;
+      isPredicateSet = NO;
+      predicate = nil;
+      isDescendantSet = YES;
     } else if ([token isKindOfClass:FBPredicateToken.class]) {
       if (isPredicateSet) {
         NSString *description = [NSString stringWithFormat:@"Predicate value '%@' is expected to be set only once.", token.asString];
@@ -459,7 +555,15 @@ static NSNumberFormatter *numberFormatter = nil;
       if (!isPositionSet) {
         chainElementPosition = 1;
       }
-      [result addObject:[[FBClassChainElement alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate]];
+      if (isDescendantSet) {
+        if (isTypeSet) {
+          [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:YES]];
+          isDescendantSet = NO;
+        }
+      } else {
+        [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:NO]];
+      }
+      isTypeSet = NO;
       isPositionSet = NO;
       isPredicateSet = NO;
       predicate = nil;
@@ -469,22 +573,28 @@ static NSNumberFormatter *numberFormatter = nil;
     // pick all siblings by default for the last item in the chain
     chainElementPosition = 0;
   }
-  [result addObject:[[FBClassChainElement alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate]];
-  return result.copy;
+  if (isDescendantSet) {
+    if (isTypeSet) {
+      [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:YES]];
+    } else {
+      NSString *description = @"Descendants lookup modifier '**/' should be followed with the actual element type";
+      *error = [self.class compilationErrorWithQuery:originalQuery description:description];
+      return nil;
+    }
+  } else {
+    [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:NO]];
+  }
+  return [[FBClassChain alloc] initWithElements:result.copy];
 }
 
-+ (FBClassChain)parseQuery:(NSString*)classChainQuery error:(NSError **)error
++ (FBClassChain *)parseQuery:(NSString*)classChainQuery error:(NSError **)error
 {
   NSAssert(classChainQuery.length > 0, @"Query length should be greater than zero", nil);
   NSArray *tokenizedQuery = [self.class tokenizedQueryWithQuery:classChainQuery error:error];
   if (nil == tokenizedQuery) {
     return nil;
   }
-  NSArray *compiledQuery = [self.class compiledQueryWithTokenizedQuery:tokenizedQuery originalQuery:classChainQuery error:error];
-  if (nil == compiledQuery) {
-    return nil;
-  }
-  return compiledQuery.copy;
+  return [self.class compiledQueryWithTokenizedQuery:tokenizedQuery originalQuery:classChainQuery error:error];
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -11,6 +11,7 @@
 
 #import "FBIntegrationTestCase.h"
 #import "FBElementUtils.h"
+#import "FBTestMacros.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBFind.h"
 #import "XCElementSnapshot+FBHelpers.h"
@@ -198,6 +199,16 @@
   }
 }
 
+- (void)testNestedQueryWithClassChain
+{
+  [self.testedApplication.buttons[@"Attributes"] tap];
+  FBAssertWaitTillBecomesTrue(self.testedApplication.buttons[@"Button"].fb_isVisible);
+  XCUIElement *datePicker = [[self.testedApplication descendantsMatchingType:XCUIElementTypeDatePicker].allElementsBoundByIndex firstObject];
+  NSArray<XCUIElement *> *matches = [datePicker fb_descendantsMatchingClassChain:@"XCUIElementTypeOther" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(matches.count, 1);
+  XCTAssertEqual([matches firstObject].elementType, XCUIElementTypeOther);
+}
+
 - (void)testDescendantsWithClassChainAndPredicates
 {
   NSArray<XCUIElement *> *matchingSnapshots;
@@ -205,6 +216,29 @@
   XCTAssertEqual(matchingSnapshots.count, 2);
   XCTAssertEqualObjects([matchingSnapshots firstObject].label, @"Alerts");
   XCTAssertEqualObjects([matchingSnapshots lastObject].label, @"Attributes");
+}
+
+- (void)testDescendantsWithIndirectClassChainAndPredicates
+{
+  NSArray<XCUIElement *> *simpleQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[2]/*/*/XCUIElementTypeButton[`label BEGINSWITH 'A'`]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *deepQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/**/XCUIElementTypeButton[`label BEGINSWITH 'A'`]" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(simpleQueryMatches.count, deepQueryMatches.count);
+  XCTAssertEqualObjects([simpleQueryMatches firstObject].label, [deepQueryMatches firstObject].label);
+  XCTAssertEqualObjects([simpleQueryMatches lastObject].label, [deepQueryMatches lastObject].label);
+}
+
+- (void)testSingleDescendantWithComplexIndirectClassChain
+{
+  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeButton[2]" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(queryMatches.count, 1);
+  XCTAssertEqual(queryMatches.lastObject.elementType, XCUIElementTypeButton);
+  XCTAssertEqualObjects(queryMatches.lastObject.label, @"Deadlock app");
+}
+
+- (void)testSingleDescendantWithComplexIndirectClassChainAndZeroMatches
+{
+  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeWindow" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(queryMatches.count, 0);
 }
 
 - (void)testDescendantsWithClassChainAndPredicatesAndIndexes

--- a/WebDriverAgentTests/UnitTests/FBClassChainTests.m
+++ b/WebDriverAgentTests/UnitTests/FBClassChainTests.m
@@ -20,127 +20,188 @@
 - (void)testValidChain
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 2);
+  XCTAssertEqual(result.elements.count, 2);
   
-  FBClassChainElement *firstElement = [result firstObject];
+  FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
   XCTAssertEqual(firstElement.position, 1);
+  XCTAssertFalse(firstElement.isDescendant);
 
-  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
   XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
   XCTAssertEqual(secondElement.position, 0);
+  XCTAssertFalse(secondElement.isDescendant);
 }
 
 - (void)testValidChainWithStar
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton[3]/*[4]/*[5]/XCUIElementTypeAlert" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton[3]/*[4]/*[5]/XCUIElementTypeAlert" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 5);
+  XCTAssertEqual(result.elements.count, 5);
   
-  FBClassChainElement *firstElement = [result firstObject];
+    FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
   XCTAssertEqual(firstElement.position, 1);
+  XCTAssertFalse(firstElement.isDescendant);
   
-  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
   XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
   XCTAssertEqual(secondElement.position, 3);
+  XCTAssertFalse(secondElement.isDescendant);
   
-  FBClassChainElement *thirdElement = [result objectAtIndex:2];
+  FBClassChainItem *thirdElement = [result.elements objectAtIndex:2];
   XCTAssertEqual(thirdElement.type, XCUIElementTypeAny);
   XCTAssertEqual(thirdElement.position, 4);
+  XCTAssertFalse(thirdElement.isDescendant);
   
-  FBClassChainElement *fourthElement = [result objectAtIndex:3];
+  FBClassChainItem *fourthElement = [result.elements objectAtIndex:3];
   XCTAssertEqual(fourthElement.type, XCUIElementTypeAny);
   XCTAssertEqual(fourthElement.position, 5);
+  XCTAssertFalse(fourthElement.isDescendant);
   
-  FBClassChainElement *fifthsElement = [result objectAtIndex:4];
+  FBClassChainItem *fifthsElement = [result.elements objectAtIndex:4];
   XCTAssertEqual(fifthsElement.type, XCUIElementTypeAlert);
   XCTAssertEqual(fifthsElement.position, 0);
+  XCTAssertFalse(fifthsElement.isDescendant);
 }
 
 - (void)testValidSingleStarChain
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"*" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"*" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 1);
+  XCTAssertEqual(result.elements.count, 1);
   
-  FBClassChainElement *firstElement = [result firstObject];
+  FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeAny);
   XCTAssertEqual(firstElement.position, 0);
+  XCTAssertFalse(firstElement.isDescendant);
+}
+
+- (void)testValidSingleStarIndirectChain
+{
+  NSError *error;
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"**/*/*/XCUIElementTypeButton" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.elements.count, 3);
+  
+  FBClassChainItem *firstElement = [result.elements firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeAny);
+  XCTAssertEqual(firstElement.position, 1);
+  XCTAssertTrue(firstElement.isDescendant);
+  
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeAny);
+  XCTAssertEqual(secondElement.position, 1);
+  XCTAssertFalse(secondElement.isDescendant);
+  
+  FBClassChainItem *thirdElement = [result.elements objectAtIndex:2];
+  XCTAssertEqual(thirdElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(thirdElement.position, 0);
+  XCTAssertFalse(thirdElement.isDescendant);
 }
 
 - (void)testValidChainWithNegativeIndex
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton[-1]" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow/XCUIElementTypeButton[-1]" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 2);
+  XCTAssertEqual(result.elements.count, 2);
   
-  FBClassChainElement *firstElement = [result firstObject];
+  FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
   XCTAssertEqual(firstElement.position, 1);
+  XCTAssertNil(firstElement.predicate);
+  XCTAssertFalse(firstElement.isDescendant);
   
-  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
   XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
   XCTAssertEqual(secondElement.position, -1);
+  XCTAssertNil(secondElement.predicate);
+  XCTAssertFalse(secondElement.isDescendant);
 }
 
 - (void)testValidChainWithSinglePredicate
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow[`name == 'blabla'`]/XCUIElementTypeButton" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow[`name == 'blabla'`]/XCUIElementTypeButton" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 2);
+  XCTAssertEqual(result.elements.count, 2);
   
-  FBClassChainElement *firstElement = [result firstObject];
+  FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
   XCTAssertEqual(firstElement.position, 1);
   XCTAssertNotNil(firstElement.predicate);
+  XCTAssertFalse(firstElement.isDescendant);
   
-  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
   XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
   XCTAssertEqual(secondElement.position, 0);
   XCTAssertNil(secondElement.predicate);
+  XCTAssertFalse(secondElement.isDescendant);
 }
 
 - (void)testValidChainWithMultiplePredicates
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow[`name == 'blabla'`]/XCUIElementTypeButton[`value == 'blabla'`]" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"XCUIElementTypeWindow[`name == 'blabla'`]/XCUIElementTypeButton[`value == 'blabla'`]" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 2);
+  XCTAssertEqual(result.elements.count, 2);
   
-  FBClassChainElement *firstElement = [result firstObject];
+  FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeWindow);
   XCTAssertEqual(firstElement.position, 1);
   XCTAssertNotNil(firstElement.predicate);
+  XCTAssertFalse(firstElement.isDescendant);
   
-  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
   XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
   XCTAssertEqual(secondElement.position, 0);
   XCTAssertNotNil(secondElement.predicate);
+  XCTAssertFalse(secondElement.isDescendant);
+}
+
+- (void)testValidChainWithIndirectSearchAndPredicates
+{
+  NSError *error;
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"**/XCUIElementTypeTable[`name == 'blabla'`][10]/**/XCUIElementTypeButton[`value == 'blabla'`]" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.elements.count, 2);
+  
+  FBClassChainItem *firstElement = [result.elements firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeTable);
+  XCTAssertEqual(firstElement.position, 10);
+  XCTAssertNotNil(firstElement.predicate);
+  XCTAssertTrue(firstElement.isDescendant);
+  
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(secondElement.position, 0);
+  XCTAssertNotNil(secondElement.predicate);
+  XCTAssertTrue(secondElement.isDescendant);
 }
 
 - (void)testValidChainWithMultiplePredicatesAndPositions
 {
   NSError *error;
-  FBClassChain result = [FBClassChainQueryParser parseQuery:@"*[`name == \"к``ири````'лиця\"`][3]/XCUIElementTypeButton[`value == \"blabla\"`][-1]" error:&error];
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"*[`name == \"к``ири````'лиця\"`][3]/XCUIElementTypeButton[`value == \"blabla\"`][-1]" error:&error];
   XCTAssertNotNil(result);
-  XCTAssertEqual(result.count, 2);
+  XCTAssertEqual(result.elements.count, 2);
   
-  FBClassChainElement *firstElement = [result firstObject];
+  FBClassChainItem *firstElement = [result.elements firstObject];
   XCTAssertEqual(firstElement.type, XCUIElementTypeAny);
   XCTAssertEqual(firstElement.position, 3);
   XCTAssertNotNil(firstElement.predicate);
+  XCTAssertFalse(firstElement.isDescendant);
   
-  FBClassChainElement *secondElement = [result objectAtIndex:1];
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
   XCTAssertEqual(secondElement.type, XCUIElementTypeButton);
   XCTAssertEqual(secondElement.position, -1);
   XCTAssertNotNil(secondElement.predicate);
+  XCTAssertFalse(secondElement.isDescendant);
 }
 
 - (void)testInvalidChains
@@ -151,6 +212,12 @@
     ,@"XCUIElementTypeWindow//*"
     ,@"XCUIElementTypeWindow*/*"
     ,@"**"
+    ,@"***"
+    ,@"**/*/**"
+    ,@"/**"
+    ,@"XCUIElementTypeWindow/**"
+    ,@"**[1]/XCUIElementTypeWindow"
+    ,@"**[`name == '1'`]/XCUIElementTypeWindow"
     ,@"XCUIElementTypeWindow[0]"
     ,@"XCUIElementTypeWindow[1][1]"
     ,@"blabla"
@@ -172,7 +239,7 @@
   ];
   for (NSString *invalidQuery in invalidQueries) {
     NSError *error;
-    FBClassChain result = [FBClassChainQueryParser parseQuery:invalidQuery error:&error];
+    FBClassChain *result = [FBClassChainQueryParser parseQuery:invalidQuery error:&error];
     XCTAssertNil(result);
     XCTAssertNotNil(error);
   }


### PR DESCRIPTION
This query is similar to xpath, but can only include indexes, predicates and valid class names. Search by direct children and descendant elements is supported. Examples of direct search requests:
 ```XCUIElementTypeWindow/XCUIElementTypeButton[3]``` - select the third child button of the first child window element
 ```XCUIElementTypeWindow``` - select all the children windows
 ```XCUIElementTypeWindow[2]``` - select the second child window in the hierarchy. Indexing starts at 1
 ```XCUIElementTypeWindow/XCUIElementTypeAny[3]``` - select the third child (of any type) of the first child window
 ```XCUIElementTypeWindow[2]/XCUIElementTypeAny``` - select all the children of the second child window
 ```XCUIElementTypeWindow[2]/XCUIElementTypeAny[-2]``` - select the second last child of the second child window
 One may use '*' (star) character to substitute the universal 'XCUIElementTypeAny' class name
 ```XCUIElementTypeWindow[`name CONTAINS[cd] "blabla"`]``` - select all windows, where name attribute starts with "blabla" or "BlAbla"
 ```XCUIElementTypeWindow[`label BEGINSWITH "blabla"`][-1]``` - select the last window, where label text begins with "blabla"
 ```XCUIElementTypeWindow/XCUIElementTypeAny[`value == "bla1" OR label == "bla2"`]``` - select all children of the first window, where value is "bla1" or label is "bla2"
 ```XCUIElementTypeWindow[`name == "you're the winner"`]/XCUIElementTypeAny[`visible == 1`]``` - select all visible children of the first window named "you're the winner"

 Predicate string should be always enclosed into \` characters inside square brackets. Use \`\` to escape a single \` character inside predicate expression. Predicate expression should be always put before the index, but never after it.

 It is not recommended to set explicit indexes for intermediate chain elements, because it slows down the lookup speed
 
 Indirect descendant search requests are pretty similar to requests above:
 ```**/XCUIElementTypeCell[`name BEGINSWITH "A"`][-1]/XCUIElementTypeButton[10]``` - select the 10-th child button of the very last cell in the tree, whose name starts with 'A'.
 ```**/XCUIElementTypeCell[`name BEGINSWITH "B"`]``` - select all cells in the tree, where name starts with 'B'
 ```**/XCUIElementTypeCell[`name BEGINSWITH "C"`]/XCUIElementTypeButton[10]``` - select the 10-th child button of the first cell in the tree, whose name starts with 'C' and which has at least ten direct children of type XCUIElementTypeButton.
 ```**/XCUIElementTypeCell[`name BEGINSWITH "D"`]/**/XCUIElementTypeButton``` - select the all descendant buttons of the first cell in the tree, whose name starts with 'D'

Double star and slash is the marker of the fact, that the next following item is the descendant of the previous chain item, rather than its child.
 
The matching result is similar to what XCTest's _children..._ and _descendants..._ selector calls of XCUIElement class instances produce when combined into a chain.