### PR TITLE
Add a workaround for XCTest bug with landscape tap for application restore

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIApplicationHelperTests.m
@@ -15,6 +15,7 @@
 #import "FBSpringboardApplication.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIElement+FBIsVisible.h"
+#import "XCUIDevice+FBRotation.h"
 
 @interface XCUIApplicationHelperTests : FBIntegrationTestCase
 @end
@@ -37,6 +38,19 @@
 - (void)testTappingAppOnSpringboard
 {
   [self goToSpringBoardFirstPage];
+  NSError *error;
+  XCTAssertTrue([[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:@"Safari" error:&error]);
+  XCTAssertNil(error);
+  XCTAssertTrue([FBApplication fb_activeApplication].buttons[@"URL"].exists);
+}
+
+- (void)testTappingAppOnSpringboardInLandscape
+{
+  if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPad) {
+    return;
+  }
+  [self goToSpringBoardFirstPage];
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationLandscapeRight];
   NSError *error;
   XCTAssertTrue([[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:@"Safari" error:&error]);
   XCTAssertNil(error);


### PR DESCRIPTION
We got several complains in Appium about application restore does not work properly for landscape mode. I investigated the issue and it looks like landscape tap works as expected starting from iOS 10.0, but only for system apps (and springboard is one of these). 
Also added a separate integration test for iPad only to confirm that.

This PR should also add a workaround for clicking alert buttons described in the issue https://github.com/facebook/WebDriverAgent/issues/615