### PR TITLE
Implement firstMatch call support for iOS 11+

### DIFF
--- a/PrivateHeaders/XCTest/XCUIElementQuery.h
+++ b/PrivateHeaders/XCTest/XCUIElementQuery.h
@@ -48,4 +48,7 @@
 - (unsigned long long)_derivedExpressedType;
 - (id)initWithInputQuery:(id)arg1 queryDescription:(id)arg2 filter:(CDUnknownBlockType)arg3;
 
+/*! DO NOT USE DIRECTLY! Please use fb_firstMatch instead */
+- (XCUIElement *)firstMatch;
+
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -10,6 +10,7 @@
 #import "XCUIElement+FBClassChain.h"
 
 #import "FBClassChainQueryParser.h"
+#import "FBXCodeCompatibility.h"
 
 NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseException";
 
@@ -71,11 +72,8 @@ NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseExcept
 + (NSArray<XCUIElement *> *)fb_matchingElementsWithItem:(FBClassChainItem *)item query:(XCUIElementQuery *)query shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   if (shouldReturnAfterFirstMatch && (item.position == 0 || item.position == 1)) {
-    // TODO: Add support for the iOS 11+ short-circuit first match
-    if (!query.element.exists) {
-      return @[];
-    }
-    return @[[query elementBoundByIndex:0]];
+    XCUIElement *result = query.fb_firstMatch;
+    return result ? @[result] : @[];
   }
   NSArray<XCUIElement *> *allMatches = query.allElementsBoundByIndex;
   if (0 == item.position) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -19,6 +19,7 @@
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "FBElementUtils.h"
+#import "FBXCodeCompatibility.h"
 
 @implementation XCUIElement (FBFind)
 
@@ -27,11 +28,8 @@
   if (!shouldReturnAfterFirstMatch) {
     return query.allElementsBoundByIndex;
   }
-  XCUIElement *matchedElement = [query elementBoundByIndex:0];
-  if (matchedElement && matchedElement.exists) {
-    return @[matchedElement];
-  }
-  return @[];
+  XCUIElement *matchedElement = query.fb_firstMatch;
+  return matchedElement ? @[matchedElement] : @[];
 }
 
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -15,6 +15,7 @@
 #import "FBMathUtils.h"
 #import "FBPredicate.h"
 #import "FBRunLoopSpinner.h"
+#import "FBXCodeCompatibility.h"
 #import "XCAXClient_iOS.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 
@@ -84,8 +85,13 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
   if (uniqueTypes && [uniqueTypes count] == 1) {
     type = [uniqueTypes.firstObject intValue];
   }
-  [matchedElements addObjectsFromArray:[[self descendantsMatchingType:type] matchingPredicate:[FBPredicate predicateWithFormat:@"%K IN %@", FBStringify(XCUIElement, wdUID), matchedUids]].allElementsBoundByIndex];
-  if (matchedElements.count <= 1) {
+  XCUIElementQuery *query = [[self descendantsMatchingType:type] matchingPredicate:[FBPredicate predicateWithFormat:@"%K IN %@", FBStringify(XCUIElement, wdUID), matchedUids]];
+  if (1 == snapshots.count) {
+    XCUIElement *result = query.fb_firstMatch;
+    return result ? @[result] : @[];
+  }
+  NSArray<XCUIElement *> *filteredElements = query.allElementsBoundByIndex;
+  if (filteredElements.count <= 1) {
     // There is no need to sort elements if count of matches is not greater than one
     return matchedElements;
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -90,10 +90,10 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
     XCUIElement *result = query.fb_firstMatch;
     return result ? @[result] : @[];
   }
-  NSArray<XCUIElement *> *filteredElements = query.allElementsBoundByIndex;
-  if (filteredElements.count <= 1) {
+  [matchedElements addObjectsFromArray:query.allElementsBoundByIndex];
+  if (matchedElements.count <= 1) {
     // There is no need to sort elements if count of matches is not greater than one
-    return matchedElements;
+    return matchedElements.copy;
   }
   NSMutableArray<XCUIElement *> *sortedElements = [NSMutableArray array];
   [snapshots enumerateObjectsUsingBlock:^(XCElementSnapshot *snapshot, NSUInteger snapshotIdx, BOOL *stopSnapshotEnum) {

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -20,6 +20,7 @@
 #import "FBRouteRequest.h"
 #import "FBRunLoopSpinner.h"
 #import "FBSession.h"
+#import "FBXCodeCompatibility.h"
 #import "FBSpringboardApplication.h"
 #import "XCUIApplication+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
@@ -82,8 +83,8 @@
      timeout:5]
     timeoutErrorMessage:errorDescription]
    spinUntilTrue:^BOOL{
-     XCUIElement *foundKeyboard = [[FBApplication fb_activeApplication].query descendantsMatchingType:XCUIElementTypeKeyboard].element;
-     return !(foundKeyboard.exists && foundKeyboard.fb_isVisible);
+     XCUIElement *foundKeyboard = [[FBApplication fb_activeApplication].query descendantsMatchingType:XCUIElementTypeKeyboard].fb_firstMatch;
+     return !(foundKeyboard && foundKeyboard.fb_isVisible);
    }
    error:&error];
   if (!isKeyboardNotPresent) {

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -16,6 +16,7 @@
 #import "FBFindElementCommands.h"
 #import "FBSpringboardApplication.h"
 #import "FBLogger.h"
+#import "FBXCodeCompatibility.h"
 #import "XCAXClient_iOS.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCElementSnapshot.h"
@@ -53,8 +54,7 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
     // In that case we ignore it.
     NSPredicate *predicateString = [NSPredicate predicateWithFormat:@"identifier == 'PopoverDismissRegion'"];
     XCUIElementQuery *query = [[self descendantsMatchingType:XCUIElementTypeAny] matchingPredicate:predicateString];
-    NSArray *childElements = [query allElementsBoundByIndex];
-    if (childElements.count == 0) {
+    if (!query.fb_firstMatch) {
       return alert;
     }
   }

--- a/WebDriverAgentLib/Utilities/FBKeyboard.m
+++ b/WebDriverAgentLib/Utilities/FBKeyboard.m
@@ -15,6 +15,7 @@
 #import "FBErrorBuilder.h"
 #import "FBRunLoopSpinner.h"
 #import "FBMacros.h"
+#import "FBXCodeCompatibility.h"
 #import "XCElementSnapshot.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCTestDriver.h"
@@ -54,8 +55,7 @@
      timeout:5]
     timeoutErrorMessage:@"Keyboard is not present"]
    spinUntilNotNil:^id{
-     XCUIElement *foundKeyboard = [[FBApplication fb_activeApplication].query descendantsMatchingType:XCUIElementTypeKeyboard].element;
-     return (foundKeyboard.exists ? foundKeyboard : nil);
+     return [[FBApplication fb_activeApplication].query descendantsMatchingType:XCUIElementTypeKeyboard].fb_firstMatch;
    }
    error:error];
 

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -15,12 +15,19 @@
  */
 @interface XCElementSnapshot (FBCompatibility)
 
-- (XCElementSnapshot *)fb_rootElement;
+- (nullable XCElementSnapshot *)fb_rootElement;
 
 @end
 
 @interface XCUIApplication (FBCompatibility)
 
-+ (instancetype)fb_applicationWithPID:(pid_t)processID;
++ (nullable instancetype)fb_applicationWithPID:(pid_t)processID;
+
+@end
+
+@interface XCUIElementQuery (FBCompatibility)
+
+/* Performs short-circuit UI tree traversion in iOS 11+ to get the first element matched by the query. Equals to nil if no matching elements are found */
+@property(nullable, readonly) XCUIElement *fb_firstMatch;
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -43,3 +43,28 @@ static dispatch_once_t onceAppWithPIDToken;
 
 @end
 
+static BOOL FBShouldUseFirstMatchSelector = NO;
+static dispatch_once_t onceFirstMatchToken;
+@implementation XCUIElementQuery (FBCompatibility)
+
+- (XCUIElement *)fb_firstMatch
+{
+  SEL firstMatchSelector = NSSelectorFromString(@"firstMatch");
+  dispatch_once(&onceFirstMatchToken, ^{
+    FBShouldUseFirstMatchSelector = [self respondsToSelector:firstMatchSelector];
+  });
+  if (FBShouldUseFirstMatchSelector) {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    XCUIElement* result = [self performSelector:firstMatchSelector];
+    #pragma clang diagnostic pop
+    return result.exists ? result : nil;
+  }
+  if (!self.element.exists) {
+    return nil;
+  }
+  return [self elementBoundByIndex:0];
+}
+
+@end
+

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -9,6 +9,8 @@
 
 #import "FBXCodeCompatibility.h"
 
+#import "XCUIElementQuery.h"
+
 static BOOL FBShouldUseOldElementRootSelector = NO;
 static dispatch_once_t onceRootElementToken;
 @implementation XCElementSnapshot (FBCompatibility)
@@ -49,15 +51,11 @@ static dispatch_once_t onceFirstMatchToken;
 
 - (XCUIElement *)fb_firstMatch
 {
-  SEL firstMatchSelector = NSSelectorFromString(@"firstMatch");
   dispatch_once(&onceFirstMatchToken, ^{
-    FBShouldUseFirstMatchSelector = [self respondsToSelector:firstMatchSelector];
+    FBShouldUseFirstMatchSelector = [self respondsToSelector:@selector(firstMatch)];
   });
   if (FBShouldUseFirstMatchSelector) {
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-    XCUIElement* result = [self performSelector:firstMatchSelector];
-    #pragma clang diagnostic pop
+    XCUIElement* result = self.firstMatch;
     return result.exists ? result : nil;
   }
   if (!self.element.exists) {


### PR DESCRIPTION
[firstMatch](https://developer.apple.com/documentation/xctest/xcuielementtypequeryprovider/2902250-firstmatch?language=objc) implements fast short-circuit traversal of UI tree, which means better lookup times for us.

I've also changed some existing methods to use this call and make them faster.

Tested on Xcode8 with iOS 10 and Xcode 9b2 + iOS 11beta.

I have noticed one new issue under iOS11 - the _children_ property of XCElementSnapshot returns empty list without any known reason. The same code works as expected under iOS 10.