### PR TITLE
Fix getting element UID in Xcode 9

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -26,7 +26,10 @@
 
 - (NSUInteger)fb_uid
 {
-  return [[self.accessibilityElement.payload objectForKey:@"uid.elementID"] intValue];
+  if ([self.accessibilityElement respondsToSelector:@selector(payload)]) {
+    return [[self.accessibilityElement.payload objectForKey:@"uid.elementID"] intValue];
+  }
+  return [[self.accessibilityElement valueForKey:@"_elementID"] intValue];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUID.m
@@ -21,12 +21,16 @@
 
 @end
 
-
+static BOOL FBShouldUsePayloadForUIDExtraction = YES;
+static dispatch_once_t oncePayloadToken;
 @implementation XCElementSnapshot (FBUID)
 
 - (NSUInteger)fb_uid
 {
-  if ([self.accessibilityElement respondsToSelector:@selector(payload)]) {
+  dispatch_once(&oncePayloadToken, ^{
+    FBShouldUsePayloadForUIDExtraction = [self.accessibilityElement respondsToSelector:@selector(payload)];
+  });
+  if (FBShouldUsePayloadForUIDExtraction) {
     return [[self.accessibilityElement.payload objectForKey:@"uid.elementID"] intValue];
   }
   return [[self.accessibilityElement valueForKey:@"_elementID"] intValue];


### PR DESCRIPTION
In the recent XCTest release instances of XCAccessibilityElement don't contain the **payload** property anymore. And the unique element's identifier has been moved to _elementID property.