### PR TITLE
Use application.frame property to make visibility property work for iOS 11

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -42,7 +42,7 @@
   if ([FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
     return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
   }
-  CGRect appFrame = [self fb_rootElement].frame;
+  CGRect appFrame = self.application.frame;
   CGSize screenSize = FBAdjustDimensionsForApplication(appFrame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
   CGRect screenFrame = CGRectMake(0, 0, screenSize.width, screenSize.height);
   if (!CGRectIntersectsRect(visibleFrame, screenFrame)) {


### PR DESCRIPTION
Without this patch XCode 9 generates the stracktrace mentioned in https://github.com/facebook/WebDriverAgent/issues/639 for each call of fb_isVisible.