### PR TITLE
Use "official" visibility detection scheme since iOS 11 by default

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -9,6 +9,7 @@
 
 #import "XCUIElement+FBIsVisible.h"
 
+#import "FBMacros.h"
 #import "FBApplication.h"
 #import "FBConfiguration.h"
 #import "FBMathUtils.h"
@@ -23,7 +24,10 @@
 
 - (BOOL)fb_isVisible
 {
-  return self.fb_lastSnapshot.fb_isVisible;
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0") || [FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
+    return self.fb_lastSnapshot.fb_isVisible;
+  }
+  return self.exists && self.hittable;
 }
 
 @end


### PR DESCRIPTION
I think it might be a good idea to stick to the visibility detection method, which is "officially" provided by Apple since we anyway plan to deprecate most of the stuff related to snapshots since iOS 11. Also, this way it will be faster and more reliable.