### PR TITLE
Make visibility check work for iOS < 11

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -42,7 +42,12 @@
   if ([FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
     return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
   }
-  CGRect appFrame = self.application.frame;
+  CGRect appFrame;
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    appFrame = self.application.frame;
+  } else {
+    appFrame = [self fb_rootElement].frame;
+  }
   CGSize screenSize = FBAdjustDimensionsForApplication(appFrame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
   CGRect screenFrame = CGRectMake(0, 0, screenSize.width, screenSize.height);
   if (!CGRectIntersectsRect(visibleFrame, screenFrame)) {


### PR DESCRIPTION
Commit https://github.com/facebook/WebDriverAgent/commit/88eba1de9b502414eb51cc4c75bd905e5027ea66 made visibility checks work for iOS 11, but they hang for earlier iOS versions. So use the old mechanism for older versions.