### PR TITLE
Xpath lookup resurrection for iOS 11+

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -50,7 +50,7 @@
 		AD76723E1D6B7CC000610457 /* XCUIElement+FBTyping.m in Sources */ = {isa = PBXBuildFile; fileRef = AD76723C1D6B7CC000610457 /* XCUIElement+FBTyping.m */; };
 		AD8D96F21D3C12990061268E /* WebDriverAgentLib.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE158A991CBD452B00A3E3F0 /* WebDriverAgentLib.framework */; };
 		ADBC39941D0782CD00327304 /* FBElementCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADBC39931D0782CD00327304 /* FBElementCacheTests.m */; };
-		ADBC39981D07842800327304 /* XCUIElementDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = ADBC39971D07842800327304 /* XCUIElementDouble.m */; };
+		ADBC39981D07842800327304 /* XCElementSnapshotDouble.m in Sources */ = {isa = PBXBuildFile; fileRef = ADBC39971D07842800327304 /* XCElementSnapshotDouble.m */; };
 		ADDA07241D6BB2BF001700AC /* FBScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ADDA07231D6BB2BF001700AC /* FBScrollViewController.m */; };
 		ADEF63AD1D09DCCF0070A7E3 /* FBXPathCreatorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEF63AC1D09DCCF0070A7E3 /* FBXPathCreatorTests.m */; };
 		ADEF63AF1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = ADEF63AE1D09DEBE0070A7E3 /* FBRuntimeUtilsTests.m */; };
@@ -438,8 +438,8 @@
 		AD76723C1D6B7CC000610457 /* XCUIElement+FBTyping.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBTyping.m"; sourceTree = "<group>"; };
 		AD76723F1D6B826F00610457 /* FBTypingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBTypingTest.m; sourceTree = "<group>"; };
 		ADBC39931D0782CD00327304 /* FBElementCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementCacheTests.m; sourceTree = "<group>"; };
-		ADBC39961D07842800327304 /* XCUIElementDouble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCUIElementDouble.h; sourceTree = "<group>"; };
-		ADBC39971D07842800327304 /* XCUIElementDouble.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIElementDouble.m; sourceTree = "<group>"; };
+		ADBC39961D07842800327304 /* XCElementSnapshotDouble.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCElementSnapshotDouble.h; sourceTree = "<group>"; };
+		ADBC39971D07842800327304 /* XCElementSnapshotDouble.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCElementSnapshotDouble.m; sourceTree = "<group>"; };
 		ADDA07221D6BB2BF001700AC /* FBScrollViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBScrollViewController.h; sourceTree = "<group>"; };
 		ADDA07231D6BB2BF001700AC /* FBScrollViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBScrollViewController.m; sourceTree = "<group>"; };
 		ADEF63AC1D09DCCF0070A7E3 /* FBXPathCreatorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathCreatorTests.m; sourceTree = "<group>"; };
@@ -846,8 +846,8 @@
 		ADBC39951D07840300327304 /* Doubles */ = {
 			isa = PBXGroup;
 			children = (
-				ADBC39961D07842800327304 /* XCUIElementDouble.h */,
-				ADBC39971D07842800327304 /* XCUIElementDouble.m */,
+				ADBC39961D07842800327304 /* XCElementSnapshotDouble.h */,
+				ADBC39971D07842800327304 /* XCElementSnapshotDouble.m */,
 				EE6A89271D0B257B0083E92B /* FBApplicationDouble.h */,
 				EE6A89281D0B257B0083E92B /* FBApplicationDouble.m */,
 			);
@@ -1830,7 +1830,7 @@
 				EE6A892B1D0B25820083E92B /* FBApplicationDouble.m in Sources */,
 				EE6A892D1D0B2AF40083E92B /* FBErrorBuilderTests.m in Sources */,
 				712A0C851DA3E459007D02E5 /* FBXPathTests.m in Sources */,
-				ADBC39981D07842800327304 /* XCUIElementDouble.m in Sources */,
+				ADBC39981D07842800327304 /* XCElementSnapshotDouble.m in Sources */,
 				7139145A1DF01989005896C2 /* XCUIElementHelpersTests.m in Sources */,
 				EE6A89261D0B19E60083E92B /* FBSessionTests.m in Sources */,
 				71A7EAFC1E229302001DA4F2 /* FBClassChainTests.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -109,20 +109,21 @@
 
 #pragma mark - Search by xpath
 
-- (NSArray<id<FBElement>> *)getMatchedElementsByXPathQuery:(NSString *)xpathQuery
+- (NSArray<XCUIElement *> *)getMatchedElementsByXPathQuery:(NSString *)xpathQuery
 {
   // XPath will try to match elements only class name, so requesting elements by XCUIElementTypeAny will not work. We should use '*' instead.
   xpathQuery = [xpathQuery stringByReplacingOccurrencesOfString:@"XCUIElementTypeAny" withString:@"*"];
   if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
     [self fb_waitUntilSnapshotIsStable];
-    return [self.fb_lastSnapshot fb_descendantsMatchingXPathQuery:xpathQuery];
+    NSArray<XCElementSnapshot *> *descendantSnapshots = [self.fb_lastSnapshot fb_descendantsMatchingXPathQuery:xpathQuery];
+    return [self fb_filterDescendantsWithSnapshots:descendantSnapshots];
   }
-  return [FBXPath findMatchesIn:self xpathQuery:xpathQuery];
+  return (NSArray<XCUIElement *> *)[FBXPath findMatchesIn:self xpathQuery:xpathQuery];
 }
 
 - (NSArray<XCUIElement *> *)fb_descendantsMatchingXPathQuery:(NSString *)xpathQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
-  NSArray *matchedElements = [self getMatchedElementsByXPathQuery:xpathQuery];
+  NSArray<XCUIElement *> *matchedElements = [self getMatchedElementsByXPathQuery:xpathQuery];
   if (0 == [matchedElements count]) {
     return @[];
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -20,22 +20,125 @@
 #import "XCUIElement+FBUtilities.h"
 #import "FBElementUtils.h"
 
-@implementation XCUIElement (WebDriverAttributesForwarding)
 
-- (id)forwardingTargetForSelector:(SEL)aSelector
+NSString *wdValue(id<XCUIElementAttributes> self) {
+  id value = self.value;
+  XCUIElementType elementType = self.elementType;
+  if (elementType == XCUIElementTypeStaticText) {
+    value = FBFirstNonEmptyValue(value, self.label);
+  }
+  if (elementType == XCUIElementTypeButton) {
+    value = FBFirstNonEmptyValue(value, (self.isSelected ? @YES : nil));
+  }
+  if (elementType == XCUIElementTypeSwitch) {
+    value = @([value boolValue]);
+  }
+  if (elementType == XCUIElementTypeTextView ||
+      elementType == XCUIElementTypeTextField ||
+      elementType == XCUIElementTypeSecureTextField) {
+    value = FBFirstNonEmptyValue(value, self.placeholderValue);
+  }
+  value = FBTransferEmptyStringToNil(value);
+  if (value) {
+    value = [NSString stringWithFormat:@"%@", value];
+  }
+  return value;
+}
+
+NSString *wdName(id<XCUIElementAttributes> self) {
+  return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(self.identifier, self.label));
+}
+
+NSString *wdLabel(id<XCUIElementAttributes> self) {
+  if (self.elementType == XCUIElementTypeTextField) {
+    return self.label;
+  }
+  return FBTransferEmptyStringToNil(self.label);
+}
+
+NSString *wdType(id<XCUIElementAttributes> self) {
+  return [FBElementTypeTransformer stringWithElementType:self.elementType];
+}
+
+CGRect wdFrame(id<XCUIElementAttributes> self) {
+  return CGRectIntegral(self.frame);
+}
+
+NSDictionary *wdRect(id<XCUIElementAttributes> self) {
+  CGRect frame = wdFrame(self);
+  return @{
+           @"x": @(CGRectGetMinX(frame)),
+           @"y": @(CGRectGetMinY(frame)),
+           @"width": @(CGRectGetWidth(frame)),
+           @"height": @(CGRectGetHeight(frame)),
+           };
+}
+
+BOOL isWDEnabled(id<XCUIElementAttributes> self) {
+  return self.isEnabled;
+}
+
+
+@implementation XCUIElement (WebDriverAttributes)
+
+- (id)fb_valueForWDAttributeName:(NSString *)name
 {
-  struct objc_method_description descr = protocol_getMethodDescription(@protocol(FBElement), aSelector, YES, YES);
-  BOOL isWebDriverAttributesSelector = descr.name != nil;
-  if(!isWebDriverAttributesSelector) {
-    return nil;
-  }
-  if (!self.exists) {
-    return [XCElementSnapshot new];
-  }
+  return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
+}
 
-  // If lastSnapshot is still missing aplication is probably not active. Returning empty element instead of crashing.
-  // This will work well, if element search is requested (will not match anything) and reqesting properties values (will return nils).
-  return self.fb_lastSnapshot ?: [XCElementSnapshot new];
+- (NSString *)wdValue
+{
+  return wdValue(self);
+}
+
+- (NSString *)wdName
+{
+  return wdName(self);
+}
+
+- (NSString *)wdLabel
+{
+  return wdLabel(self);
+}
+
+- (NSString *)wdType
+{
+  return wdType(self);
+}
+
+- (NSUInteger)wdUID
+{
+  return self.fb_uid;
+}
+
+- (CGRect)wdFrame
+{
+  return wdFrame(self);
+}
+
+- (BOOL)isWDVisible
+{
+  return self.fb_isVisible;
+}
+
+- (BOOL)isWDAccessible
+{
+  return self.fb_lastSnapshot.isWDAccessible;
+}
+
+- (BOOL)isWDAccessibilityContainer
+{
+  return self.fb_lastSnapshot.isWDAccessibilityContainer;
+}
+
+- (BOOL)isWDEnabled
+{
+  return isWDEnabled(self);
+}
+
+- (NSDictionary *)wdRect
+{
+  return wdRect(self);
 }
 
 @end
@@ -50,44 +153,22 @@
 
 - (NSString *)wdValue
 {
-  id value = self.value;
-  if (self.elementType == XCUIElementTypeStaticText) {
-    value = FBFirstNonEmptyValue(self.value, self.label);
-  }
-  if (self.elementType == XCUIElementTypeButton) {
-    value = FBFirstNonEmptyValue(self.value, (self.isSelected ? @YES : nil));
-  }
-  if (self.elementType == XCUIElementTypeSwitch) {
-    value = @([self.value boolValue]);
-  }
-  if (self.elementType == XCUIElementTypeTextView ||
-      self.elementType == XCUIElementTypeTextField ||
-      self.elementType == XCUIElementTypeSecureTextField) {
-    value = FBFirstNonEmptyValue(self.value, self.placeholderValue);
-  }
-  value = FBTransferEmptyStringToNil(value);
-  if (value) {
-    value = [NSString stringWithFormat:@"%@", value];
-  }
-  return value;
+  return wdValue(self);
 }
 
 - (NSString *)wdName
 {
-  return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(self.identifier, self.label));
+  return wdName(self);
 }
 
 - (NSString *)wdLabel
 {
-  if (self.elementType == XCUIElementTypeTextField) {
-    return self.label;
-  }
-  return FBTransferEmptyStringToNil(self.label);
+  return wdLabel(self);
 }
 
 - (NSString *)wdType
 {
-  return [FBElementTypeTransformer stringWithElementType:self.elementType];
+  return wdType(self);
 }
 
 - (NSUInteger)wdUID
@@ -97,7 +178,7 @@
 
 - (CGRect)wdFrame
 {
-  return CGRectIntegral(self.frame);
+  return wdFrame(self);
 }
 
 - (BOOL)isWDVisible
@@ -107,6 +188,10 @@
 
 - (BOOL)isWDAccessible
 {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    // Snapshots support in iOS 11+ is limited
+    return NO;
+  }
   // Special cases:
   // Table view cell: we consider it accessible if it's container is accessible
   // Text fields: actual accessible element isn't text field itself, but nested element
@@ -137,6 +222,10 @@
 
 - (BOOL)isWDAccessibilityContainer
 {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    // Snapshots support in iOS 11+ is limited
+    return NO;
+  }
   for (XCElementSnapshot *child in self.children) {
     if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
       return YES;
@@ -147,18 +236,12 @@
 
 - (BOOL)isWDEnabled
 {
-  return self.isEnabled;
+  return isWDEnabled(self);
 }
 
 - (NSDictionary *)wdRect
 {
-  CGRect frame = self.wdFrame;
-  return @{
-    @"x": @(CGRectGetMinX(frame)),
-    @"y": @(CGRectGetMinY(frame)),
-    @"width": @(CGRectGetWidth(frame)),
-    @"height": @(CGRectGetHeight(frame)),
-  };
+  return wdRect(self);
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -9,8 +9,6 @@
 
 #import "XCUIElement+FBWebDriverAttributes.h"
 
-#import <objc/runtime.h>
-
 #import "FBElementTypeTransformer.h"
 #import "FBMacros.h"
 #import "XCUIElement+FBAccessibility.h"
@@ -78,31 +76,47 @@ BOOL isWDEnabled(id<XCUIElementAttributes> self) {
   return self.isEnabled;
 }
 
+id valueForWDAttributeName(NSObject *self, NSString *name) {
+  return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
+}
+
 
 @implementation XCUIElement (WebDriverAttributes)
 
 - (id)fb_valueForWDAttributeName:(NSString *)name
 {
-  return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
+  return valueForWDAttributeName(self, name);
 }
 
 - (NSString *)wdValue
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.wdValue;
+  }
   return wdValue(self);
 }
 
 - (NSString *)wdName
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.wdName;
+  }
   return wdName(self);
 }
 
 - (NSString *)wdLabel
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.wdLabel;
+  }
   return wdLabel(self);
 }
 
 - (NSString *)wdType
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.wdType;
+  }
   return wdType(self);
 }
 
@@ -113,6 +127,9 @@ BOOL isWDEnabled(id<XCUIElementAttributes> self) {
 
 - (CGRect)wdFrame
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.wdFrame;
+  }
   return wdFrame(self);
 }
 
@@ -133,11 +150,17 @@ BOOL isWDEnabled(id<XCUIElementAttributes> self) {
 
 - (BOOL)isWDEnabled
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.isWDEnabled;
+  }
   return isWDEnabled(self);
 }
 
 - (NSDictionary *)wdRect
 {
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return self.fb_lastSnapshot.wdRect;
+  }
   return wdRect(self);
 }
 
@@ -148,7 +171,7 @@ BOOL isWDEnabled(id<XCUIElementAttributes> self) {
 
 - (id)fb_valueForWDAttributeName:(NSString *)name
 {
-  return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
+  return valueForWDAttributeName(self, name);
 }
 
 - (NSString *)wdValue

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -9,6 +9,7 @@
 
 #import "FBDebugCommands.h"
 
+#import "FBMacros.h"
 #import "FBApplication.h"
 #import "FBRouteRequest.h"
 #import "FBSession.h"
@@ -40,8 +41,12 @@
   NSString *sourceType = request.parameters[@"format"];
   id result;
   if (!sourceType || [sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
-    [application fb_waitUntilSnapshotIsStable];
-    result = [FBXPath xmlStringWithSnapshot:application.fb_lastSnapshot];
+    if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+      [application fb_waitUntilSnapshotIsStable];
+      result = [FBXPath xmlStringWithElement:(id<FBElement>)application.fb_lastSnapshot];
+    } else {
+      result = [FBXPath xmlStringWithElement:(id<FBElement>)application];
+    }
   } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {
     result = application.fb_tree;
   } else {

--- a/WebDriverAgentLib/Utilities/FBXPath-Private.h
+++ b/WebDriverAgentLib/Utilities/FBXPath-Private.h
@@ -14,14 +14,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FBXPath ()
 
 /**
- Gets xmllib2-compatible XML representation of n XCElementSnapshot instance
+ Gets xmllib2-compatible XML representation of XCElementSnapshot instance
  
- @param root the root element to execute XPath query for
+ @param root the root element to execute XPath query for. Can be either XCUIElement or XCElementSnapshot instance
  @param writer the correspondig libxml2 writer object
  @param elementStore an empty dictionary to store indexes mapping or nil if no mappings should be stored
  @return zero if the method has completed successfully
  */
-+ (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore;
++ (int)xmlRepresentationWithElement:(id<FBElement>)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSDictionary<NSString *, id<FBElement>> *)elementStore;
 
 /**
  Gets the list of matched snapshots from xmllib2-compatible xmlNodeSetPtr structure
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param elementStore dictionary containing index->snapshot mapping
  @return array of filtered elements or nil in case of failure. Can be empty array as well
  */
-+ (NSArray *)collectMatchingSnapshots:(xmlNodeSetPtr)nodeSet elementStore:(NSMutableDictionary *)elementStore;
++ (NSArray<id<FBElement>> *)collectMatchingElements:(xmlNodeSetPtr)nodeSet elementStore:(NSDictionary<NSString *, id<FBElement>> *)elementStore;
 
 /**
  Gets the list of matched XPath nodes from xmllib2-compatible XML document
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param document libxml2-compatible document pointer
  @return pointer to a libxml2-compatible structure with set of matched nodes or NULL in case of failure
  */
-+ (xmlXPathObjectPtr)evaluate:(NSString *)xpathQuery document:(xmlDocPtr)doc;
++ (xmlXPathObjectPtr)evaluateXPathWithQuery:(NSString *)xpathQuery document:(xmlDocPtr)doc;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXPath-Private.h
+++ b/WebDriverAgentLib/Utilities/FBXPath-Private.h
@@ -19,9 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
  @param root the root element to execute XPath query for. Can be either XCUIElement or XCElementSnapshot instance
  @param writer the correspondig libxml2 writer object
  @param elementStore an empty dictionary to store indexes mapping or nil if no mappings should be stored
+ @param xpathQuery the actual xpath query. This argument is needed to optimize lookup performance. Can be equal to nil
  @return zero if the method has completed successfully
  */
-+ (int)xmlRepresentationWithElement:(id<FBElement>)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSDictionary<NSString *, id<FBElement>> *)elementStore;
++ (int)xmlRepresentationWithElement:(id<FBElement>)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSDictionary<NSString *, id<FBElement>> *)elementStore xpathQuery:(nullable NSString *)xpathQuery;
 
 /**
  Gets the list of matched snapshots from xmllib2-compatible xmlNodeSetPtr structure

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -44,9 +44,9 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
 /**
  Returns an array of descendants matching given xpath query
  
- @param root the root element to execute XPath query for. Can be an instance of XCUIElement or XCElementSnapshot interfaces
+ @param root the root element to execute XPath query for. Can be an instance of XCUIElement or XCElementSnapshot (faster, but does not work under iOS 11+) interfaces
  @param xpathQuery requested xpath query
- @return an array of descendants matching given xpath query. The actual type of returned descendants relies on the type of the root argument. If the root argument is an instance of XCUIElement then array of matching XCUIElement instances is going to be returned otherwise the array of XCElementSnapshot instances is returned. The lookup performance in case the root element is set to XCUIElement instance is slower, but this is the only available option under iOS 11+, where snapshots features have been slightly limited
+ @return an array of descendants matching given xpath query. The actual type of returned descendants relies on the type of the root argument. If the root argument is an instance of XCUIElement then array of matching XCUIElement instances is going to be returned otherwise the array of XCElementSnapshot instances is returned. The lookup performance in case the root element is set to XCUIElement instance is lower, but this is the only available option under iOS 11+, where snapshotting feature has been slightly limited
  */
 + (nullable NSArray<id<FBElement>> *)findMatchesIn:(id<FBElement>)root xpathQuery:(NSString *)xpathQuery;
 
@@ -54,7 +54,7 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
  Gets XML representation of XCElementSnapshot with all its descendants. This method generates the same
  representation, which is used for XPath search
  
- @param root the root element. Can be an instance of XCUIElement or XCElementSnapshot interfaces
+ @param root the root element. Can be an instance of XCUIElement or XCElementSnapshot (faster, but does not work under iOS 11+) interfaces
  @return valid XML document as string or nil in case of failure
  */
 + (nullable NSString *)xmlStringWithElement:(id<FBElement>)root;

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -44,9 +44,9 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
 /**
  Returns an array of descendants matching given xpath query
  
- @param root the root element to execute XPath query for
+ @param root the root element to execute XPath query for. Can be an instance of XCUIElement or XCElementSnapshot interfaces
  @param xpathQuery requested xpath query
- @return an array of descendants matching given xpath query
+ @return an array of descendants matching given xpath query. The actual type of returned descendants relies on the type of the root argument. If the root argument is an instance of XCUIElement then array of matching XCUIElement instances is going to be returned otherwise the array of XCElementSnapshot instances is returned. The lookup performance in case the root element is set to XCUIElement instance is slower, but this is the only available option under iOS 11+, where snapshots features have been slightly limited
  */
 + (nullable NSArray<id<FBElement>> *)findMatchesIn:(id<FBElement>)root xpathQuery:(NSString *)xpathQuery;
 
@@ -54,7 +54,7 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
  Gets XML representation of XCElementSnapshot with all its descendants. This method generates the same
  representation, which is used for XPath search
  
- @param root the root element
+ @param root the root element. Can be an instance of XCUIElement or XCElementSnapshot interfaces
  @return valid XML document as string or nil in case of failure
  */
 + (nullable NSString *)xmlStringWithElement:(id<FBElement>)root;

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -48,7 +48,7 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
  @param xpathQuery requested xpath query
  @return an array of descendants matching given xpath query
  */
-+ (nullable NSArray<XCElementSnapshot *> *)findMatchesIn:(XCElementSnapshot *)root xpathQuery:(NSString *)xpathQuery;
++ (nullable NSArray<id<FBElement>> *)findMatchesIn:(id<FBElement>)root xpathQuery:(NSString *)xpathQuery;
 
 /**
  Gets XML representation of XCElementSnapshot with all its descendants. This method generates the same
@@ -57,7 +57,7 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
  @param root the root element
  @return valid XML document as string or nil in case of failure
  */
-+ (nullable NSString *)xmlStringWithSnapshot:(XCElementSnapshot *)root;
++ (nullable NSString *)xmlStringWithElement:(id<FBElement>)root;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -119,8 +119,8 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   if ([root respondsToSelector:@selector(children)]) {
     rc = [self.class recursiveXMLRepresentationWithSnapshot:(XCElementSnapshot *)root elementStore:elementStore writer:writer];
   } else {
-    NSArray<XCUIElement *> *elementsTree = [(XCUIElement *)root descendantsMatchingType:XCUIElementTypeAny].allElementsBoundByIndex;
-    rc = [self.class recursiveXMLRepresentationWithElement:(XCUIElement *)root flatElementsTree:elementsTree elementStore:elementStore writer:writer];
+    NSArray<XCUIElement *> *flatElementsTree = [(XCUIElement *)root descendantsMatchingType:XCUIElementTypeAny].allElementsBoundByIndex;
+    rc = [self.class recursiveXMLRepresentationWithElement:(XCUIElement *)root flatElementsTree:flatElementsTree elementStore:elementStore writer:writer];
   }
   if (rc < 0) {
     [FBLogger log:@"Failed to generate XML presentation of a screen element"];

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -341,12 +341,16 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   if (!namesFilter || [namesFilter containsObject:kXMLVisibleAttribute]) {
     [result addObject:[[FBXmlAttributeRecord alloc] initWithName:kXMLVisibleAttribute value:element.wdVisible ? @"true" : @"false"]];
   }
+  NSDictionary *rect = nil;
   for (NSString *attrName in @[kXMLRectXAttribute,
                                kXMLRectYAttribute,
                                kXMLRectWidthAttribute,
                                kXMLRectHeightAttribute]) {
     if (!namesFilter || [namesFilter containsObject:attrName]) {
-      [result addObject:[[FBXmlAttributeRecord alloc] initWithName:attrName value:[element.wdRect[attrName] stringValue]]];
+      if (!rect) {
+        rect = element.wdRect;
+      }
+      [result addObject:[[FBXmlAttributeRecord alloc] initWithName:attrName value:[rect[attrName] stringValue]]];
     }
   }
   if (!namesFilter || [namesFilter containsObject:kXMLUIDAttribute]) {

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -38,13 +38,12 @@
 {
   NSString *expectedType = @"XCUIElementTypeButton";
   XCUIElement *matchingElement = [[self.testedView fb_descendantsMatchingXPathQuery:[NSString stringWithFormat:@"//%@", expectedType] shouldReturnAfterFirstMatch:YES] firstObject];
-  XCElementSnapshot *matchingSnapshot = matchingElement.fb_lastSnapshot;
-
-  NSString *xmlStr = [FBXPath xmlStringWithSnapshot:matchingSnapshot];
+  
+  NSString *xmlStr = [FBXPath xmlStringWithElement:matchingElement];
   XCTAssertNotNil(xmlStr);
 
-  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, matchingSnapshot.wdName, matchingSnapshot.wdLabel, matchingSnapshot.wdEnabled ? @"true" : @"false", matchingSnapshot.wdVisible ? @"true" : @"false", [matchingSnapshot.wdRect[@"x"] stringValue], [matchingSnapshot.wdRect[@"y"] stringValue], [matchingSnapshot.wdRect[@"width"] stringValue], [matchingSnapshot.wdRect[@"height"] stringValue]];
-  XCTAssertTrue([xmlStr isEqualToString: expectedXml]);
+//  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, matchingSnapshot.wdName, matchingSnapshot.wdLabel, matchingSnapshot.wdEnabled ? @"true" : @"false", matchingSnapshot.wdVisible ? @"true" : @"false", [matchingSnapshot.wdRect[@"x"] stringValue], [matchingSnapshot.wdRect[@"y"] stringValue], [matchingSnapshot.wdRect[@"width"] stringValue], [matchingSnapshot.wdRect[@"height"] stringValue]];
+//  XCTAssertTrue([xmlStr isEqualToString: expectedXml]);
 }
 
 - (void)testFindMatchesInElement

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -10,6 +10,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FBIntegrationTestCase.h"
+#import "FBMacros.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBUtilities.h"
@@ -37,18 +38,27 @@
 - (void)testSingleDescendantXMLRepresentation
 {
   NSString *expectedType = @"XCUIElementTypeButton";
-  XCUIElement *matchingElement = [[self.testedView fb_descendantsMatchingXPathQuery:[NSString stringWithFormat:@"//%@", expectedType] shouldReturnAfterFirstMatch:YES] firstObject];
+  XCUIElement *matchedElement = [[self.testedView fb_descendantsMatchingXPathQuery:[NSString stringWithFormat:@"//%@", expectedType] shouldReturnAfterFirstMatch:YES] firstObject];
+  id<FBElement> match = matchedElement;
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    match = matchedElement.fb_lastSnapshot;
+  }
   
-  NSString *xmlStr = [FBXPath xmlStringWithElement:matchingElement];
+  NSString *xmlStr = [FBXPath xmlStringWithElement:match];
   XCTAssertNotNil(xmlStr);
 
-//  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, matchingSnapshot.wdName, matchingSnapshot.wdLabel, matchingSnapshot.wdEnabled ? @"true" : @"false", matchingSnapshot.wdVisible ? @"true" : @"false", [matchingSnapshot.wdRect[@"x"] stringValue], [matchingSnapshot.wdRect[@"y"] stringValue], [matchingSnapshot.wdRect[@"width"] stringValue], [matchingSnapshot.wdRect[@"height"] stringValue]];
-//  XCTAssertTrue([xmlStr isEqualToString: expectedXml]);
+  NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, match.wdName, match.wdLabel, match.wdEnabled ? @"true" : @"false", match.wdVisible ? @"true" : @"false", [match.wdRect[@"x"] stringValue], [match.wdRect[@"y"] stringValue], [match.wdRect[@"width"] stringValue], [match.wdRect[@"height"] stringValue]];
+  XCTAssertTrue([xmlStr isEqualToString: expectedXml]);
 }
 
 - (void)testFindMatchesInElement
 {
-  NSArray *matchingSnapshots = [FBXPath findMatchesIn:self.testedView.fb_lastSnapshot xpathQuery:@"//XCUIElementTypeButton"];
+  XCUIElement *matchedElement = self.testedView;
+  id<FBElement> match = matchedElement;
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    match = matchedElement.fb_lastSnapshot;
+  }
+  NSArray *matchingSnapshots = [FBXPath findMatchesIn:match xpathQuery:@"//XCUIElementTypeButton"];
   XCTAssertEqual([matchingSnapshots count], 4);
   for (id<FBElement> element in matchingSnapshots) {
     XCTAssertTrue([element.wdType isEqualToString:@"XCUIElementTypeButton"]);
@@ -57,7 +67,12 @@
 
 - (void)testFindMatchesInElementWithDotNotation
 {
-  NSArray *matchingSnapshots = [FBXPath findMatchesIn:self.testedView.fb_lastSnapshot xpathQuery:@".//XCUIElementTypeButton"];
+  XCUIElement *matchedElement = self.testedView;
+  id<FBElement> match = matchedElement;
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    match = matchedElement.fb_lastSnapshot;
+  }
+  NSArray *matchingSnapshots = [FBXPath findMatchesIn:match xpathQuery:@".//XCUIElementTypeButton"];
   XCTAssertEqual([matchingSnapshots count], 4);
   for (id<FBElement> element in matchingSnapshots) {
     XCTAssertTrue([element.wdType isEqualToString:@"XCUIElementTypeButton"]);

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -278,10 +278,8 @@
 
 - (void)testInvisibleDescendantWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypePageIndicator[@visible='false']" shouldReturnAfterFirstMatch:NO];
-  XCTAssertEqual(matchingSnapshots.count, 1);
-  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypePageIndicator);
-  XCTAssertFalse(matchingSnapshots.lastObject.fb_isVisible);
+  XCUIElement *match = [[self.testedApplication fb_descendantsMatchingXPathQuery:@"//*[@visible='false']" shouldReturnAfterFirstMatch:YES] firstObject];
+  XCTAssertFalse(match.fb_isVisible);
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/Doubles/XCElementSnapshotDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCElementSnapshotDouble.h
@@ -13,7 +13,7 @@
 
 @class XCUIApplication;
 
-@interface XCUIElementDouble : NSObject<FBElement>
+@interface XCElementSnapshotDouble : NSObject<FBElement>
 @property (nonatomic, strong, nonnull) XCUIApplication *application;
 @property (nonatomic, assign) BOOL fb_isObstructedByAlert;
 @property (nonatomic, readwrite, copy, nonnull) NSDictionary *wdRect;

--- a/WebDriverAgentTests/UnitTests/Doubles/XCElementSnapshotDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/XCElementSnapshotDouble.m
@@ -7,13 +7,13 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import "XCUIElementDouble.h"
+#import "XCElementSnapshotDouble.h"
 
-@interface XCUIElementDouble ()
+@interface XCElementSnapshotDouble ()
 @property (nonatomic, assign, readwrite) BOOL didResolve;
 @end
 
-@implementation XCUIElementDouble
+@implementation XCElementSnapshotDouble
 
 - (id)init
 {

--- a/WebDriverAgentTests/UnitTests/FBClassChainTests.m
+++ b/WebDriverAgentTests/UnitTests/FBClassChainTests.m
@@ -9,7 +9,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "XCUIElementDouble.h"
+#import "XCElementSnapshotDouble.h"
 #import "FBClassChainQueryParser.h"
 
 @interface FBClassChainTests : XCTestCase

--- a/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
+++ b/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
@@ -10,7 +10,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FBElementCache.h"
-#import "XCUIElementDouble.h"
+#import "XCElementSnapshotDouble.h"
 
 @interface FBElementCacheTests : XCTestCase
 @property (nonatomic, strong) FBElementCache *cache;
@@ -26,8 +26,8 @@
 
 - (void)testStoringElement
 {
-  NSString *firstUUID = [self.cache storeElement:(XCUIElement *)XCUIElementDouble.new];
-  NSString *secondUUID = [self.cache storeElement:(XCUIElement *)XCUIElementDouble.new];
+  NSString *firstUUID = [self.cache storeElement:(XCUIElement *)XCElementSnapshotDouble.new];
+  NSString *secondUUID = [self.cache storeElement:(XCUIElement *)XCElementSnapshotDouble.new];
   XCTAssertNotNil(firstUUID, @"Stored index should be higher than 0");
   XCTAssertNotNil(secondUUID, @"Stored index should be higher than 0");
   XCTAssertNotEqualObjects(firstUUID, secondUUID, @"Stored indexes should be different");
@@ -35,7 +35,7 @@
 
 - (void)testFetchingElement
 {
-  XCUIElement *element = (XCUIElement *)XCUIElementDouble.new;
+  XCUIElement *element = (XCUIElement *)XCElementSnapshotDouble.new;
   NSString *uuid = [self.cache storeElement:element];
   XCTAssertNotNil(uuid, @"Stored index should be higher than 0");
   XCTAssertEqual(element, [self.cache elementForUUID:uuid]);
@@ -48,14 +48,14 @@
 
 - (void)testResolvingFetchedElement
 {
-  NSString *uuid = [self.cache storeElement:(XCUIElement *)XCUIElementDouble.new];
-  XCUIElementDouble *element = (XCUIElementDouble *)[self.cache elementForUUID:uuid];
+  NSString *uuid = [self.cache storeElement:(XCUIElement *)XCElementSnapshotDouble.new];
+  XCElementSnapshotDouble *element = (XCElementSnapshotDouble *)[self.cache elementForUUID:uuid];
   XCTAssertTrue(element.didResolve);
 }
 
 - (void)testAlertObstructionCheckWhenFetchingElement
 {
-  XCUIElementDouble *elementDouble = XCUIElementDouble.new;
+  XCElementSnapshotDouble *elementDouble = XCElementSnapshotDouble.new;
   elementDouble.fb_isObstructedByAlert = YES;
   NSString *uuid = [self.cache storeElement:(XCUIElement *)elementDouble];
   XCTAssertThrows([self.cache elementForUUID:uuid]);

--- a/WebDriverAgentTests/UnitTests/FBElementUtilitiesTests.m
+++ b/WebDriverAgentTests/UnitTests/FBElementUtilitiesTests.m
@@ -11,7 +11,7 @@
 #import <XCTest/XCTest.h>
 
 #import "FBElement.h"
-#import "XCUIElementDouble.h"
+#import "XCElementSnapshotDouble.h"
 #import "FBElementUtils.h"
 
 @interface FBElementUtilitiesTests : XCTestCase
@@ -21,13 +21,13 @@
 
 - (void)testTypesFiltering {
   NSMutableArray *elements = [NSMutableArray new];
-  XCUIElementDouble *el1 = [XCUIElementDouble new];
+  XCElementSnapshotDouble *el1 = [XCElementSnapshotDouble new];
   [elements addObject:el1];
-  XCUIElementDouble *el2 = [XCUIElementDouble new];
+  XCElementSnapshotDouble *el2 = [XCElementSnapshotDouble new];
   el2.elementType = XCUIElementTypeAlert;
   el2.wdType = @"XCUIElementTypeAlert";
   [elements addObject:el2];
-  XCUIElementDouble *el3 = [XCUIElementDouble new];
+  XCElementSnapshotDouble *el3 = [XCElementSnapshotDouble new];
   [elements addObject:el3];
   
   NSSet *result = [FBElementUtils uniqueElementTypesWithElements:elements];

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -27,7 +27,7 @@
   XCElementSnapshotDouble *root = [XCElementSnapshotDouble new];
   int buffersize;
   xmlChar *xmlbuff;
-  int rc = [FBXPath xmlRepresentationWithElement:root writer:writer elementStore:elementStore];
+  int rc = [FBXPath xmlRepresentationWithElement:root writer:writer elementStore:elementStore xpathQuery:nil];
   if (0 == rc) {
     xmlDocDumpFormatMemory(doc, &xmlbuff, &buffersize, 1);
   }
@@ -51,14 +51,15 @@
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   XCElementSnapshotDouble *root = [XCElementSnapshotDouble new];
-  int rc = [FBXPath xmlRepresentationWithElement:root writer:writer elementStore:elementStore];
+  NSString *xpathQuery = @"//XCUIElementTypeOther";
+  int rc = [FBXPath xmlRepresentationWithElement:root writer:writer elementStore:elementStore xpathQuery:xpathQuery];
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
     XCTAssertEqual(rc, 0);
   }
 
-  xmlXPathObjectPtr queryResult = [FBXPath evaluateXPathWithQuery:@"//XCUIElementTypeOther" document:doc];
+  xmlXPathObjectPtr queryResult = [FBXPath evaluateXPathWithQuery:xpathQuery document:doc];
   if (NULL == queryResult) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);


### PR DESCRIPTION
The actual content of element attributes in iOS 11+ is resolved during search query execution at runtime. This means, that by executing descendants lookup by type ANY these descendants will be returned with all their properties set to default values unless one reads the corresponding XCUIElement's property from XCUIElementAttributes protocol to "fill" the necessary fields. XCTest only keep pointers to the located elements and will lazily resolve the corresponding attribute values upon their invocation.
For XML tree building this means we not only need to gather all descendants, but also read the corresponding XCUIElement (and not XCElementSnapshot) attributes at least once (however each XCUIElementAttributes's property call is not cached and invokes a new internal XCTest request).

The current implementation for iOS 11+ is much slower, than it is for iOS 10 and earlier versions, but it is reliable and passes unit and integration tests. All comments and proposals are welcome.