### PR TITLE
Use native calls for iOS 11, since the bug with coordinates in landscape mode has been addressed there

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -19,6 +19,7 @@
 #import "XCElementSnapshot+FBHitPoint.h"
 #import "XCPointerEventPath.h"
 #import "XCTRunnerDaemonSession.h"
+#import "XCUICoordinate.h"
 
 const CGFloat FBTapDuration = 0.01f;
 
@@ -26,6 +27,10 @@ const CGFloat FBTapDuration = 0.01f;
 
 - (BOOL)fb_tapWithError:(NSError **)error
 {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    [self tap];
+    return YES;
+  }
   XCElementSnapshot *snapshot = self.fb_lastSnapshot;
   CGPoint hitpoint = snapshot.fb_hitPoint;
   if (CGPointEqualToPoint(hitpoint, CGPointMake(-1, -1))) {
@@ -36,6 +41,11 @@ const CGFloat FBTapDuration = 0.01f;
 
 - (BOOL)fb_tapCoordinate:(CGPoint)relativeCoordinate error:(NSError **)error
 {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    XCUICoordinate *tapCoordinate = [[XCUICoordinate alloc] initWithElement:self normalizedOffset:CGVectorMake(relativeCoordinate.x, relativeCoordinate.y)];
+    [tapCoordinate tap];
+    return YES;
+  }
   CGPoint hitPoint = CGPointMake(self.frame.origin.x + relativeCoordinate.x, self.frame.origin.y + relativeCoordinate.y);
   if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
     /*

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -9,6 +9,7 @@
 
 #import "XCUIElement+FBTyping.h"
 
+#import "FBMacros.h"
 #import "FBErrorBuilder.h"
 #import "FBKeyboard.h"
 #import "NSString+FBVisualLength.h"
@@ -20,6 +21,10 @@
 {
   if (!self.hasKeyboardFocus && ![self fb_tapWithError:error]) {
     return NO;
+  }
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    [self typeText:text];
+    return YES;
   }
   if (![FBKeyboard typeText:text error:error]) {
     return NO;

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -152,11 +152,12 @@
   if ([value isKindOfClass:[NSArray class]]) {
     textToType = [value componentsJoinedByString:@""];
   }
-  if (element.elementType == XCUIElementTypePickerWheel) {
+  XCUIElementType elementType = element.elementType;
+  if (elementType == XCUIElementTypePickerWheel) {
     [element adjustToPickerWheelValue:textToType];
     return FBResponseWithOK();
   }
-  if (element.elementType == XCUIElementTypeSlider) {
+  if (elementType == XCUIElementTypeSlider) {
     CGFloat sliderValue = textToType.floatValue;
     if (sliderValue < 0.0 || sliderValue > 1.0 ) {
       return FBResponseWithErrorFormat(@"Value of slider should be in 0..1 range");
@@ -206,7 +207,7 @@
 + (id<FBResponsePayload>)handleDoubleTapCoordinate:(FBRouteRequest *)request
 {
   CGPoint doubleTapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  XCUICoordinate *doubleTapCoordinate = [self.class gestureCoordinateWithCoordinate:doubleTapPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *doubleTapCoordinate = [self.class gestureCoordinateWithCoordinate:doubleTapPoint application:request.session.application shouldApplyOrientationWorkaround:SYSTEM_VERSION_LESS_THAN(@"11.0")];
   [doubleTapCoordinate doubleTap];
   return FBResponseWithOK();
 }
@@ -230,7 +231,7 @@
 + (id<FBResponsePayload>)handleTouchAndHoldCoordinate:(FBRouteRequest *)request
 {
   CGPoint touchPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  XCUICoordinate *pressCoordinate = [self.class gestureCoordinateWithCoordinate:touchPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *pressCoordinate = [self.class gestureCoordinateWithCoordinate:touchPoint application:request.session.application shouldApplyOrientationWorkaround:SYSTEM_VERSION_LESS_THAN(@"11.0")];
   [pressCoordinate pressForDuration:[request.arguments[@"duration"] doubleValue]];
   return FBResponseWithOK();
 }
@@ -289,8 +290,8 @@
   CGPoint startPoint = CGPointMake((CGFloat)[request.arguments[@"fromX"] doubleValue], (CGFloat)[request.arguments[@"fromY"] doubleValue]);
   CGPoint endPoint = CGPointMake((CGFloat)[request.arguments[@"toX"] doubleValue], (CGFloat)[request.arguments[@"toY"] doubleValue]);
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
-  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:YES];
-  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:SYSTEM_VERSION_LESS_THAN(@"11.0")];
+  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:SYSTEM_VERSION_LESS_THAN(@"11.0")];
   [startCoordinate pressForDuration:duration thenDragToCoordinate:endCoordinate];
   return FBResponseWithOK();
 }
@@ -303,7 +304,7 @@
   CGPoint startPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"fromX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"fromY"] doubleValue]));
   CGPoint endPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"toX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"toY"] doubleValue]));
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
-  BOOL shouldApplyOrientationWorkaround = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0");
+  BOOL shouldApplyOrientationWorkaround = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0") && SYSTEM_VERSION_LESS_THAN(@"11.0");
   XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
   XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
   [startCoordinate pressForDuration:duration thenDragToCoordinate:endCoordinate];
@@ -338,7 +339,7 @@
   CGPoint tapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
   if (nil == element) {
-    XCUICoordinate *tapCoordinate = [self.class gestureCoordinateWithCoordinate:tapPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+    XCUICoordinate *tapCoordinate = [self.class gestureCoordinateWithCoordinate:tapPoint application:request.session.application shouldApplyOrientationWorkaround:SYSTEM_VERSION_LESS_THAN(@"11.0")];
     [tapCoordinate tap];
   } else {
     NSError *error;


### PR DESCRIPTION
It looks like Apple finally did the job and taps in landscape mode are working properly now. However changing the device orientation still has no effect on Simulator window and it stays in portrait mode, but nobody cares.