### PR TITLE
Read XCUIElement attributes directly from the instance since iOS 11

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -61,7 +61,8 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 {
   NSMutableDictionary *info = [[NSMutableDictionary alloc] init];
   info[@"type"] = [FBElementTypeTransformer shortStringWithElementType:snapshot.elementType];
-  info[@"rawIdentifier"] = FBValueOrNull([snapshot.identifier isEqual:@""] ? nil : snapshot.identifier);
+  NSString *identifier = snapshot.identifier;
+  info[@"rawIdentifier"] = FBValueOrNull([identifier isEqual:@""] ? nil : identifier);
   info[@"name"] = FBValueOrNull(snapshot.wdName);
   info[@"value"] = FBValueOrNull(snapshot.wdValue);
   info[@"label"] = FBValueOrNull(snapshot.wdLabel);
@@ -106,7 +107,8 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   }
   if ([info count]) {
     info[@"type"] = [FBElementTypeTransformer shortStringWithElementType:snapshot.elementType];
-    info[@"rawIdentifier"] = FBValueOrNull([snapshot.identifier isEqual:@""] ? nil : snapshot.identifier);
+    NSString *identifier = snapshot.identifier;
+    info[@"rawIdentifier"] = FBValueOrNull([identifier isEqual:@""] ? nil : identifier);
     info[@"name"] = FBValueOrNull(snapshot.wdName);
   } else {
     return nil;

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -36,7 +36,8 @@ const CGFloat FBTapDuration = 0.01f;
 
 - (BOOL)fb_tapCoordinate:(CGPoint)relativeCoordinate error:(NSError **)error
 {
-  CGPoint hitPoint = CGPointMake(self.frame.origin.x + relativeCoordinate.x, self.frame.origin.y + relativeCoordinate.y);
+  CGPoint selfFrameOrigin = self.frame.origin;
+  CGPoint hitPoint = CGPointMake(selfFrameOrigin.x + relativeCoordinate.x, selfFrameOrigin.y + relativeCoordinate.y);
   if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
     /*
      Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -152,11 +152,12 @@
   if ([value isKindOfClass:[NSArray class]]) {
     textToType = [value componentsJoinedByString:@""];
   }
-  if (element.elementType == XCUIElementTypePickerWheel) {
+  XCUIElementType elementType = element.elementType;
+  if (elementType == XCUIElementTypePickerWheel) {
     [element adjustToPickerWheelValue:textToType];
     return FBResponseWithOK();
   }
-  if (element.elementType == XCUIElementTypeSlider) {
+  if (elementType == XCUIElementTypeSlider) {
     CGFloat sliderValue = textToType.floatValue;
     if (sliderValue < 0.0 || sliderValue > 1.0 ) {
       return FBResponseWithErrorFormat(@"Value of slider should be in 0..1 range");
@@ -300,8 +301,9 @@
   FBSession *session = request.session;
   FBElementCache *elementCache = session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
-  CGPoint startPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"fromX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"fromY"] doubleValue]));
-  CGPoint endPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"toX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"toY"] doubleValue]));
+  CGPoint selfFrameOrigin = element.frame.origin;
+  CGPoint startPoint = CGPointMake((CGFloat)(selfFrameOrigin.x + [request.arguments[@"fromX"] doubleValue]), (CGFloat)(selfFrameOrigin.y + [request.arguments[@"fromY"] doubleValue]));
+  CGPoint endPoint = CGPointMake((CGFloat)(selfFrameOrigin.x + [request.arguments[@"toX"] doubleValue]), (CGFloat)(selfFrameOrigin.y + [request.arguments[@"toY"] doubleValue]));
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
   BOOL shouldApplyOrientationWorkaround = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0");
   XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -95,8 +95,9 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
   NSArray<XCUIElement *> *staticTextList = [alert descendantsMatchingType:XCUIElementTypeStaticText].allElementsBoundByIndex;
   NSMutableArray<NSString *> *resultText = [NSMutableArray array];
   for (XCUIElement *staticText in staticTextList) {
-    if (staticText.wdLabel && staticText.isWDVisible) {
-      [resultText addObject:[NSString stringWithFormat:@"%@", staticText.wdLabel]];
+    NSString *label = staticText.wdLabel;
+    if (label && staticText.isWDVisible) {
+      [resultText addObject:[NSString stringWithFormat:@"%@", label]];
     }
   }
   if (resultText.count) {


### PR DESCRIPTION
The PR solves iOS 11 issues, which happen on iOS11 because of limited snapshots functionality. XCUIElement snapshot does not contain valid values even after **resolve** selector is invoked until the corresponding attribute has been explicitly read by calling _XCUIElementAttributes_ protocol property on XCUIElement instance. This makes snapshots pretty useless in iOS11. 
Also, there is one more thing to mention - each invocation of _XCUIElementAttributes_ protocol property creates a new call to the UI and slows down testing performance if the amount of such calls is  high. That is why I try to cache received values inside method calls where it is possible.

The PR is the basis for fixing xpath and predicate lookup in iOS 11.