### PR TITLE
Use dedicated screenshoting method for iOS 11

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -16,6 +16,11 @@
 #import "FBSpringboardApplication.h"
 
 #import "XCAXClient_iOS.h"
+#if defined(__has_include)
+  #if __has_include("XCTest/XCUIScreen.h")
+    #import "XCTest/XCUIScreen.h"
+  #endif
+#endif
 
 static const NSTimeInterval FBHomeButtonCoolOffTime = 1.;
 
@@ -38,6 +43,15 @@ static const NSTimeInterval FBHomeButtonCoolOffTime = 1.;
 
 - (NSData *)fb_screenshot
 {
+  NSData *result = nil;
+  #if defined(__has_include)
+    #if __has_include("XCTest/XCUIScreen.h")
+  result = XCUIScreen.mainScreen.screenshot.PNGRepresentation;
+    #endif
+  #endif
+  if (result) {
+    return result;
+  }
   return [[XCAXClient_iOS sharedClient] screenshotData];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIDevice+FBHelpers.m
@@ -15,6 +15,7 @@
 
 #import "FBSpringboardApplication.h"
 
+#import "FBMacros.h"
 #import "XCAXClient_iOS.h"
 #if defined(__has_include)
   #if __has_include("XCTest/XCUIScreen.h")
@@ -46,7 +47,9 @@ static const NSTimeInterval FBHomeButtonCoolOffTime = 1.;
   NSData *result = nil;
   #if defined(__has_include)
     #if __has_include("XCTest/XCUIScreen.h")
-  result = XCUIScreen.mainScreen.screenshot.PNGRepresentation;
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    result = [[[XCUIScreen mainScreen] screenshot] PNGRepresentation];
+  }
     #endif
   #endif
   if (result) {


### PR DESCRIPTION
The screenshot implementation based on XCAXClient_iOS is kind'a hacky and sometimes unstable (so we need to retry several times on Appium side or fall back to simctl in case of Simulator). And since iOS11 Apple finally added native support for making screenshots then why not to use it?