### PR TITLE
Use backspace-delete instead of just backspace for clear

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTyping.m
@@ -30,11 +30,13 @@
 - (BOOL)fb_clearTextWithError:(NSError **)error
 {
   NSUInteger preClearTextLength = 0;
+  NSData *encodedSequence = [@"\\u0008\\u007F" dataUsingEncoding:NSASCIIStringEncoding];
+  NSString *backspaceDeleteSequence = [[NSString alloc] initWithData:encodedSequence encoding:NSNonLossyASCIIStringEncoding];
   while ([self.value fb_visualLength] != preClearTextLength) {
     NSMutableString *textToType = @"".mutableCopy;
     preClearTextLength = [self.value fb_visualLength];
     for (NSUInteger i = 0 ; i < preClearTextLength ; i++) {
-      [textToType appendString:@"\b"];
+      [textToType appendString:backspaceDeleteSequence];
     }
     if (![self fb_typeText:textToType error:error]) {
       return NO;


### PR DESCRIPTION
We have had issues where the cursor begins in the middle of the text, so just entering a backspace never finishes.

Here instead we enter a backspace (`\u0008`, moving to the left of the cursor) and a delete (`\u007F`, moving to the right of the cursor) together, so the string is deleted in both directions.

The weird machinations is to combat the error "universal character name refers to a control character" which came from trying to enter the unicode sequence directly, take [from here](https://stackoverflow.com/a/17155938).