### PR TITLE
Fix FBFailureProofTestCaseTests

### DIFF
--- a/WebDriverAgentLib/Utilities/FBFailureProofTestCase.m
+++ b/WebDriverAgentLib/Utilities/FBFailureProofTestCase.m
@@ -26,6 +26,14 @@
   self.internalImplementation = (_XCTestCaseImplementation *)[FBXCTestCaseImplementationFailureHoldingProxy proxyWithXCTestCaseImplementation:self.internalImplementation];
 }
 
+- (void)recordFailureWithDescription:(NSString *)description
+                              inFile:(NSString *)filePath
+                              atLine:(NSUInteger)lineNumber
+                            expected:(BOOL)expected
+{
+  [self _enqueueFailureWithDescription:description inFile:filePath atLine:lineNumber expected:expected];
+}
+
 /**
  Private XCTestCase method used to block and tunnel failure messages
  */


### PR DESCRIPTION
Method signature has changed with Xcode 9.b4