### PR TITLE
Add a possibility to run multiple applications in scope of a single session

### DIFF
--- a/PrivateHeaders/XCTest/XCUIApplication.h
+++ b/PrivateHeaders/XCTest/XCUIApplication.h
@@ -34,9 +34,6 @@
 @property(readonly, nonatomic) UIInterfaceOrientation interfaceOrientation; //TODO tvos
 @property(readonly, nonatomic) BOOL running;
 @property(nonatomic) pid_t processID; // @synthesize processID=_processID;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED <= __IPHONE_10_0
-@property(nonatomic, readwrite) NSUInteger state; // @synthesize state=_state;
-#endif
 @property(readonly) XCAccessibilityElement *accessibilityElement;
 
 /*! DO NOT USE DIRECTLY! Please use fb_applicationWithPID instead */

--- a/PrivateHeaders/XCTest/XCUIApplication.h
+++ b/PrivateHeaders/XCTest/XCUIApplication.h
@@ -43,6 +43,8 @@
 + (instancetype)appWithPID:(pid_t)processID;
 /*! DO NOT USE DIRECTLY! Please use fb_applicationWithPID instead */
 + (instancetype)applicationWithPID:(pid_t)processID;
+/*! DO NOT USE DIRECTLY! Please use fb_activate instead */
+- (void)activate;
 
 - (void)dismissKeyboard;
 - (BOOL)setFauxCollectionViewCellsEnabled:(BOOL)arg1 error:(id *)arg2;

--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7139145C1DF01A12005896C2 /* NSExpressionFBFormatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7139145B1DF01A12005896C2 /* NSExpressionFBFormatTests.m */; };
 		713C6DCF1DDC772A00285B92 /* FBElementUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 713C6DCD1DDC772A00285B92 /* FBElementUtils.h */; };
 		713C6DD01DDC772A00285B92 /* FBElementUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 713C6DCE1DDC772A00285B92 /* FBElementUtils.m */; };
+		7152EB301F41F9960047EEFF /* FBSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7152EB2F1F41F9960047EEFF /* FBSessionTests.m */; };
 		71555A3D1DEC460A007D4A8B /* NSExpression+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */; };
 		71555A3E1DEC460A007D4A8B /* NSExpression+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */; };
 		716E0BCE1E917E810087A825 /* NSString+FBXMLSafeString.h in Headers */ = {isa = PBXBuildFile; fileRef = 716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */; };
@@ -409,6 +410,7 @@
 		713C6DCD1DDC772A00285B92 /* FBElementUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBElementUtils.h; sourceTree = "<group>"; };
 		713C6DCE1DDC772A00285B92 /* FBElementUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementUtils.m; sourceTree = "<group>"; };
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
+		7152EB2F1F41F9960047EEFF /* FBSessionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSessionTests.m; sourceTree = "<group>"; };
 		71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSExpression+FBFormat.h"; sourceTree = "<group>"; };
 		71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSExpression+FBFormat.m"; sourceTree = "<group>"; };
 		716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+FBXMLSafeString.h"; sourceTree = "<group>"; };
@@ -1062,6 +1064,7 @@
 				EE05BAF91D13003C00A3EB00 /* FBKeyboardTests.m */,
 				7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */,
 				EE55B3261D1D54CF003AAAEC /* FBScrollingTests.m */,
+				7152EB2F1F41F9960047EEFF /* FBSessionTests.m */,
 				EE26409A1D0EB5E8009BE6B0 /* FBTapTest.m */,
 				EE1E06DC1D1811C4007CF043 /* FBTestMacros.h */,
 				AD76723F1D6B826F00610457 /* FBTypingTest.m */,
@@ -1869,6 +1872,7 @@
 				EE55B3271D1D54CF003AAAEC /* FBScrollingTests.m in Sources */,
 				EE6A89371D0B35920083E92B /* FBFailureProofTestCaseTests.m in Sources */,
 				EE006EAD1EB99B15006900A4 /* FBElementVisibilityTests.m in Sources */,
+				7152EB301F41F9960047EEFF /* FBSessionTests.m in Sources */,
 				EE9B769A1CF799F400275851 /* FBAlertTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -31,12 +31,10 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
     return NO;
   }
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
-      return NO;
-    }
-  } else {
+  if (self.class.fb_hasMultiAppSupport) {
     [self fb_activate];
+  } else if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
+    return NO;
   }
   return YES;
 }

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -26,20 +26,17 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 
 - (BOOL)fb_deactivateWithDuration:(NSTimeInterval)duration error:(NSError **)error
 {
+  NSString *applicationIdentifier = self.label;
+  if(![[XCUIDevice sharedDevice] fb_goToHomescreenWithError:error]) {
+    return NO;
+  }
+  [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
   if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    NSString *applicationIdentifier = self.label;
-    if(![[XCUIDevice sharedDevice] fb_goToHomescreenWithError:error]) {
-      return NO;
-    }
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
     if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
       return NO;
     }
   } else {
-    XCUIApplication *previousApplication = self;
-    [[[XCUIApplication alloc] initPrivateWithPath:nil bundleID:@"com.apple.springboard"] fb_activate];
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
-    [previousApplication fb_activate];
+    [self fb_activate];
   }
   return YES;
 }

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -26,10 +26,15 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 - (BOOL)fb_deactivateWithDuration:(NSTimeInterval)duration error:(NSError **)error
 {
   NSString *applicationIdentifier = self.label;
+  XCUIApplication *previousApplication = self;
   if(![[XCUIDevice sharedDevice] fb_goToHomescreenWithError:error]) {
     return NO;
   }
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    [previousApplication activate];
+    return YES;
+  }
   if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
     return NO;
   }

--- a/WebDriverAgentLib/Commands/FBAlertViewCommands.m
+++ b/WebDriverAgentLib/Commands/FBAlertViewCommands.m
@@ -35,7 +35,7 @@
 + (id<FBResponsePayload>)handleAlertTextCommand:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  NSString *alertText = [FBAlert alertWithApplication:session.application].text;
+  NSString *alertText = [FBAlert alertWithApplication:session.activeApplication].text;
   if (!alertText) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);
   }
@@ -46,7 +46,7 @@
 {
   FBSession *session = request.session;
   NSString *name = request.arguments[@"name"];
-  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  FBAlert *alert = [FBAlert alertWithApplication:session.activeApplication];
   NSError *error;
 
   if (!alert.isPresent) {
@@ -66,7 +66,7 @@
 {
   FBSession *session = request.session;
   NSString *name = request.arguments[@"name"];
-  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  FBAlert *alert = [FBAlert alertWithApplication:session.activeApplication];
   NSError *error;
     
   if (!alert.isPresent) {
@@ -84,7 +84,7 @@
 
 + (id<FBResponsePayload>)handleGetAlertButtonsCommand:(FBRouteRequest *)request {
   FBSession *session = request.session;
-  FBAlert *alert = [FBAlert alertWithApplication:session.application];
+  FBAlert *alert = [FBAlert alertWithApplication:session.activeApplication];
 
   if (!alert.isPresent) {
     return FBResponseWithStatus(FBCommandStatusNoAlertPresent, nil);

--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -57,7 +57,7 @@
   NSNumber *requestedDuration = request.arguments[@"duration"];
   NSTimeInterval duration = (requestedDuration ? requestedDuration.doubleValue : 3.);
   NSError *error;
-  if (![request.session.application fb_deactivateWithDuration:duration error:&error]) {
+  if (![request.session.activeApplication fb_deactivateWithDuration:duration error:&error]) {
     return FBResponseWithError(error);
   }
   return FBResponseWithOK();
@@ -71,7 +71,7 @@
 
 + (id<FBResponsePayload>)handleDismissKeyboardCommand:(FBRouteRequest *)request
 {
-  [request.session.application dismissKeyboard];
+  [request.session.activeApplication dismissKeyboard];
   NSError *error;
   NSString *errorDescription = @"The keyboard cannot be dismissed. Try to dismiss it in the way supported by your application under test.";
   if ([UIDevice.currentDevice userInterfaceIdiom] == UIUserInterfaceIdiomPhone) {

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -36,7 +36,7 @@
 
 + (id<FBResponsePayload>)handleGetSourceCommand:(FBRouteRequest *)request
 {
-  FBApplication *application = request.session.application ?: [FBApplication fb_activeApplication];
+  FBApplication *application = request.session.activeApplication ?: [FBApplication fb_activeApplication];
   NSString *sourceType = request.parameters[@"format"];
   id result;
   if (!sourceType || [sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
@@ -58,7 +58,7 @@
 
 + (id<FBResponsePayload>)handleGetAccessibleSourceCommand:(FBRouteRequest *)request
 {
-  FBApplication *application = request.session.application ?: [FBApplication fb_activeApplication];
+  FBApplication *application = request.session.activeApplication ?: [FBApplication fb_activeApplication];
   return FBResponseWithObject(application.fb_accessibilityTree ?: @{});
 }
 

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -207,7 +207,7 @@
 + (id<FBResponsePayload>)handleDoubleTapCoordinate:(FBRouteRequest *)request
 {
   CGPoint doubleTapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  XCUICoordinate *doubleTapCoordinate = [self.class gestureCoordinateWithCoordinate:doubleTapPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *doubleTapCoordinate = [self.class gestureCoordinateWithCoordinate:doubleTapPoint application:request.session.activeApplication shouldApplyOrientationWorkaround:YES];
   [doubleTapCoordinate doubleTap];
   return FBResponseWithOK();
 }
@@ -231,7 +231,7 @@
 + (id<FBResponsePayload>)handleTouchAndHoldCoordinate:(FBRouteRequest *)request
 {
   CGPoint touchPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  XCUICoordinate *pressCoordinate = [self.class gestureCoordinateWithCoordinate:touchPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *pressCoordinate = [self.class gestureCoordinateWithCoordinate:touchPoint application:request.session.activeApplication shouldApplyOrientationWorkaround:YES];
   [pressCoordinate pressForDuration:[request.arguments[@"duration"] doubleValue]];
   return FBResponseWithOK();
 }
@@ -290,8 +290,8 @@
   CGPoint startPoint = CGPointMake((CGFloat)[request.arguments[@"fromX"] doubleValue], (CGFloat)[request.arguments[@"fromY"] doubleValue]);
   CGPoint endPoint = CGPointMake((CGFloat)[request.arguments[@"toX"] doubleValue], (CGFloat)[request.arguments[@"toY"] doubleValue]);
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
-  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:YES];
-  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.activeApplication shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.activeApplication shouldApplyOrientationWorkaround:YES];
   [startCoordinate pressForDuration:duration thenDragToCoordinate:endCoordinate];
   return FBResponseWithOK();
 }
@@ -305,8 +305,8 @@
   CGPoint endPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"toX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"toY"] doubleValue]));
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
   BOOL shouldApplyOrientationWorkaround = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0");
-  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
-  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
+  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.activeApplication shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
+  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.activeApplication shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
   [startCoordinate pressForDuration:duration thenDragToCoordinate:endCoordinate];
   return FBResponseWithOK();
 }
@@ -339,7 +339,7 @@
   CGPoint tapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
   if (nil == element) {
-    XCUICoordinate *tapCoordinate = [self.class gestureCoordinateWithCoordinate:tapPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+    XCUICoordinate *tapCoordinate = [self.class gestureCoordinateWithCoordinate:tapPoint application:request.session.activeApplication shouldApplyOrientationWorkaround:YES];
     [tapCoordinate tap];
   } else {
     NSError *error;
@@ -372,8 +372,8 @@
 
 + (id<FBResponsePayload>)handleGetWindowSize:(FBRouteRequest *)request
 {
-  CGRect frame = request.session.application.wdFrame;
-  CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, request.session.application.interfaceOrientation);
+  CGRect frame = request.session.activeApplication.wdFrame;
+  CGSize screenSize = FBAdjustDimensionsForApplication(frame.size, request.session.activeApplication.interfaceOrientation);
   return FBResponseWithStatus(FBCommandStatusNoError, @{
     @"width": @(screenSize.width),
     @"height": @(screenSize.height),

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -55,7 +55,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindElement:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  XCUIElement *element = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application];
+  XCUIElement *element = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.activeApplication];
   if (!element) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
@@ -65,7 +65,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindElements:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  NSArray *elements = [self.class elementsUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application
+  NSArray *elements = [self.class elementsUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.activeApplication
                     shouldReturnAfterFirstMatch:NO];
   return FBResponseWithCachedElements(elements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
 }

--- a/WebDriverAgentLib/Commands/FBOrientationCommands.m
+++ b/WebDriverAgentLib/Commands/FBOrientationCommands.m
@@ -50,13 +50,13 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
 + (id<FBResponsePayload>)handleGetOrientation:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  return FBResponseWithStatus(FBCommandStatusNoError, [self.class interfaceOrientationForApplication:session.application]);
+  return FBResponseWithStatus(FBCommandStatusNoError, [self.class interfaceOrientationForApplication:session.activeApplication]);
 }
 
 + (id<FBResponsePayload>)handleSetOrientation:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  if ([self.class setDeviceOrientation:request.arguments[@"orientation"] forApplication:session.application]) {
+  if ([self.class setDeviceOrientation:request.arguments[@"orientation"] forApplication:session.activeApplication]) {
     return FBResponseWithOK();
   }
   return FBResponseWithStatus(FBCommandStatusRotationNotAllowed, @"Unable To Rotate Device");
@@ -72,7 +72,7 @@ const struct FBWDOrientationValues FBWDOrientationValues = {
 + (id<FBResponsePayload>)handleSetRotation:(FBRouteRequest *)request
 {
     FBSession *session = request.session;
-    if ([self.class setDeviceRotation:request.arguments forApplication:session.application]) {
+    if ([self.class setDeviceRotation:request.arguments forApplication:session.activeApplication]) {
         return FBResponseWithOK();
     }
     return FBResponseWithStatus(FBCommandStatusRotationNotAllowed, [NSString stringWithFormat:@"Rotation not supported: %@", request.arguments[@"rotation"]]);

--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -32,6 +32,8 @@
     [[FBRoute POST:@"/session/apps/activate"] respondWithTarget:self action:@selector(handleSessionAppActivate:)],
     [[FBRoute POST:@"/session/apps/terminate"] respondWithTarget:self action:@selector(handleSessionAppTerminate:)],
     [[FBRoute GET:@"/session/apps/state"] respondWithTarget:self action:@selector(handleSessionAppState:)],
+    [[FBRoute GET:@"/session/apps/is_supported"] respondWithTarget:self action:@selector(handleSessionAppsSupported:)],
+    [[FBRoute GET:@"/session/apps/is_supported"].withoutSession respondWithTarget:self action:@selector(handleSessionAppsSupported:)],
     [[FBRoute GET:@""] respondWithTarget:self action:@selector(handleGetActiveSession:)],
     [[FBRoute DELETE:@""] respondWithTarget:self action:@selector(handleDeleteSession:)],
     [[FBRoute GET:@"/status"].withoutSession respondWithTarget:self action:@selector(handleGetStatus:)],
@@ -117,6 +119,11 @@
 {
   NSUInteger state = [request.session applicationStateWithBundleId:(id)request.arguments[@"bundleId"]];
   return FBResponseWithStatus(FBCommandStatusNoError, @{@"state": @(state)});
+}
+
++ (id<FBResponsePayload>)handleSessionAppsSupported:(FBRouteRequest *)request
+{
+  return FBResponseWithStatus(FBCommandStatusNoError, @{@"supported": @(FBSession.hasMultiAppSupport)});
 }
 
 + (id<FBResponsePayload>)handleGetActiveSession:(FBRouteRequest *)request

--- a/WebDriverAgentLib/FBSpringboardApplication.h
+++ b/WebDriverAgentLib/FBSpringboardApplication.h
@@ -9,9 +9,11 @@
 
 #import <WebDriverAgentLib/FBApplication.h>
 
-@interface FBSpringboardApplication : FBApplication
-
 NS_ASSUME_NONNULL_BEGIN
+
+static NSString *const SPRINGBOARD_BUNDLE_ID = @"com.apple.springboard";
+
+@interface FBSpringboardApplication : FBApplication
 
 /**
  @return FBApplication that is attached to SpringBoard

--- a/WebDriverAgentLib/FBSpringboardApplication.m
+++ b/WebDriverAgentLib/FBSpringboardApplication.m
@@ -29,7 +29,7 @@
   static FBSpringboardApplication *_springboardApp;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    _springboardApp = [[FBSpringboardApplication alloc] initPrivateWithPath:nil bundleID:@"com.apple.springboard"];
+    _springboardApp = [[FBSpringboardApplication alloc] initPrivateWithPath:nil bundleID:SPRINGBOARD_BUNDLE_ID];
   });
   [_springboardApp query];
   [_springboardApp resolve];

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -8,6 +8,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import "XCUIApplication.h"
 
 @class FBApplication;
 @class FBElementCache;
@@ -23,7 +24,7 @@ extern NSString *const FBApplicationCrashedException;
 @interface FBSession : NSObject
 
 /*! Application tested during that session */
-@property (nonatomic, strong, readonly) FBApplication *application;
+@property (nonatomic, strong, readonly) FBApplication *activeApplication;
 
 /*! Session's identifier */
 @property (nonatomic, copy, readonly) NSString *identifier;
@@ -59,6 +60,43 @@ extern NSString *const FBApplicationCrashedException;
  Kills application associated with that session and removes session
  */
 - (void)kill;
+
+/**
+ Launch an application with given bundle identifier in scope of current session.
+ !This method is only available since iOS 11
+ 
+ @param bundleIdentifier Valid bundle identifier of the application to be launched
+ */
+- (void)launchApplicationWithBundleId:(NSString *)bundleIdentifier;
+
+/**
+ Activate an application with given bundle identifier in scope of current session.
+ !This method is only available since iOS 11
+ 
+ @param bundleIdentifier Valid bundle identifier of the application to be activated
+ */
+- (void)activateApplicationWithBundleId:(NSString *)bundleIdentifier;
+
+/**
+ Terminate an application with the given bundle id. The application should be previously
+ executed by launchApplicationWithBundleId method or passed to the init method.
+ !This method is only available since iOS 11
+ 
+ @param bundleIdentifier Valid bundle identifier of the application to be terminated
+ @return Either YES if the app has been successfully terminated or NO if it was not running
+ */
+- (BOOL)terminateApplicationWithBundleId:(NSString *)bundleIdentifier;
+
+/**
+ Get the state of the particular application in scope of the current session.
+ !This method is only available since iOS 11
+ 
+ @param bundleIdentifier Valid bundle identifier of the application to get the state from
+ @return Application state as integer number. See
+         https://developer.apple.com/documentation/xctest/xcuiapplicationstate?language=objc
+         for more details on possible enum values
+ */
+- (NSUInteger)applicationStateWithBundleId:(NSString *)bundleIdentifier;
 
 @end
 

--- a/WebDriverAgentLib/Routing/FBSession.h
+++ b/WebDriverAgentLib/Routing/FBSession.h
@@ -63,16 +63,16 @@ extern NSString *const FBApplicationCrashedException;
 
 /**
  Launch an application with given bundle identifier in scope of current session.
- !This method is only available since iOS 11
- 
+ !This method is only available if hasMultiAppSupport returns true
+
  @param bundleIdentifier Valid bundle identifier of the application to be launched
  */
 - (void)launchApplicationWithBundleId:(NSString *)bundleIdentifier;
 
 /**
  Activate an application with given bundle identifier in scope of current session.
- !This method is only available since iOS 11
- 
+ !This method is only available if hasMultiAppSupport returns true
+
  @param bundleIdentifier Valid bundle identifier of the application to be activated
  */
 - (void)activateApplicationWithBundleId:(NSString *)bundleIdentifier;
@@ -80,8 +80,8 @@ extern NSString *const FBApplicationCrashedException;
 /**
  Terminate an application with the given bundle id. The application should be previously
  executed by launchApplicationWithBundleId method or passed to the init method.
- !This method is only available since iOS 11
- 
+ !This method is only available if hasMultiAppSupport returns true
+
  @param bundleIdentifier Valid bundle identifier of the application to be terminated
  @return Either YES if the app has been successfully terminated or NO if it was not running
  */
@@ -89,14 +89,19 @@ extern NSString *const FBApplicationCrashedException;
 
 /**
  Get the state of the particular application in scope of the current session.
- !This method is only available since iOS 11
- 
+ !This method is only available if hasMultiAppSupport returns true
+
  @param bundleIdentifier Valid bundle identifier of the application to get the state from
  @return Application state as integer number. See
          https://developer.apple.com/documentation/xctest/xcuiapplicationstate?language=objc
          for more details on possible enum values
  */
 - (NSUInteger)applicationStateWithBundleId:(NSString *)bundleIdentifier;
+
+/**
+ @return YES if the session has multi-application support (e. g. since Xcode9 SDK)
+ */
++ (BOOL)hasMultiAppSupport;
 
 @end
 

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -77,10 +77,11 @@ static FBSession *_activeSession;
 {
   FBSession *session = [FBSession new];
   session.identifier = [[NSUUID UUID] UUIDString];
-  session.testedApplicationBundleId = [application bundleID];
+  session.testedApplicationBundleId = nil;
   NSMutableDictionary *apps = [NSMutableDictionary dictionary];
   if (application) {
     [apps setObject:application forKey:application.bundleID];
+    session.testedApplicationBundleId = application.bundleID;
   }
   session.applications = apps.copy;
   session.elementCache = [FBElementCache new];
@@ -110,7 +111,7 @@ static FBSession *_activeSession;
   }
   if (testedApplication) {
     const BOOL testedApplicationIsActiveAndNotRunning = (application.processID == testedApplication.processID && !application.running);
-    if (testedApplicationIsActiveAndNotRunning && ![self.applications objectForKey:application.bundleID]) {
+    if (testedApplicationIsActiveAndNotRunning) {
       [[NSException exceptionWithName:FBApplicationCrashedException reason:@"Application is not running, possibly crashed" userInfo:nil] raise];
     }
   }

--- a/WebDriverAgentLib/Routing/FBSession.m
+++ b/WebDriverAgentLib/Routing/FBSession.m
@@ -146,6 +146,9 @@ static FBSession *_activeSession;
 
 - (void)launchApplicationWithBundleId:(NSString *)bundleIdentifier
 {
+  if (!self.class.hasMultiAppSupport) {
+    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'launch' method is not supported by the current iOS SDK" userInfo:@{}] raise];
+  }
   XCUIApplication *app = [self registerApplicationWithBundleId:bundleIdentifier];
   if (!app.running) {
     [app launch];
@@ -155,12 +158,18 @@ static FBSession *_activeSession;
 
 - (void)activateApplicationWithBundleId:(NSString *)bundleIdentifier
 {
+  if (!self.class.hasMultiAppSupport) {
+    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
+  }
   XCUIApplication *app = [self registerApplicationWithBundleId:bundleIdentifier];
   [app fb_activate];
 }
 
 - (BOOL)terminateApplicationWithBundleId:(NSString *)bundleIdentifier
 {
+  if (!self.class.hasMultiAppSupport) {
+    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'terminate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
+  }
   XCUIApplication *app = [self registerApplicationWithBundleId:bundleIdentifier];
   BOOL result = NO;
   if (app.running) {
@@ -173,11 +182,19 @@ static FBSession *_activeSession;
 
 - (NSUInteger)applicationStateWithBundleId:(NSString *)bundleIdentifier
 {
+  if (!self.class.hasMultiAppSupport) {
+    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'state' method is not supported by the current iOS SDK" userInfo:@{}] raise];
+  }
   XCUIApplication *app = [self.applications objectForKey:bundleIdentifier];
   if (!app) {
     app = [[XCUIApplication alloc] initPrivateWithPath:nil bundleID:bundleIdentifier];
   }
   return app.fb_state;
+}
+
++ (BOOL)hasMultiAppSupport
+{
+  return FBApplication.fb_hasMultiAppSupport;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -33,4 +33,6 @@ extern NSString *const FBApplicationMethodNotSupportedException;
 
 - (void)fb_activate;
 
++ (BOOL)fb_hasMultiAppSupport;
+
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -19,8 +19,18 @@
 
 @end
 
+/**
+ The exception happends if one tries to call application method,
+ which is not supported in the current iOS version
+ */
+extern NSString *const FBApplicationMethodNotSupportedException;
+
 @interface XCUIApplication (FBCompatibility)
 
 + (instancetype)fb_applicationWithPID:(pid_t)processID;
+
+- (NSUInteger)fb_state;
+
+- (void)fb_activate;
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -52,18 +52,22 @@ static dispatch_once_t onceActivate;
     FBCanUseActivate = [self respondsToSelector:@selector(activate)];
   });
   if (!FBCanUseActivate) {
-    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is only supported since iOS 11" userInfo:@{}] raise];
+    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
   }
   [self activate];
 }
 
 - (NSUInteger)fb_state
 {
-  id state = [self valueForKey:@"state"];
-  if (!state) {
-    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'state' method is only supported since iOS 11" userInfo:@{}] raise];
-  }
-  return [state intValue];
+  return [[self valueForKey:@"state"] intValue];
+}
+
++ (BOOL)fb_hasMultiAppSupport
+{
+  dispatch_once(&onceActivate, ^{
+    FBCanUseActivate = [self respondsToSelector:@selector(activate)];
+  });
+  return FBCanUseActivate;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -33,8 +33,6 @@ static BOOL FBShouldUseOldAppWithPIDSelector = NO;
 static dispatch_once_t onceAppWithPIDToken;
 static BOOL FBCanUseActivate = NO;
 static dispatch_once_t onceActivate;
-static BOOL FBCanUseState = NO;
-static dispatch_once_t onceState;
 @implementation XCUIApplication (FBCompatibility)
 
 + (instancetype)fb_applicationWithPID:(pid_t)processID
@@ -61,17 +59,11 @@ static dispatch_once_t onceState;
 
 - (NSUInteger)fb_state
 {
-  SEL stateSelector = NSSelectorFromString(@"state");
-  dispatch_once(&onceState, ^{
-    FBCanUseState = [self respondsToSelector:stateSelector];
-  });
-  if (!FBCanUseState) {
+  id state = [self valueForKey:@"state"];
+  if (!state) {
     [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'state' method is only supported since iOS 11" userInfo:@{}] raise];
   }
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-  return [[self performSelector:stateSelector] intValue];
-  #pragma clang diagnostic pop
+  return [state intValue];
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBSessionTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionTests.m
@@ -13,6 +13,7 @@
 #import "FBApplication.h"
 #import "FBMacros.h"
 #import "FBSession.h"
+#import "FBSpringboardApplication.h"
 #import "FBXCodeCompatibility.h"
 
 @interface FBSessionTests : FBIntegrationTestCase
@@ -20,8 +21,7 @@
 @end
 
 
-static NSString *const SETTINGS_APP_ID = @"com.apple.Preferences";
-static NSString *const SPRINGBOARD_APP_ID = @"com.apple.springboard";
+static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
 
 @implementation FBSessionTests
 
@@ -38,14 +38,14 @@ static NSString *const SPRINGBOARD_APP_ID = @"com.apple.springboard";
   FBApplication *testedApp = self.session.activeApplication;
   @try {
     XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
-    [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
-    XCTAssertEqualObjects(SETTINGS_APP_ID, self.session.activeApplication.bundleID);
-    XCTAssertEqual([self.session applicationStateWithBundleId:SETTINGS_APP_ID], 4);
+    [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
+    XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
+    XCTAssertEqual([self.session applicationStateWithBundleId:SETTINGS_BUNDLE_ID], 4);
     [self.session activateApplicationWithBundleId:testedApp.bundleID];
     XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
     XCTAssertEqual([self.session applicationStateWithBundleId:testedApp.bundleID], 4);
   } @catch (NSException *e) {
-    if (!SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
       @throw e;
     }
     XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
@@ -54,42 +54,54 @@ static NSString *const SPRINGBOARD_APP_ID = @"com.apple.springboard";
 
 - (void)testSettingsAppCanBeReopenedInScopeOfTheCurrentSession
 {
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    return;
+  @try {
+    FBApplication *testedApp = self.session.activeApplication;
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+    [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
+    [self.session terminateApplicationWithBundleId:SETTINGS_BUNDLE_ID];
+    XCTAssertEqualObjects(SPRINGBOARD_BUNDLE_ID, self.session.activeApplication.bundleID);
+    [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
+    XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
+  } @catch (NSException *e) {
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+      @throw e;
+    }
+    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
-  FBApplication *testedApp = self.session.activeApplication;
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
-  [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
-  [self.session terminateApplicationWithBundleId:SETTINGS_APP_ID];
-  XCTAssertEqualObjects(SPRINGBOARD_APP_ID, self.session.activeApplication.bundleID);
-  [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
-  XCTAssertEqualObjects(SETTINGS_APP_ID, self.session.activeApplication.bundleID);
 }
 
 - (void)testMainAppCanBeReactivatedInScopeOfTheCurrentSession
 {
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    return;
+  @try {
+    FBApplication *testedApp = self.session.activeApplication;
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+    [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
+    XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
+    [self.session activateApplicationWithBundleId:testedApp.bundleID];
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  } @catch (NSException *e) {
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+      @throw e;
+    }
+    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
-  FBApplication *testedApp = self.session.activeApplication;
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
-  [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
-  XCTAssertEqualObjects(SETTINGS_APP_ID, self.session.activeApplication.bundleID);
-  [self.session activateApplicationWithBundleId:testedApp.bundleID];
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
 }
 
 - (void)testMainAppCanBeRestartedInScopeOfTheCurrentSession
 {
-  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
-    return;
+  @try {
+    FBApplication *testedApp = self.session.activeApplication;
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+    [self.session terminateApplicationWithBundleId:testedApp.bundleID];
+    XCTAssertEqualObjects(SPRINGBOARD_BUNDLE_ID, self.session.activeApplication.bundleID);
+    [self.session launchApplicationWithBundleId:testedApp.bundleID];
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  } @catch (NSException *e) {
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+      @throw e;
+    }
+    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
-  FBApplication *testedApp = self.session.activeApplication;
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
-  [self.session terminateApplicationWithBundleId:testedApp.bundleID];
-  XCTAssertEqualObjects(SPRINGBOARD_APP_ID, self.session.activeApplication.bundleID);
-  [self.session launchApplicationWithBundleId:testedApp.bundleID];
-  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBSessionTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionTests.m
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+#import "FBApplication.h"
+#import "FBMacros.h"
+#import "FBSession.h"
+#import "FBXCodeCompatibility.h"
+
+@interface FBSessionTests : FBIntegrationTestCase
+@property (nonatomic) FBSession *session;
+@end
+
+
+static NSString *const SETTINGS_APP_ID = @"com.apple.Preferences";
+static NSString *const SPRINGBOARD_APP_ID = @"com.apple.springboard";
+
+@implementation FBSessionTests
+
+- (void)setUp
+{
+  [super setUp];
+  [self launchApplication];
+  
+  self.session = [FBSession sessionWithApplication:FBApplication.fb_activeApplication];
+}
+
+- (void)testSettingsAppCanBeOpenedInScopeOfTheCurrentSession
+{
+  FBApplication *testedApp = self.session.activeApplication;
+  @try {
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+    [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
+    XCTAssertEqualObjects(SETTINGS_APP_ID, self.session.activeApplication.bundleID);
+    XCTAssertEqual([self.session applicationStateWithBundleId:SETTINGS_APP_ID], 4);
+    [self.session activateApplicationWithBundleId:testedApp.bundleID];
+    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+    XCTAssertEqual([self.session applicationStateWithBundleId:testedApp.bundleID], 4);
+  } @catch (NSException *e) {
+    if (!SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+      @throw e;
+    }
+    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
+  }
+}
+
+- (void)testSettingsAppCanBeReopenedInScopeOfTheCurrentSession
+{
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return;
+  }
+  FBApplication *testedApp = self.session.activeApplication;
+  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
+  [self.session terminateApplicationWithBundleId:SETTINGS_APP_ID];
+  XCTAssertEqualObjects(SPRINGBOARD_APP_ID, self.session.activeApplication.bundleID);
+  [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
+  XCTAssertEqualObjects(SETTINGS_APP_ID, self.session.activeApplication.bundleID);
+}
+
+- (void)testMainAppCanBeReactivatedInScopeOfTheCurrentSession
+{
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return;
+  }
+  FBApplication *testedApp = self.session.activeApplication;
+  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  [self.session launchApplicationWithBundleId:SETTINGS_APP_ID];
+  XCTAssertEqualObjects(SETTINGS_APP_ID, self.session.activeApplication.bundleID);
+  [self.session activateApplicationWithBundleId:testedApp.bundleID];
+  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+}
+
+- (void)testMainAppCanBeRestartedInScopeOfTheCurrentSession
+{
+  if (SYSTEM_VERSION_LESS_THAN(@"11.0")) {
+    return;
+  }
+  FBApplication *testedApp = self.session.activeApplication;
+  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+  [self.session terminateApplicationWithBundleId:testedApp.bundleID];
+  XCTAssertEqualObjects(SPRINGBOARD_APP_ID, self.session.activeApplication.bundleID);
+  [self.session launchApplicationWithBundleId:testedApp.bundleID];
+  XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationTests/FBSessionTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBSessionTests.m
@@ -29,15 +29,14 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
 {
   [super setUp];
   [self launchApplication];
-  
+
   self.session = [FBSession sessionWithApplication:FBApplication.fb_activeApplication];
 }
 
 - (void)testSettingsAppCanBeOpenedInScopeOfTheCurrentSession
 {
-  FBApplication *testedApp = self.session.activeApplication;
+  FBApplication *testedApp = FBApplication.fb_activeApplication;
   @try {
-    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
     [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
     XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
     XCTAssertEqual([self.session applicationStateWithBundleId:SETTINGS_BUNDLE_ID], 4);
@@ -45,62 +44,54 @@ static NSString *const SETTINGS_BUNDLE_ID = @"com.apple.Preferences";
     XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
     XCTAssertEqual([self.session applicationStateWithBundleId:testedApp.bundleID], 4);
   } @catch (NSException *e) {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (![e.name isEqualToString:FBApplicationMethodNotSupportedException]) {
       @throw e;
     }
-    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
 }
 
 - (void)testSettingsAppCanBeReopenedInScopeOfTheCurrentSession
 {
   @try {
-    FBApplication *testedApp = self.session.activeApplication;
-    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
     [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
     [self.session terminateApplicationWithBundleId:SETTINGS_BUNDLE_ID];
     XCTAssertEqualObjects(SPRINGBOARD_BUNDLE_ID, self.session.activeApplication.bundleID);
     [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
     XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
   } @catch (NSException *e) {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (![e.name isEqualToString:FBApplicationMethodNotSupportedException]) {
       @throw e;
     }
-    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
 }
 
 - (void)testMainAppCanBeReactivatedInScopeOfTheCurrentSession
 {
+  FBApplication *testedApp = FBApplication.fb_activeApplication;
   @try {
-    FBApplication *testedApp = self.session.activeApplication;
-    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
     [self.session launchApplicationWithBundleId:SETTINGS_BUNDLE_ID];
     XCTAssertEqualObjects(SETTINGS_BUNDLE_ID, self.session.activeApplication.bundleID);
     [self.session activateApplicationWithBundleId:testedApp.bundleID];
     XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
   } @catch (NSException *e) {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (![e.name isEqualToString:FBApplicationMethodNotSupportedException]) {
       @throw e;
     }
-    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
 }
 
 - (void)testMainAppCanBeRestartedInScopeOfTheCurrentSession
 {
+  FBApplication *testedApp = FBApplication.fb_activeApplication;
   @try {
-    FBApplication *testedApp = self.session.activeApplication;
-    XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
     [self.session terminateApplicationWithBundleId:testedApp.bundleID];
     XCTAssertEqualObjects(SPRINGBOARD_BUNDLE_ID, self.session.activeApplication.bundleID);
     [self.session launchApplicationWithBundleId:testedApp.bundleID];
     XCTAssertEqualObjects(testedApp.bundleID, self.session.activeApplication.bundleID);
   } @catch (NSException *e) {
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"11.0")) {
+    if (![e.name isEqualToString:FBApplicationMethodNotSupportedException]) {
       @throw e;
     }
-    XCTAssertEqualObjects(e.name, FBApplicationMethodNotSupportedException);
   }
 }
 

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
@@ -11,4 +11,5 @@
 
 @interface FBApplicationDouble : NSObject
 @property (nonatomic, assign, readonly) BOOL didTerminate;
+@property (nonatomic) NSString* bundleID;
 @end

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
@@ -15,6 +15,15 @@
 
 @implementation FBApplicationDouble
 
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    self.bundleID = @"some.bundle.identifier";
+  }
+  return self;
+}
+
 - (void)terminate
 {
   self.didTerminate = YES;


### PR DESCRIPTION
It is sometimes necessary to interact with some helper apps while main application is running, for example Settings or Calendar. Xcode9 SDK introduces a possibility to handle multiple apps in scope of a single test session, activate, terminate and switch between them. 
Also, I've added a possibility to stop the application under test and then start it when needed, which might be useful for functional testing.