### PR TITLE
Update deprecated openurl method

### DIFF
--- a/WebDriverAgentLib/Commands/FBSessionCommands.m
+++ b/WebDriverAgentLib/Commands/FBSessionCommands.m
@@ -53,6 +53,10 @@
       [NSString stringWithFormat:@"%@ is not a valid URL", url]
     );
   }
+  if ([[UIApplication sharedApplication] respondsToSelector:@selector(openURL:options:completionHandler:)]) {
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+    return FBResponseWithOK();
+  }
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (![[UIApplication sharedApplication] openURL:url]) {


### PR DESCRIPTION
`- (BOOL)openURL:(NSURL*)url` is marked as deprecated since iOS 10. So we use the updated one whenever possible.