### PR TITLE
Improve xpath lookup performance by analyzing the query string

### DIFF
--- a/WebDriverAgentLib/Utilities/FBXPath-Private.h
+++ b/WebDriverAgentLib/Utilities/FBXPath-Private.h
@@ -19,9 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
  @param root the root element to execute XPath query for
  @param writer the correspondig libxml2 writer object
  @param elementStore an empty dictionary to store indexes mapping or nil if no mappings should be stored
+ @param query Optional XPath query value. By analyzing this query we may optimize the lookup speed.
  @return zero if the method has completed successfully
  */
-+ (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore;
++ (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore query:(nullable NSString*)query;
 
 /**
  Gets the list of matched snapshots from xmllib2-compatible xmlNodeSetPtr structure

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -18,7 +18,7 @@
 #import "NSString+FBXMLSafeString.h"
 
 
-@interface ElementAttribute : NSObject
+@interface FBElementAttribute : NSObject
 
 @property (nonatomic, readonly) id<FBElement> element;
 
@@ -32,51 +32,51 @@
 
 @end
 
-@interface TypeAttribute : ElementAttribute
+@interface FBTypeAttribute : FBElementAttribute
 
 @end
 
-@interface ValueAttribute : ElementAttribute
+@interface FBValueAttribute : FBElementAttribute
 
 @end
 
-@interface NameAttribute : ElementAttribute
+@interface FBNameAttribute : FBElementAttribute
 
 @end
 
-@interface LabelAttribute : ElementAttribute
+@interface FBLabelAttribute : FBElementAttribute
 
 @end
 
-@interface EnabledAttribute : ElementAttribute
+@interface FBEnabledAttribute : FBElementAttribute
 
 @end
 
-@interface VisibleAttribute : ElementAttribute
+@interface FBVisibleAttribute : FBElementAttribute
 
 @end
 
-@interface DimensionAttribute : ElementAttribute
+@interface FBDimensionAttribute : FBElementAttribute
 
 @end
 
-@interface XAttribute : DimensionAttribute
+@interface FBXAttribute : FBDimensionAttribute
 
 @end
 
-@interface YAttribute : DimensionAttribute
+@interface FBYAttribute : FBDimensionAttribute
 
 @end
 
-@interface WidthAttribute : DimensionAttribute
+@interface FBWidthAttribute : FBDimensionAttribute
 
 @end
 
-@interface HeigthAttribute : DimensionAttribute
+@interface FBHeightAttribute : FBDimensionAttribute
 
 @end
 
-@interface IndexAttribute : ElementAttribute
+@interface FBIndexAttribute : FBElementAttribute
 
 @property (nonatomic, nonnull, readonly) NSString* indexValue;
 
@@ -182,10 +182,10 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 {
   if ([query rangeOfString:@"[^\\w@]@\\*[^\\w]" options:NSRegularExpressionSearch].location != NSNotFound) {
     // read all element attributes if 'star' attribute name pattern is used in xpath query
-    return [NSSet setWithArray:ElementAttribute.supportedAttributes];
+    return [NSSet setWithArray:FBElementAttribute.supportedAttributes];
   }
   NSMutableSet<Class> *result = [NSMutableSet set];
-  for (Class attributeCls in ElementAttribute.supportedAttributes) {
+  for (Class attributeCls in FBElementAttribute.supportedAttributes) {
     if ([query rangeOfString:[NSString stringWithFormat:@"[^\\w@]@%@[^\\w]", [attributeCls name]] options:NSRegularExpressionSearch].location != NSNotFound) {
       [result addObject:attributeCls];
     }
@@ -281,7 +281,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 + (int)recordElementAttributes:(xmlTextWriterPtr)writer forElement:(XCElementSnapshot *)element indexPath:(nullable NSString *)indexPath includedAttributes:(nullable NSSet<Class> *)includedAttributes
 {
-  for (Class attributeCls in ElementAttribute.supportedAttributes) {
+  for (Class attributeCls in FBElementAttribute.supportedAttributes) {
     // include all supported attributes by default unless enumerated explicitly
     if (includedAttributes && ![includedAttributes containsObject:attributeCls]) {
       continue;
@@ -294,7 +294,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
   if (nil != indexPath) {
     // index path is the special case
-    return [[[IndexAttribute alloc] initWithValue:indexPath] recordWithWriter:writer];
+    return [[[FBIndexAttribute alloc] initWithValue:indexPath] recordWithWriter:writer];
   }
   return 0;
 }
@@ -338,7 +338,9 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 @end
 
 
-@implementation ElementAttribute
+static NSString *const FBAbstractMethodInvocationException = @"AbstractMethodInvocationException";
+
+@implementation FBElementAttribute
 
 - (instancetype)initWithElement:(id<FBElement>)element
 {
@@ -351,14 +353,14 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 + (NSString *)name
 {
-  // Override this method in subclasses
-  return @"";
+  NSString *errMsg = [NSString stringWithFormat:@"The asbtract method +(NSString *)name is expected to be overriden by %@", NSStringFromClass(self.class)];
+  @throw [NSException exceptionWithName:FBAbstractMethodInvocationException reason:errMsg userInfo:nil];
 }
 
 - (NSString *)value
 {
-  // Override this method in subclasses
-  return nil;
+  NSString *errMsg = [NSString stringWithFormat:@"The asbtract method -(NSString *)value is expected to be overriden by %@", NSStringFromClass(self.class)];
+  @throw [NSException exceptionWithName:FBAbstractMethodInvocationException reason:errMsg userInfo:nil];
 }
 
 - (int)recordWithWriter:(xmlTextWriterPtr)writer
@@ -378,21 +380,21 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 {
   // The list of attributes to be written for each XML node
   // The enumeration order does matter here
-  return @[TypeAttribute.class,
-           ValueAttribute.class,
-           NameAttribute.class,
-           LabelAttribute.class,
-           EnabledAttribute.class,
-           VisibleAttribute.class,
-           XAttribute.class,
-           YAttribute.class,
-           WidthAttribute.class,
-           HeigthAttribute.class];
+  return @[FBTypeAttribute.class,
+           FBValueAttribute.class,
+           FBNameAttribute.class,
+           FBLabelAttribute.class,
+           FBEnabledAttribute.class,
+           FBVisibleAttribute.class,
+           FBXAttribute.class,
+           FBYAttribute.class,
+           FBWidthAttribute.class,
+           FBHeightAttribute.class];
 }
 
 @end
 
-@implementation TypeAttribute
+@implementation FBTypeAttribute
 
 + (NSString *)name
 {
@@ -406,7 +408,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation ValueAttribute : ElementAttribute
+@implementation FBValueAttribute
 
 + (NSString *)name
 {
@@ -426,7 +428,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation NameAttribute : ElementAttribute
+@implementation FBNameAttribute
 
 + (NSString *)name
 {
@@ -440,7 +442,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation LabelAttribute : ElementAttribute
+@implementation FBLabelAttribute
 
 + (NSString *)name
 {
@@ -454,7 +456,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation EnabledAttribute : ElementAttribute
+@implementation FBEnabledAttribute
 
 + (NSString *)name
 {
@@ -468,7 +470,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation VisibleAttribute : ElementAttribute
+@implementation FBVisibleAttribute
 
 + (NSString *)name
 {
@@ -482,7 +484,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation DimensionAttribute : ElementAttribute
+@implementation FBDimensionAttribute
 
 - (NSString *)value
 {
@@ -491,7 +493,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation XAttribute : DimensionAttribute
+@implementation FBXAttribute
 
 + (NSString *)name
 {
@@ -500,7 +502,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation YAttribute : DimensionAttribute
+@implementation FBYAttribute
 
 + (NSString *)name
 {
@@ -509,7 +511,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation WidthAttribute : DimensionAttribute
+@implementation FBWidthAttribute
 
 + (NSString *)name
 {
@@ -518,7 +520,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation HeigthAttribute : DimensionAttribute
+@implementation FBHeightAttribute
 
 + (NSString *)name
 {
@@ -527,7 +529,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 @end
 
-@implementation IndexAttribute : ElementAttribute
+@implementation FBIndexAttribute
 
 - (instancetype)initWithValue:(NSString *)value
 {

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -180,13 +180,13 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 + (NSSet<Class> *)elementAttributesWithXPathQuery:(NSString *)query
 {
-  if ([query rangeOfString:@"@\\*\\b" options:NSRegularExpressionSearch].location != NSNotFound) {
+  if ([query rangeOfString:@"[^\\w@]@\\*[^\\w]" options:NSRegularExpressionSearch].location != NSNotFound) {
     // read all element attributes if 'star' attribute name pattern is used in xpath query
     return [NSSet setWithArray:ElementAttribute.supportedAttributes];
   }
   NSMutableSet<Class> *result = [NSMutableSet set];
   for (Class attributeCls in ElementAttribute.supportedAttributes) {
-    if ([query rangeOfString:[NSString stringWithFormat:@"@%@\\b", [attributeCls name]] options:NSRegularExpressionSearch].location != NSNotFound) {
+    if ([query rangeOfString:[NSString stringWithFormat:@"[^\\w@]@%@[^\\w]", [attributeCls name]] options:NSRegularExpressionSearch].location != NSNotFound) {
       [result addObject:attributeCls];
     }
   }

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -17,6 +17,74 @@
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "NSString+FBXMLSafeString.h"
 
+
+@interface ElementAttribute : NSObject
+
+@property (nonatomic, readonly) id<FBElement> element;
+
++ (nonnull NSString *)name;
+- (nullable NSString *)value;
+
+- (instancetype)initWithElement:(id<FBElement>)element;
+- (int)recordWithWriter:(xmlTextWriterPtr)writer;
+
++ (NSArray<Class> *)supportedAttributes;
+
+@end
+
+@interface TypeAttribute : ElementAttribute
+
+@end
+
+@interface ValueAttribute : ElementAttribute
+
+@end
+
+@interface NameAttribute : ElementAttribute
+
+@end
+
+@interface LabelAttribute : ElementAttribute
+
+@end
+
+@interface EnabledAttribute : ElementAttribute
+
+@end
+
+@interface VisibleAttribute : ElementAttribute
+
+@end
+
+@interface DimensionAttribute : ElementAttribute
+
+@end
+
+@interface XAttribute : DimensionAttribute
+
+@end
+
+@interface YAttribute : DimensionAttribute
+
+@end
+
+@interface WidthAttribute : DimensionAttribute
+
+@end
+
+@interface HeigthAttribute : DimensionAttribute
+
+@end
+
+@interface IndexAttribute : ElementAttribute
+
+@property (nonatomic, nonnull, readonly) NSString* indexValue;
+
+- (instancetype)initWithValue:(NSString *)value;
+
+@end
+
+
 const static char *_UTF8Encoding = "UTF-8";
 
 static NSString *const kXMLIndexPathKey = @"private_indexPath";
@@ -36,7 +104,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 {
   xmlDocPtr doc;
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
-  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:nil];
+  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:nil query:nil];
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
@@ -61,7 +129,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     return nil;
   }
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
-  int rc = [FBXPath getSnapshotAsXML:root writer:writer elementStore:elementStore];
+  int rc = [FBXPath getSnapshotAsXML:root writer:writer elementStore:elementStore query:xpathQuery];
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
@@ -110,14 +178,28 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   return matchingSnapshots;
 }
 
++ (NSSet<Class> *)elementAttributesWithXPathQuery:(NSString *)query
+{
+  NSMutableSet<Class> *result = [NSMutableSet set];
+  for (Class attributeCls in ElementAttribute.supportedAttributes) {
+    if ([query rangeOfString:[NSString stringWithFormat:@"@%@\\b", [attributeCls name]] options:NSRegularExpressionSearch].location != NSNotFound) {
+      [result addObject:attributeCls];
+    }
+  }
+  return result.copy;
+}
+
 + (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore
+                  query:(nullable NSString*)query
 {
   int rc = xmlTextWriterStartDocument(writer, NULL, _UTF8Encoding, NULL);
   if (rc < 0) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterStartDocument. Error code: %d", rc];
     return rc;
   }
-  rc = [FBXPath generateXMLPresentation:root indexPath:(elementStore != nil ? topNodeIndexPath : nil) elementStore:elementStore writer:writer];
+  // Trying to be smart here and only including attributes, that were asked in the query, to the resulting document.
+  // This may speed up the lookup significantly in some cases
+  rc = [FBXPath generateXMLPresentation:root indexPath:(elementStore != nil ? topNodeIndexPath : nil) elementStore:elementStore includedAttributes:(query == nil ? nil : [self.class elementAttributesWithXPathQuery:query]) writer:writer];
   if (rc < 0) {
     [FBLogger log:@"Failed to generate XML presentation of a screen element"];
     return rc;
@@ -194,74 +276,27 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   return [self.class xmlCharPtrForInput:[safeString cStringUsingEncoding:NSUTF8StringEncoding]];
 }
 
-+ (int)recordElementAttributes:(xmlTextWriterPtr)writer forElement:(XCElementSnapshot *)element indexPath:(nullable NSString *)indexPath
++ (int)recordElementAttributes:(xmlTextWriterPtr)writer forElement:(XCElementSnapshot *)element indexPath:(nullable NSString *)indexPath includedAttributes:(nullable NSSet<Class> *)includedAttributes
 {
-  int rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "type", [self.class safeXmlStringWithString:element.wdType]);
-  if (rc < 0) {
-    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(type='%@'). Error code: %d", element.wdType, rc];
-    return rc;
-  }
-  if (element.wdValue) {
-    id value = element.wdValue;
-    NSString *stringValue;
-    if ([value isKindOfClass:[NSValue class]]) {
-      stringValue = [value stringValue];
-    } else if ([value isKindOfClass:[NSString class]]) {
-      stringValue = value;
-    } else {
-      stringValue = [value description];
+  for (Class attributeCls in ElementAttribute.supportedAttributes) {
+    // include all supported attributes by default unless enumerated explicitly
+    if (includedAttributes && ![includedAttributes containsObject:attributeCls]) {
+      continue;
     }
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "value", [self.class safeXmlStringWithString:stringValue]);
+    int rc = [[[attributeCls alloc] initWithElement:element] recordWithWriter:writer];
     if (rc < 0) {
-      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(value='%@'). Error code: %d", stringValue, rc];
-      return rc;
-    }
-  }
-  if (element.wdName) {
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "name", [self.class safeXmlStringWithString:element.wdName]);
-    if (rc < 0) {
-      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(name='%@'). Error code: %d", element.wdName, rc];
-      return rc;
-    }
-  }
-  if (element.wdLabel) {
-    rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "label", [self.class safeXmlStringWithString:element.wdLabel]);
-    if (rc < 0) {
-      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(label='%@'). Error code: %d", element.wdLabel, rc];
-      return rc;
-    }
-  }
-  rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "enabled", element.wdEnabled ? BAD_CAST "true" : BAD_CAST "false");
-  if (rc < 0) {
-    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(wdEnabled). Error code: %d", rc];
-    return rc;
-  }
-  rc = xmlTextWriterWriteAttribute(writer, BAD_CAST "visible", element.wdVisible ? BAD_CAST "true" : BAD_CAST "false");
-  if (rc < 0) {
-    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(wdVisible). Error code: %d", rc];
-    return rc;
-  }
-  for (NSString *attrName in @[@"x", @"y", @"width", @"height"]) {
-    rc = xmlTextWriterWriteAttribute(writer, [self.class safeXmlStringWithString:attrName],
-                                     [self.class safeXmlStringWithString:[element.wdRect[attrName] stringValue]]);
-    if (rc < 0) {
-      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(%@). Error code: %d", attrName, rc];
       return rc;
     }
   }
 
   if (nil != indexPath) {
-    rc = xmlTextWriterWriteAttribute(writer, [self.class safeXmlStringWithString:kXMLIndexPathKey], [self.class safeXmlStringWithString:indexPath]);
-    if (rc < 0) {
-      [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(indexPath='%@'). Error code: %d", indexPath, rc];
-      return rc;
-    }
+    // index path is the special case
+    return [[[IndexAttribute alloc] initWithValue:indexPath] recordWithWriter:writer];
   }
-
   return 0;
 }
 
-+ (int)generateXMLPresentation:(XCElementSnapshot *)root indexPath:(nullable NSString *)indexPath elementStore:(nullable NSMutableDictionary *)elementStore writer:(xmlTextWriterPtr)writer
++ (int)generateXMLPresentation:(XCElementSnapshot *)root indexPath:(nullable NSString *)indexPath elementStore:(nullable NSMutableDictionary *)elementStore includedAttributes:(nullable NSSet<Class> *)includedAttributes writer:(xmlTextWriterPtr)writer
 {
   NSAssert((indexPath == nil && elementStore == nil) || (indexPath != nil && elementStore != nil), @"Either both or none of indexPath and elementStore arguments should be equal to nil", nil);
 
@@ -271,7 +306,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     return rc;
   }
 
-  rc = [FBXPath recordElementAttributes:writer forElement:root indexPath:indexPath];
+  rc = [FBXPath recordElementAttributes:writer forElement:root indexPath:indexPath includedAttributes:includedAttributes];
   if (rc < 0) {
     return rc;
   }
@@ -283,7 +318,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     if (elementStore != nil && newIndexPath != nil) {
       elementStore[newIndexPath] = childSnapshot;
     }
-    rc = [self generateXMLPresentation:childSnapshot indexPath:newIndexPath elementStore:elementStore writer:writer];
+    rc = [self generateXMLPresentation:childSnapshot indexPath:newIndexPath elementStore:elementStore includedAttributes:includedAttributes writer:writer];
     if (rc < 0) {
       return rc;
     }
@@ -298,3 +333,219 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 }
 
 @end
+
+
+@implementation ElementAttribute
+
+- (instancetype)initWithElement:(id<FBElement>)element
+{
+  self = [super init];
+  if (self) {
+    _element = element;
+  }
+  return self;
+}
+
++ (NSString *)name
+{
+  // Override this method in subclasses
+  return @"";
+}
+
+- (NSString *)value
+{
+  // Override this method in subclasses
+  return nil;
+}
+
+- (int)recordWithWriter:(xmlTextWriterPtr)writer
+{
+  if (nil == self.value) {
+    // Skip the attribute if the value equals to nil
+    return 0;
+  }
+  int rc = xmlTextWriterWriteAttribute(writer, [FBXPath safeXmlStringWithString:[self.class name]], [FBXPath safeXmlStringWithString:self.value]);
+  if (rc < 0) {
+    [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterWriteAttribute(%@='%@'). Error code: %d", [self.class name], self.value, rc];
+  }
+  return rc;
+}
+
++ (NSArray<Class> *)supportedAttributes
+{
+  // The list of attributes to be written for each XML node
+  // The enumeration order does matter here
+  return @[TypeAttribute.class,
+           ValueAttribute.class,
+           NameAttribute.class,
+           LabelAttribute.class,
+           EnabledAttribute.class,
+           VisibleAttribute.class,
+           XAttribute.class,
+           YAttribute.class,
+           WidthAttribute.class,
+           HeigthAttribute.class];
+}
+
+@end
+
+@implementation TypeAttribute
+
++ (NSString *)name
+{
+  return @"type";
+}
+
+- (NSString *)value
+{
+  return self.element.wdType;
+}
+
+@end
+
+@implementation ValueAttribute : ElementAttribute
+
++ (NSString *)name
+{
+  return @"value";
+}
+
+- (NSString *)value
+{
+  id idValue = self.element.wdValue;
+  if ([idValue isKindOfClass:[NSValue class]]) {
+    return [idValue stringValue];
+  } else if ([idValue isKindOfClass:[NSString class]]) {
+    return idValue;
+  }
+  return [idValue description];
+}
+
+@end
+
+@implementation NameAttribute : ElementAttribute
+
++ (NSString *)name
+{
+  return @"name";
+}
+
+- (NSString *)value
+{
+  return self.element.wdName;
+}
+
+@end
+
+@implementation LabelAttribute : ElementAttribute
+
++ (NSString *)name
+{
+  return @"label";
+}
+
+- (NSString *)value
+{
+  return self.element.wdLabel;
+}
+
+@end
+
+@implementation EnabledAttribute : ElementAttribute
+
++ (NSString *)name
+{
+  return @"enabled";
+}
+
+- (NSString *)value
+{
+  return self.element.wdEnabled ? @"true" : @"false";
+}
+
+@end
+
+@implementation VisibleAttribute : ElementAttribute
+
++ (NSString *)name
+{
+  return @"visible";
+}
+
+- (NSString *)value
+{
+  return self.element.wdVisible ? @"true" : @"false";
+}
+
+@end
+
+@implementation DimensionAttribute : ElementAttribute
+
+- (NSString *)value
+{
+  return [NSString stringWithFormat:@"%@", [self.element.wdRect objectForKey:[self.class name]]];
+}
+
+@end
+
+@implementation XAttribute : DimensionAttribute
+
++ (NSString *)name
+{
+  return @"x";
+}
+
+@end
+
+@implementation YAttribute : DimensionAttribute
+
++ (NSString *)name
+{
+  return @"y";
+}
+
+@end
+
+@implementation WidthAttribute : DimensionAttribute
+
++ (NSString *)name
+{
+  return @"width";
+}
+
+@end
+
+@implementation HeigthAttribute : DimensionAttribute
+
++ (NSString *)name
+{
+  return @"height";
+}
+
+@end
+
+@implementation IndexAttribute : ElementAttribute
+
+- (instancetype)initWithValue:(NSString *)value
+{
+  self = [super initWithElement:nil];
+  if (self) {
+    _indexValue = value;
+  }
+  return self;
+}
+
++ (NSString *)name
+{
+  return kXMLIndexPathKey;
+}
+
+- (NSString *)value
+{
+  return self.indexValue;
+}
+
+@end
+
+
+

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -193,8 +193,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   return result.copy;
 }
 
-+ (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore
-                  query:(nullable NSString*)query
++ (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore query:(nullable NSString*)query
 {
   int rc = xmlTextWriterStartDocument(writer, NULL, _UTF8Encoding, NULL);
   if (rc < 0) {

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -180,6 +180,10 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 
 + (NSSet<Class> *)elementAttributesWithXPathQuery:(NSString *)query
 {
+  if ([query rangeOfString:@"@\\*\\b" options:NSRegularExpressionSearch].location != NSNotFound) {
+    // read all element attributes if 'star' attribute name pattern is used in xpath query
+    return [NSSet setWithArray:ElementAttribute.supportedAttributes];
+  }
   NSMutableSet<Class> *result = [NSMutableSet set];
   for (Class attributeCls in ElementAttribute.supportedAttributes) {
     if ([query rangeOfString:[NSString stringWithFormat:@"@%@\\b", [attributeCls name]] options:NSRegularExpressionSearch].location != NSNotFound) {

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -27,7 +27,7 @@
   XCUIElementDouble *root = [XCUIElementDouble new];
   int buffersize;
   xmlChar *xmlbuff;
-  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:elementStore];
+  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:elementStore query:nil];
   if (0 == rc) {
     xmlDocDumpFormatMemory(doc, &xmlbuff, &buffersize, 1);
   }
@@ -49,14 +49,15 @@
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   XCUIElementDouble *root = [XCUIElementDouble new];
-  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:elementStore];
+  NSString *query = [NSString stringWithFormat:@"//%@", root.wdType];
+  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:elementStore query:query];
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
     XCTAssertEqual(rc, 0);
   }
 
-  xmlXPathObjectPtr queryResult = [FBXPath evaluate:@"//XCUIElementTypeOther" document:doc];
+  xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc];
   if (NULL == queryResult) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);


### PR DESCRIPTION
Reading element attributes is very expensive operation from performance point of view. The current algorithm requires to read all attributes for each accessibility element, which is going to be included into the xml document, where xpath lookup is going to be performed. This patch adds a bit more selective logic to this process, so we only read attributes, which are actually present in the client query.

I tried the patch with my local framework and performance improvement is sometimes more than 3x depending on the actual elements count in the tree (especially when we don't need to explicitly use **visible** attribute, which is the most expensive one to calculate, in the query).