### PR TITLE
Add a possibility to use containingPredicate: selector in class chain queries

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.h
@@ -30,8 +30,11 @@ extern NSString *const FBClassChainQueryParseException;
  XCUIElementTypeWindow[`label BEGINSWITH "blabla"`][-1] - select the last window, where label text begins with "blabla".
  XCUIElementTypeWindow/XCUIElementTypeAny[`value == "bla1" OR label == "bla2"`] - select all children of the first window, where value is "bla1" or label is "bla2".
  XCUIElementTypeWindow[`name == "you're the winner"`]/XCUIElementTypeAny[`visible == 1`] - select all visible children of the first window named "you're the winner".
- Predicate string should be always enclosed into ` characters inside square brackets. Use `` to escape a single ` character inside predicate expression.
- Predicate expression should be always put before the index, but never after it.
+ XCUIElementTypeWindow/XCUIElementTypeTable/XCUIElementTypeCell[`visible == 1`][$type == XCUIElementTypeImage AND name == 'bla'$]/XCUIElementTypeTextField - select a text field, which is a direct child of a visible table cell, which has at least one descendant image with identifier 'bla'.
+ Predicate string should be always enclosed into ` or $ characters inside square brackets. Use `` or $$ to escape a single ` or $ character inside predicate expression.
+ Single backtick means the predicate expression is applied to the current children. It is the direct alternative of matchingPredicate: query selector.
+ Single dollar sign means the predicate expression is applied to all the descendants of the current element(s). It is the direct alternative of containingPredicate: query selector.
+ Predicate expression should be always put before the index, but never after it. All predicate expressions are executed in the same exact order, which is set in the chain query.
  It is not recommended to set explicit indexes for intermediate chain elements, because it slows down the lookup speed.
  
  Indirect descendant search requests are pretty similar to requests above:

--- a/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBClassChain.m
@@ -62,8 +62,14 @@ NSString *const FBClassChainQueryParseException = @"FBClassChainQueryParseExcept
       query = [self childrenMatchingType:item.type];
     }
   }
-  if (item.predicate) {
-    query = [query matchingPredicate:(id)item.predicate];
+  if (item.predicates) {
+    for (FBAbstractPredicateItem *predicate in item.predicates) {
+      if ([predicate isKindOfClass:FBSelfPredicateItem.class]) {
+        query = [query matchingPredicate:predicate.value];
+      } else if ([predicate isKindOfClass:FBDescendantPredicateItem.class]) {
+        query = [query containingPredicate:predicate.value];
+      }
+    }
   }
   return query;
 }

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.h
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.h
@@ -12,16 +12,39 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface FBAbstractPredicateItem : NSObject
+
+/*! The actual predicate value of an item */
+@property (nonatomic, readonly) NSPredicate *value;
+
+/**
+ Instance constructor, which allows to set item value on instance creation
+ 
+ @param value the actual predicate value
+ @return FBAbstractPredicateItem instance
+ */
+- (instancetype)initWithValue:(NSPredicate *)value;
+
+@end
+
+@interface FBSelfPredicateItem : FBAbstractPredicateItem
+
+@end
+
+@interface FBDescendantPredicateItem : FBAbstractPredicateItem
+
+@end
+
 @interface FBClassChainItem : NSObject
 
 /*! Element's position */
 @property (readonly, nonatomic) NSInteger position;
 /*! Element's type */
 @property (readonly, nonatomic) XCUIElementType type;
-/*! Element's predicate */
-@property (nullable, readonly, nonatomic) NSPredicate *predicate;
 /*! Whether an element is a descendant of the previos element */
 @property (readonly, nonatomic) BOOL isDescendant;
+/*! The ordered list of matching predicates for the current element */
+@property (readonly, nonatomic) NSArray<FBAbstractPredicateItem *> *predicates;
 
 /**
  Instance constructor, which allows to set element type and position
@@ -31,13 +54,13 @@ NS_ASSUME_NONNULL_BEGIN
    starts with 1. Zero value means that all sibling element should be selected.
    Negative value means that numeration starts from the last element, for example
    -1 is the last child element and -2 is the second last element
- @param predicate valid predicate expession for element search. Can be nil
+ @param predicates the list of matching descendant/self predicates
  @param isDescendant equals to YES if the element is a descendantt element of
-   the previous element in the chain. NO value maens the element is the direct
+   the previous element in the chain. NO value means the element is the direct
    child of the previous element
  @return FBClassChainElement instance
  */
-- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicate:(NSPredicate *)predicate isDescendant:(BOOL)isDescendant;
+- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicates:(NSArray<FBAbstractPredicateItem *> *)predicates isDescendant:(BOOL)isDescendant;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
@@ -40,11 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-
 @interface FBOpeningBracketToken : FBBaseClassChainToken
 
 @end
-
 
 @interface FBClosingBracketToken : FBBaseClassChainToken
 
@@ -54,10 +52,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-
-@interface FBPredicateToken : FBBaseClassChainToken
+@interface FBAbstractPredicateToken : FBBaseClassChainToken
 
 @property (nonatomic) BOOL isParsingCompleted;
+
++ (NSString *)enclosingMarker;
+
+@end
+
+@interface FBSelfPredicateToken : FBAbstractPredicateToken
+
+@end
+
+@interface FBDescendantPredicateToken : FBAbstractPredicateToken
 
 @end
 
@@ -245,7 +252,7 @@ static NSString *const DESCENDANT_MARKER = @"**/";
 
 - (NSArray<Class> *)followingTokens
 {
-  return @[FBNumberToken.class, FBPredicateToken.class];
+  return @[FBNumberToken.class, FBSelfPredicateToken.class, FBDescendantPredicateToken.class];
 }
 
 + (NSUInteger)maxLength
@@ -293,10 +300,9 @@ static NSString *const DESCENDANT_MARKER = @"**/";
 
 @end
 
+static NSString *const FBAbstractMethodInvocationException = @"FBAbstractMethodInvocationException";
 
-@implementation FBPredicateToken
-
-static NSString* const ENCLOSING_MARKER = @"`";
+@implementation FBAbstractPredicateToken
 
 - (id)init
 {
@@ -305,6 +311,12 @@ static NSString* const ENCLOSING_MARKER = @"`";
     _isParsingCompleted = NO;
   }
   return self;
+}
+
++ (NSString *)enclosingMarker
+{
+  NSString *errMsg = [NSString stringWithFormat:@"The + (NSString *)enclosingMarker method is expected to be overriden by %@ class", NSStringFromClass(self.class)];
+  @throw [NSException exceptionWithName:FBAbstractMethodInvocationException reason:errMsg userInfo:nil];
 }
 
 + (NSCharacterSet *)allowedCharacters
@@ -319,7 +331,7 @@ static NSString* const ENCLOSING_MARKER = @"`";
 
 + (BOOL)canConsumeCharacter:(unichar)character
 {
-  return [[NSCharacterSet characterSetWithCharactersInString:ENCLOSING_MARKER] characterIsMember:character];
+  return [[NSCharacterSet characterSetWithCharactersInString:self.class.enclosingMarker] characterIsMember:character];
 }
 
 - (void)stripLastChar
@@ -334,11 +346,11 @@ static NSString* const ENCLOSING_MARKER = @"`";
   NSString *currentChar = [NSString stringWithFormat:@"%C", character];
   if (!self.isParsingCompleted && [self.class.allowedCharacters characterIsMember:character]) {
     if (0 == self.asString.length) {
-      if ([ENCLOSING_MARKER isEqualToString:currentChar]) {
+      if ([self.class.enclosingMarker isEqualToString:currentChar]) {
         // Do not include enclosing character
         return self;
       }
-    } else if ([ENCLOSING_MARKER isEqualToString:currentChar]) {
+    } else if ([self.class.enclosingMarker isEqualToString:currentChar]) {
       [self appendChar:character];
       self.isParsingCompleted = YES;
       return self;
@@ -347,7 +359,7 @@ static NSString* const ENCLOSING_MARKER = @"`";
     return self;
   }
   if (self.isParsingCompleted) {
-    if ([currentChar isEqualToString:ENCLOSING_MARKER]) {
+    if ([currentChar isEqualToString:self.class.enclosingMarker]) {
       // Escaped enclosing character has been detected. Do not finish parsing
       self.isParsingCompleted = NO;
       return self;
@@ -361,16 +373,34 @@ static NSString* const ENCLOSING_MARKER = @"`";
 
 @end
 
+@implementation FBSelfPredicateToken
+
++ (NSString *)enclosingMarker
+{
+  return @"`";
+}
+
+@end
+
+@implementation FBDescendantPredicateToken
+
++ (NSString *)enclosingMarker
+{
+  return @"$";
+}
+
+@end
+
 
 @implementation FBClassChainItem
 
-- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicate:(NSPredicate *)predicate isDescendant:(BOOL)isDescendant
+- (instancetype)initWithType:(XCUIElementType)type position:(NSInteger)position predicates:(NSArray<FBAbstractPredicateItem *> *)predicates isDescendant:(BOOL)isDescendant
 {
   self = [super init];
   if (self) {
     _type = type;
     _position = position;
-    _predicate = predicate;
+    _predicates = predicates;
     _isDescendant = isDescendant;
   }
   return self;
@@ -481,8 +511,7 @@ static NSNumberFormatter *numberFormatter = nil;
   BOOL isTypeSet = NO;
   BOOL isPositionSet = NO;
   BOOL isDescendantSet = NO;
-  BOOL isPredicateSet = NO;
-  NSPredicate *predicate = nil;
+  NSMutableArray<FBAbstractPredicateItem *> *predicates = [NSMutableArray array];
   for (FBBaseClassChainToken *token in tokenizedQuery) {
     if ([token isKindOfClass:FBClassNameToken.class]) {
       if (isTypeSet) {
@@ -517,27 +546,25 @@ static NSNumberFormatter *numberFormatter = nil;
       }
       isTypeSet = NO;
       isPositionSet = NO;
-      isPredicateSet = NO;
-      predicate = nil;
+      [predicates removeAllObjects];
       isDescendantSet = YES;
-    } else if ([token isKindOfClass:FBPredicateToken.class]) {
-      if (isPredicateSet) {
-        NSString *description = [NSString stringWithFormat:@"Predicate value '%@' is expected to be set only once.", token.asString];
-        *error = [self.class compilationErrorWithQuery:originalQuery description:description];
-        return nil;
-      }
+    } else if ([token isKindOfClass:FBAbstractPredicateToken.class]) {
       if (isPositionSet) {
         NSString *description = [NSString stringWithFormat:@"Predicate value '%@' must be set before position value.", token.asString];
         *error = [self.class compilationErrorWithQuery:originalQuery description:description];
         return nil;
       }
-      if (!((FBPredicateToken *)token).isParsingCompleted) {
+      if (!((FBAbstractPredicateToken *)token).isParsingCompleted) {
         NSString *description = [NSString stringWithFormat:@"Cannot find the end of '%@' predicate value.", token.asString];
         *error = [self.class compilationErrorWithQuery:originalQuery description:description];
         return nil;
       }
-      predicate = [NSPredicate fb_formatSearchPredicate:[FBPredicate predicateWithFormat:token.asString]];
-      isPredicateSet = YES;
+      NSPredicate *value = [NSPredicate fb_formatSearchPredicate:[FBPredicate predicateWithFormat:token.asString]];
+      if ([token isKindOfClass:FBSelfPredicateToken.class]) {
+        [predicates addObject:[[FBSelfPredicateItem alloc] initWithValue:value]];
+      } else if ([token isKindOfClass:FBDescendantPredicateToken.class]) {
+        [predicates addObject:[[FBDescendantPredicateItem alloc] initWithValue:value]];
+      }
     } else if ([token isKindOfClass:FBNumberToken.class]) {
       if (isPositionSet) {
         NSString *description = [NSString stringWithFormat:@"Position value '%@' is expected to be set only once.", token.asString];
@@ -558,16 +585,15 @@ static NSNumberFormatter *numberFormatter = nil;
       }
       if (isDescendantSet) {
         if (isTypeSet) {
-          [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:YES]];
+          [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicates:predicates.copy isDescendant:YES]];
           isDescendantSet = NO;
         }
       } else {
-        [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:NO]];
+        [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicates:predicates.copy isDescendant:NO]];
       }
       isTypeSet = NO;
       isPositionSet = NO;
-      isPredicateSet = NO;
-      predicate = nil;
+      [predicates removeAllObjects];
     }
   }
   if (!isPositionSet) {
@@ -576,14 +602,14 @@ static NSNumberFormatter *numberFormatter = nil;
   }
   if (isDescendantSet) {
     if (isTypeSet) {
-      [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:YES]];
+      [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicates:predicates.copy isDescendant:YES]];
     } else {
       NSString *description = @"Descendants lookup modifier '**/' should be followed with the actual element type";
       *error = [self.class compilationErrorWithQuery:originalQuery description:description];
       return nil;
     }
   } else {
-    [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicate:predicate isDescendant:NO]];
+    [result addObject:[[FBClassChainItem alloc] initWithType:chainElementType position:chainElementPosition predicates:predicates.copy isDescendant:NO]];
   }
   return [[FBClassChain alloc] initWithElements:result.copy];
 }
@@ -597,5 +623,27 @@ static NSNumberFormatter *numberFormatter = nil;
   }
   return [self.class compiledQueryWithTokenizedQuery:tokenizedQuery originalQuery:classChainQuery error:error];
 }
+
+@end
+
+
+@implementation FBAbstractPredicateItem
+
+- (instancetype)initWithValue:(NSPredicate *)value
+{
+  self = [super init];
+  if (self) {
+    _value = value;
+  }
+  return self;
+}
+
+@end
+
+@implementation FBSelfPredicateItem
+
+@end
+
+@implementation FBDescendantPredicateItem
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -237,6 +237,15 @@
   XCTAssertEqualObjects([simpleQueryMatches lastObject].label, [deepQueryMatches lastObject].label);
 }
 
+- (void)testClassChainWithDescendantPredicate
+{
+  NSArray<XCUIElement *> *simpleQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[2]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *predicateQueryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow/*/*[$type == 'XCUIElementTypeButton' AND label BEGINSWITH 'A'$]" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(simpleQueryMatches.count, predicateQueryMatches.count);
+  XCTAssertEqual([simpleQueryMatches firstObject].elementType, [predicateQueryMatches firstObject].elementType);
+  XCTAssertEqual([simpleQueryMatches lastObject].elementType, [predicateQueryMatches lastObject].elementType);
+}
+
 - (void)testSingleDescendantWithComplexIndirectClassChain
 {
   NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/*/XCUIElementTypeButton[2]" shouldReturnAfterFirstMatch:NO];


### PR DESCRIPTION
For now class chain already implements all the available XCUIElementQuery selectors, except of the _containing..._ one. This PR adds support of containingPredicate: selector (which is also a superset of containingType:identifier: one), so now the implementation is full and provides API clients with complete set of selectors, which are supported natively by XCTest.