### PR TITLE
Handle coordinates calculation for non-default screen orienation, which has been fixed since iphoneos SDK 11.0

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7139145C1DF01A12005896C2 /* NSExpressionFBFormatTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7139145B1DF01A12005896C2 /* NSExpressionFBFormatTests.m */; };
 		713C6DCF1DDC772A00285B92 /* FBElementUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 713C6DCD1DDC772A00285B92 /* FBElementUtils.h */; };
 		713C6DD01DDC772A00285B92 /* FBElementUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 713C6DCE1DDC772A00285B92 /* FBElementUtils.m */; };
+		714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */; };
 		71555A3D1DEC460A007D4A8B /* NSExpression+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */; };
 		71555A3E1DEC460A007D4A8B /* NSExpression+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */; };
 		716E0BCE1E917E810087A825 /* NSString+FBXMLSafeString.h in Headers */ = {isa = PBXBuildFile; fileRef = 716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */; };
@@ -408,6 +409,7 @@
 		7139145B1DF01A12005896C2 /* NSExpressionFBFormatTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSExpressionFBFormatTests.m; sourceTree = "<group>"; };
 		713C6DCD1DDC772A00285B92 /* FBElementUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBElementUtils.h; sourceTree = "<group>"; };
 		713C6DCE1DDC772A00285B92 /* FBElementUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementUtils.m; sourceTree = "<group>"; };
+		714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKVersionTests.m; sourceTree = "<group>"; };
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
 		71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSExpression+FBFormat.h"; sourceTree = "<group>"; };
 		71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSExpression+FBFormat.m"; sourceTree = "<group>"; };
@@ -1096,6 +1098,7 @@
 				712A0C841DA3E459007D02E5 /* FBXPathTests.m */,
 				7139145B1DF01A12005896C2 /* NSExpressionFBFormatTests.m */,
 				71A224E71DE326C500844D55 /* NSPredicateFBFormatTests.m */,
+				714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */,
 				ADEF63AC1D09DCCF0070A7E3 /* FBXPathCreatorTests.m */,
 				EE18883C1DA663EB00307AA8 /* FBMathUtilsTests.m */,
 				713914591DF01989005896C2 /* XCUIElementHelpersTests.m */,
@@ -1823,6 +1826,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EE3F8CFE1D08AA17006F02CE /* FBRunLoopSpinnerTests.m in Sources */,
+				714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */,
 				EE3F8D001D08B05F006F02CE /* FBElementTypeTransformerTests.m in Sources */,
 				EEE16E971D33A25500172525 /* FBConfigurationTests.m in Sources */,
 				ADBC39941D0782CD00327304 /* FBElementCacheTests.m in Sources */,

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -13,7 +13,6 @@
 #import "FBLogger.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
-#import "FBRuntimeUtils.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCEventGenerator.h"
 #import "XCSynthesizedEventRecord.h"

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -38,7 +38,7 @@ const CGFloat FBTapDuration = 0.01f;
 - (BOOL)fb_tapCoordinate:(CGPoint)relativeCoordinate error:(NSError **)error
 {
   CGPoint hitPoint = CGPointMake(self.frame.origin.x + relativeCoordinate.x, self.frame.origin.y + relativeCoordinate.y);
-  if (isSDKVersionGreaterThanOrEqualTo(@"10.0")) {
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
     /*
      Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
      even if the device is not in portait mode. That is why we need to recalculate them manually

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -13,6 +13,7 @@
 #import "FBLogger.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
+#import "FBRuntimeUtils.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCEventGenerator.h"
 #import "XCSynthesizedEventRecord.h"
@@ -37,7 +38,7 @@ const CGFloat FBTapDuration = 0.01f;
 - (BOOL)fb_tapCoordinate:(CGPoint)relativeCoordinate error:(NSError **)error
 {
   CGPoint hitPoint = CGPointMake(self.frame.origin.x + relativeCoordinate.x, self.frame.origin.y + relativeCoordinate.y);
-  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+  if (isSDKVersionGreaterThanOrEqualTo(@"10.0")) {
     /*
      Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
      even if the device is not in portait mode. That is why we need to recalculate them manually

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -21,6 +21,7 @@
 #import "FBApplication.h"
 #import "FBMacros.h"
 #import "FBMathUtils.h"
+#import "FBRuntimeUtils.h"
 #import "NSPredicate+FBFormat.h"
 #import "XCUICoordinate.h"
 #import "XCUIDevice.h"
@@ -207,7 +208,7 @@
 + (id<FBResponsePayload>)handleDoubleTapCoordinate:(FBRouteRequest *)request
 {
   CGPoint doubleTapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  XCUICoordinate *doubleTapCoordinate = [self.class gestureCoordinateWithCoordinate:doubleTapPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *doubleTapCoordinate = [self.class gestureCoordinateWithCoordinate:doubleTapPoint application:request.session.application shouldApplyOrientationWorkaround:isSDKVersionLessThan(@"11.0")];
   [doubleTapCoordinate doubleTap];
   return FBResponseWithOK();
 }
@@ -231,7 +232,7 @@
 + (id<FBResponsePayload>)handleTouchAndHoldCoordinate:(FBRouteRequest *)request
 {
   CGPoint touchPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  XCUICoordinate *pressCoordinate = [self.class gestureCoordinateWithCoordinate:touchPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *pressCoordinate = [self.class gestureCoordinateWithCoordinate:touchPoint application:request.session.application shouldApplyOrientationWorkaround:isSDKVersionLessThan(@"11.0")];
   [pressCoordinate pressForDuration:[request.arguments[@"duration"] doubleValue]];
   return FBResponseWithOK();
 }
@@ -290,8 +291,8 @@
   CGPoint startPoint = CGPointMake((CGFloat)[request.arguments[@"fromX"] doubleValue], (CGFloat)[request.arguments[@"fromY"] doubleValue]);
   CGPoint endPoint = CGPointMake((CGFloat)[request.arguments[@"toX"] doubleValue], (CGFloat)[request.arguments[@"toY"] doubleValue]);
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
-  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:YES];
-  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:YES];
+  XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:isSDKVersionLessThan(@"11.0")];
+  XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:isSDKVersionLessThan(@"11.0")];
   [startCoordinate pressForDuration:duration thenDragToCoordinate:endCoordinate];
   return FBResponseWithOK();
 }
@@ -304,7 +305,7 @@
   CGPoint startPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"fromX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"fromY"] doubleValue]));
   CGPoint endPoint = CGPointMake((CGFloat)(element.frame.origin.x + [request.arguments[@"toX"] doubleValue]), (CGFloat)(element.frame.origin.y + [request.arguments[@"toY"] doubleValue]));
   NSTimeInterval duration = [request.arguments[@"duration"] doubleValue];
-  BOOL shouldApplyOrientationWorkaround = SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0");
+  BOOL shouldApplyOrientationWorkaround = isSDKVersionGreaterThanOrEqualTo(@"10.0") && isSDKVersionLessThan(@"11.0");
   XCUICoordinate *endCoordinate = [self.class gestureCoordinateWithCoordinate:endPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
   XCUICoordinate *startCoordinate = [self.class gestureCoordinateWithCoordinate:startPoint application:session.application shouldApplyOrientationWorkaround:shouldApplyOrientationWorkaround];
   [startCoordinate pressForDuration:duration thenDragToCoordinate:endCoordinate];
@@ -339,7 +340,7 @@
   CGPoint tapPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
   if (nil == element) {
-    XCUICoordinate *tapCoordinate = [self.class gestureCoordinateWithCoordinate:tapPoint application:request.session.application shouldApplyOrientationWorkaround:YES];
+    XCUICoordinate *tapCoordinate = [self.class gestureCoordinateWithCoordinate:tapPoint application:request.session.application shouldApplyOrientationWorkaround:isSDKVersionLessThan(@"11.0")];
     [tapCoordinate tap];
   } else {
     NSError *error;

--- a/WebDriverAgentLib/Utilities/FBRuntimeUtils.h
+++ b/WebDriverAgentLib/Utilities/FBRuntimeUtils.h
@@ -26,6 +26,13 @@ NSArray<Class> *FBClassesThatConformsToProtocol(Protocol *protocol);
 void *FBRetrieveSymbolFromBinary(const char *binary, const char *name);
 
 /**
+ Get the compiler SDK version as string.
+ 
+ @return SDK version as string, for example "10.0" or nil if it cannot be received
+ */
+NSString * _Nullable FBSDKVersion(void);
+
+/**
  Check if the compiler SDK version is less than the given version.
  The current iOS version is taken instead if SDK version cannot be retrieved.
  

--- a/WebDriverAgentLib/Utilities/FBRuntimeUtils.h
+++ b/WebDriverAgentLib/Utilities/FBRuntimeUtils.h
@@ -25,4 +25,49 @@ NSArray<Class> *FBClassesThatConformsToProtocol(Protocol *protocol);
  */
 void *FBRetrieveSymbolFromBinary(const char *binary, const char *name);
 
+/**
+ Check if the compiler SDK version is less than the given version.
+ The current iOS version is taken instead if SDK version cannot be retrieved.
+ 
+ @param expected the expected version to compare with, for example '10.3'
+ @return YES if the given version is less than the SDK version used for WDA compilation
+ */
+BOOL isSDKVersionLessThan(NSString *expected);
+
+/**
+ Check if the compiler SDK version is less or equal to the given version.
+ The current iOS version is taken instead if SDK version cannot be retrieved.
+ 
+ @param expected the expected version to compare with, for example '10.3'
+ @return YES if the given version is less or equal to the SDK version used for WDA compilation
+ */
+BOOL isSDKVersionLessThanOrEqualTo(NSString *expected);
+
+/**
+ Check if the compiler SDK version is equal to the given version.
+ The current iOS version is taken instead if SDK version cannot be retrieved.
+ 
+ @param expected the expected version to compare with, for example '10.3'
+ @return YES if the given version is equal to the SDK version used for WDA compilation
+ */
+BOOL isSDKVersionEqualTo(NSString *expected);
+
+/**
+ Check if the compiler SDK version is greater or equal to the given version.
+ The current iOS version is taken instead if SDK version cannot be retrieved.
+ 
+ @param expected the expected version to compare with, for example '10.3'
+ @return YES if the given version is greater or equal to the SDK version used for WDA compilation
+ */
+BOOL isSDKVersionGreaterThanOrEqualTo(NSString *expected);
+
+/**
+ Check if the compiler SDK version is greater than the given version.
+ The current iOS version is taken instead if SDK version cannot be retrieved.
+ 
+ @param expected the expected version to compare with, for example '10.3'
+ @return YES if the given version is greater than the SDK version used for WDA compilation
+ */
+BOOL isSDKVersionGreaterThan(NSString *expected);
+
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBRuntimeUtils.m
+++ b/WebDriverAgentLib/Utilities/FBRuntimeUtils.m
@@ -9,6 +9,9 @@
 
 #import "FBRuntimeUtils.h"
 
+#import "FBMacros.h"
+#import "XCUIDevice.h"
+
 #include <dlfcn.h>
 #import <objc/runtime.h>
 
@@ -40,4 +43,71 @@ void *FBRetrieveSymbolFromBinary(const char *binary, const char *name)
   void *pointer = dlsym(handle, name);
   NSCAssert(pointer, @"%s could not be located", name);
   return pointer;
+}
+
+static NSString *sdkVersion = nil;
+static dispatch_once_t onceSdkVersionToken;
+NSString * _Nullable FBSDKVersion()
+{
+  dispatch_once(&onceSdkVersionToken, ^{
+    NSString *sdkName = [[NSBundle mainBundle] infoDictionary][@"DTSDKName"];
+    if (sdkName) {
+      // the value of DTSDKName looks like 'iphoneos9.2'
+      NSRange versionRange = [sdkName rangeOfString:@"\\d+\\.\\d+" options:NSRegularExpressionSearch];
+      if (versionRange.location != NSNotFound) {
+        sdkVersion = [sdkName substringWithRange:versionRange];
+      }
+    }
+  });
+  return sdkVersion;
+}
+
+BOOL isSDKVersionLessThan(NSString *expected)
+{
+  NSString *version = FBSDKVersion();
+  if (nil == version) {
+    return SYSTEM_VERSION_LESS_THAN(expected);
+  }
+  NSComparisonResult result = [version compare:expected options:NSNumericSearch];
+  return result == NSOrderedAscending;
+}
+
+BOOL isSDKVersionLessThanOrEqualTo(NSString *expected)
+{
+  NSString *version = FBSDKVersion();
+  if (nil == version) {
+    return SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(expected);
+  }
+  NSComparisonResult result = [version compare:expected options:NSNumericSearch];
+  return result == NSOrderedAscending || result == NSOrderedSame;
+}
+
+BOOL isSDKVersionEqualTo(NSString *expected)
+{
+  NSString *version = FBSDKVersion();
+  if (nil == version) {
+    return SYSTEM_VERSION_EQUAL_TO(expected);
+  }
+  NSComparisonResult result = [version compare:expected options:NSNumericSearch];
+  return result == NSOrderedSame;
+}
+
+BOOL isSDKVersionGreaterThanOrEqualTo(NSString *expected)
+{
+  NSString *version = FBSDKVersion();
+  if (nil == version) {
+    return SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(expected);
+  }
+  NSComparisonResult result = [version compare:expected options:NSNumericSearch];
+  return result == NSOrderedDescending || result == NSOrderedSame;
+}
+
+BOOL isSDKVersionGreaterThan(NSString *expected)
+{
+  NSString *version = FBSDKVersion();
+  if (nil == version) {
+    return SYSTEM_VERSION_GREATER_THAN(expected);
+  }
+  NSComparisonResult result = [version compare:expected options:NSNumericSearch];
+  return result == NSOrderedDescending || result == NSOrderedSame;
 }

--- a/WebDriverAgentLib/Utilities/FBRuntimeUtils.m
+++ b/WebDriverAgentLib/Utilities/FBRuntimeUtils.m
@@ -109,5 +109,5 @@ BOOL isSDKVersionGreaterThan(NSString *expected)
     return SYSTEM_VERSION_GREATER_THAN(expected);
   }
   NSComparisonResult result = [version compare:expected options:NSNumericSearch];
-  return result == NSOrderedDescending || result == NSOrderedSame;
+  return result == NSOrderedDescending;
 }

--- a/WebDriverAgentTests/UnitTests/FBSDKVersionTests.m
+++ b/WebDriverAgentTests/UnitTests/FBSDKVersionTests.m
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBRuntimeUtils.h"
+
+@interface FBSDKVersionTests : XCTestCase
+@property (nonatomic, readonly) NSString *currentSDKVersion;
+@property (nonatomic, readonly) NSString *lowerSDKVersion;
+@property (nonatomic, readonly) NSString *higherSDKVersion;
+@end
+
+@implementation FBSDKVersionTests
+
+- (void)setUp
+{
+  [super setUp];
+  _currentSDKVersion = @"11.0";
+  NSDictionary *bundleDict = [[NSBundle mainBundle] infoDictionary];
+  [bundleDict setValue:self.currentSDKVersion forKey:@"DTSDKName"];
+  _lowerSDKVersion = [NSString stringWithFormat:@"%@", @((int)[self.currentSDKVersion doubleValue] - 1)];
+  _higherSDKVersion = [NSString stringWithFormat:@"%@", @((int)[self.currentSDKVersion doubleValue] + 1)];
+}
+
+- (void)testIsSDKVersionLessThanOrEqualTo
+{
+  XCTAssertTrue(isSDKVersionLessThanOrEqualTo(self.higherSDKVersion));
+  XCTAssertFalse(isSDKVersionLessThanOrEqualTo(self.lowerSDKVersion));
+  XCTAssertTrue(isSDKVersionLessThanOrEqualTo(self.currentSDKVersion));
+}
+
+- (void)testIsSDKVersionLessThan
+{
+  XCTAssertTrue(isSDKVersionLessThan(self.higherSDKVersion));
+  XCTAssertFalse(isSDKVersionLessThan(self.lowerSDKVersion));
+  XCTAssertFalse(isSDKVersionLessThan(self.currentSDKVersion));
+}
+
+- (void)testIsSDKVersionEqualTo
+{
+  XCTAssertFalse(isSDKVersionEqualTo(self.higherSDKVersion));
+  XCTAssertFalse(isSDKVersionEqualTo(self.lowerSDKVersion));
+  XCTAssertTrue(isSDKVersionEqualTo(self.currentSDKVersion));
+}
+
+- (void)testIsSDKVersionGreaterThanOrEqualTo
+{
+  XCTAssertFalse(isSDKVersionGreaterThanOrEqualTo(self.higherSDKVersion));
+  XCTAssertTrue(isSDKVersionGreaterThanOrEqualTo(self.lowerSDKVersion));
+  XCTAssertTrue(isSDKVersionGreaterThanOrEqualTo(self.currentSDKVersion));
+}
+
+- (void)testIsSDKVersionGreaterThan
+{
+  XCTAssertFalse(isSDKVersionGreaterThan(self.higherSDKVersion));
+  XCTAssertTrue(isSDKVersionGreaterThan(self.lowerSDKVersion));
+  XCTAssertFalse(isSDKVersionGreaterThan(self.currentSDKVersion));
+}
+
+@end

--- a/WebDriverAgentTests/UnitTests/FBSDKVersionTests.m
+++ b/WebDriverAgentTests/UnitTests/FBSDKVersionTests.m
@@ -22,9 +22,9 @@
 - (void)setUp
 {
   [super setUp];
-  _currentSDKVersion = @"11.0";
   NSDictionary *bundleDict = [[NSBundle mainBundle] infoDictionary];
-  [bundleDict setValue:self.currentSDKVersion forKey:@"DTSDKName"];
+  [bundleDict setValue:@"11.0" forKey:@"DTSDKName"];
+  _currentSDKVersion = FBSDKVersion();
   _lowerSDKVersion = [NSString stringWithFormat:@"%@", @((int)[self.currentSDKVersion doubleValue] - 1)];
   _higherSDKVersion = [NSString stringWithFormat:@"%@", @((int)[self.currentSDKVersion doubleValue] + 1)];
 }


### PR DESCRIPTION
XCTest has a bug when tap coordinates are inverted if device orientation differs from portrait, which has been fixed since SDK version 11.0 (Xcode9+). This PR checks the actual SDK version used to compile WDA to determine whether to apply coordinates calculation workaround.