### PR TITLE
Make sure source type is set

### DIFF
--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -37,9 +37,9 @@
 + (id<FBResponsePayload>)handleGetSourceCommand:(FBRouteRequest *)request
 {
   FBApplication *application = request.session.application ?: [FBApplication fb_activeApplication];
-  NSString *sourceType = request.parameters[@"format"];
+  NSString *sourceType = request.parameters[@"format"] ?: @"xml";
   id result;
-  if (!sourceType || [sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
+  if ([sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
     [application fb_waitUntilSnapshotIsStable];
     result = [FBXPath xmlStringWithSnapshot:application.fb_lastSnapshot];
   } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {


### PR DESCRIPTION
It might be that resulting error message contains "(null)" string if _format_ request argument is not set in the current implementation. This PR fixes this problem by assuring that _sourceType_ is always set to a valid string.