### PR TITLE
Add one more source type

### DIFF
--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -44,6 +44,8 @@
     result = [FBXPath xmlStringWithSnapshot:application.fb_lastSnapshot];
   } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {
     result = application.fb_tree;
+  } else if ([sourceType caseInsensitiveCompare:@"description"] == NSOrderedSame) {
+    result = application.debugDescription;
   } else {
     return FBResponseWithStatus(
       FBCommandStatusUnsupported,

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -49,7 +49,14 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_JSON] == NSOrderedSame) {
     result = application.fb_tree;
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_DESCRIPTION] == NSOrderedSame) {
-    result = application.debugDescription;
+    NSMutableArray<NSString *> *childrenDescriptions = [NSMutableArray array];
+    for (XCUIElement *child in [application childrenMatchingType:XCUIElementTypeAny].allElementsBoundByIndex) {
+      [childrenDescriptions addObject:child.debugDescription];
+    }
+    // debugDescription property of XCUIApplication instance shows descendants addresses in memory
+    // instead of the actual information about them, however the representation works properly
+    // for all descendant elements
+    result = (0 == childrenDescriptions.count) ? application.debugDescription : [childrenDescriptions componentsJoinedByString:@"\n\n"];
   } else {
     return FBResponseWithStatus(
       FBCommandStatusUnsupported,

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -54,7 +54,7 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
     return FBResponseWithStatus(
       FBCommandStatusUnsupported,
       [NSString stringWithFormat:@"Unknown source format '%@'. Only %@ source formats are supported.",
-       @[SOURCE_FORMAT_XML, SOURCE_FORMAT_JSON, SOURCE_FORMAT_DESCRIPTION], sourceType]
+       sourceType, @[SOURCE_FORMAT_XML, SOURCE_FORMAT_JSON, SOURCE_FORMAT_DESCRIPTION]]
     );
   }
   if (nil == result) {

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -34,22 +34,27 @@
 
 #pragma mark - Commands
 
+static NSString *const SOURCE_FORMAT_XML = @"xml";
+static NSString *const SOURCE_FORMAT_JSON = @"json";
+static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
+
 + (id<FBResponsePayload>)handleGetSourceCommand:(FBRouteRequest *)request
 {
   FBApplication *application = request.session.application ?: [FBApplication fb_activeApplication];
-  NSString *sourceType = request.parameters[@"format"];
+  NSString *sourceType = request.parameters[@"format"] ?: SOURCE_FORMAT_XML;
   id result;
-  if (!sourceType || [sourceType caseInsensitiveCompare:@"xml"] == NSOrderedSame) {
+  if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_XML] == NSOrderedSame) {
     [application fb_waitUntilSnapshotIsStable];
     result = [FBXPath xmlStringWithSnapshot:application.fb_lastSnapshot];
-  } else if ([sourceType caseInsensitiveCompare:@"json"] == NSOrderedSame) {
+  } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_JSON] == NSOrderedSame) {
     result = application.fb_tree;
-  } else if ([sourceType caseInsensitiveCompare:@"description"] == NSOrderedSame) {
+  } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_DESCRIPTION] == NSOrderedSame) {
     result = application.debugDescription;
   } else {
     return FBResponseWithStatus(
       FBCommandStatusUnsupported,
-      [NSString stringWithFormat:@"Unknown source type '%@'. Only 'xml' and 'json' source types are supported.", sourceType]
+      [NSString stringWithFormat:@"Unknown source format '%@'. Only %@ source formats are supported.",
+       @[SOURCE_FORMAT_XML, SOURCE_FORMAT_JSON, SOURCE_FORMAT_DESCRIPTION], sourceType]
     );
   }
   if (nil == result) {


### PR DESCRIPTION
There are many complains about _/source_ endpoint is slow, especially on iOS11. This is something, that cannot be avoided, but instead one can use the standard XCUIElement's _debugDescription_ property to see the basic hierarchy as Apple itself recommends. This endpoint is fast and might be enough for clients to just quickly check the current state of the UI tree.