### PR TITLE
Implement support for gesture chains

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -10,6 +10,11 @@
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */; };
+		71241D781FAE31F100B9559F /* FBAppiumActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 71241D771FAE31F100B9559F /* FBAppiumActionsSynthesizer.m */; };
+		71241D7B1FAE3D2500B9559F /* FBTouchActionCommands.h in Headers */ = {isa = PBXBuildFile; fileRef = 71241D791FAE3D2500B9559F /* FBTouchActionCommands.h */; };
+		71241D7C1FAE3D2500B9559F /* FBTouchActionCommands.m in Sources */ = {isa = PBXBuildFile; fileRef = 71241D7A1FAE3D2500B9559F /* FBTouchActionCommands.m */; };
+		71241D7E1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71241D7D1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m */; };
+		71241D801FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71241D7F1FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m */; };
 		712A0C851DA3E459007D02E5 /* FBXPathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 712A0C841DA3E459007D02E5 /* FBXPathTests.m */; };
 		712A0C871DA3E55D007D02E5 /* FBXPath-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */; };
 		712A0C8C1DA3F25B007D02E5 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
@@ -20,12 +25,18 @@
 		713C6DCF1DDC772A00285B92 /* FBElementUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 713C6DCD1DDC772A00285B92 /* FBElementUtils.h */; };
 		713C6DD01DDC772A00285B92 /* FBElementUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 713C6DCE1DDC772A00285B92 /* FBElementUtils.m */; };
 		714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */; };
+		714097431FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 714097411FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h */; };
+		714097471FAE1B32008FB2C5 /* FBAppiumActionsSynthesizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 714097451FAE1B32008FB2C5 /* FBAppiumActionsSynthesizer.h */; };
+		7140974B1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 714097491FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h */; };
+		7140974C1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7140974A1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m */; };
+		7140974E1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */; };
 		71555A3D1DEC460A007D4A8B /* NSExpression+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */; };
 		71555A3E1DEC460A007D4A8B /* NSExpression+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */; };
 		716E0BCE1E917E810087A825 /* NSString+FBXMLSafeString.h in Headers */ = {isa = PBXBuildFile; fileRef = 716E0BCC1E917E810087A825 /* NSString+FBXMLSafeString.h */; };
 		716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */; };
 		716E0BD11E917F260087A825 /* FBXMLSafeStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */; };
 		7174AF041D9D39AF008C8AD5 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
+		719A97AC1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 719A97AB1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m */; };
 		719FF5B91DAD21F5008E0099 /* FBElementUtilitiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */; };
 		71A224E51DE2F56600844D55 /* NSPredicate+FBFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */; };
 		71A224E61DE2F56600844D55 /* NSPredicate+FBFormat.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A224E41DE2F56600844D55 /* NSPredicate+FBFormat.m */; };
@@ -37,6 +48,9 @@
 		71A7EAFC1E229302001DA4F2 /* FBClassChainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */; };
 		71B49EC71ED1A58100D51AD6 /* XCUIElement+FBUID.h in Headers */ = {isa = PBXBuildFile; fileRef = 71B49EC51ED1A58100D51AD6 /* XCUIElement+FBUID.h */; };
 		71B49EC81ED1A58100D51AD6 /* XCUIElement+FBUID.m in Sources */ = {isa = PBXBuildFile; fileRef = 71B49EC61ED1A58100D51AD6 /* XCUIElement+FBUID.m */; };
+		71BD20731F86116100B36EC2 /* XCUIApplication+FBTouchAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */; };
+		71BD20741F86116100B36EC2 /* XCUIApplication+FBTouchAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */; };
+		71BD20781F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 71BD20771F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m */; };
 		71E95ADF1DC101BA002D0364 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
 		AD35D01A1CF1418E00870A75 /* RoutingHTTPServer.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = AD42DD2B1CF1238500806E5D /* RoutingHTTPServer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AD35D0641CF1C2C300870A75 /* RoutingHTTPServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD42DD2B1CF1238500806E5D /* RoutingHTTPServer.framework */; };
@@ -401,6 +415,11 @@
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
 		7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBPickerWheelSelectTests.m; sourceTree = "<group>"; };
+		71241D771FAE31F100B9559F /* FBAppiumActionsSynthesizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAppiumActionsSynthesizer.m; sourceTree = "<group>"; };
+		71241D791FAE3D2500B9559F /* FBTouchActionCommands.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBTouchActionCommands.h; sourceTree = "<group>"; };
+		71241D7A1FAE3D2500B9559F /* FBTouchActionCommands.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBTouchActionCommands.m; sourceTree = "<group>"; };
+		71241D7D1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBW3CTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
+		71241D7F1FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBW3CMultiTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
 		712A0C841DA3E459007D02E5 /* FBXPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathTests.m; sourceTree = "<group>"; };
 		712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBXPath-Private.h"; sourceTree = "<group>"; };
 		7136A4771E8918E60024FC3D /* XCUIElement+FBPickerWheel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBPickerWheel.h"; sourceTree = "<group>"; };
@@ -410,6 +429,11 @@
 		713C6DCD1DDC772A00285B92 /* FBElementUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBElementUtils.h; sourceTree = "<group>"; };
 		713C6DCE1DDC772A00285B92 /* FBElementUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementUtils.m; sourceTree = "<group>"; };
 		714801D01FA9D9FA00DC5997 /* FBSDKVersionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBSDKVersionTests.m; sourceTree = "<group>"; };
+		714097411FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBBaseActionsSynthesizer.h; sourceTree = "<group>"; };
+		714097451FAE1B32008FB2C5 /* FBAppiumActionsSynthesizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBAppiumActionsSynthesizer.h; sourceTree = "<group>"; };
+		714097491FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FBW3CActionsSynthesizer.h; sourceTree = "<group>"; };
+		7140974A1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBW3CActionsSynthesizer.m; sourceTree = "<group>"; };
+		7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBBaseActionsSynthesizer.m; sourceTree = "<group>"; };
 		714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathIntegrationTests.m; sourceTree = "<group>"; };
 		71555A3B1DEC460A007D4A8B /* NSExpression+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSExpression+FBFormat.h"; sourceTree = "<group>"; };
 		71555A3C1DEC460A007D4A8B /* NSExpression+FBFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSExpression+FBFormat.m"; sourceTree = "<group>"; };
@@ -417,6 +441,7 @@
 		716E0BCD1E917E810087A825 /* NSString+FBXMLSafeString.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+FBXMLSafeString.m"; sourceTree = "<group>"; };
 		716E0BD01E917F260087A825 /* FBXMLSafeStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXMLSafeStringTests.m; sourceTree = "<group>"; };
 		7174AF031D9D39AF008C8AD5 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
+		719A97AB1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAppiumMultiTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
 		719FF5B81DAD21F5008E0099 /* FBElementUtilitiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBElementUtilitiesTests.m; sourceTree = "<group>"; };
 		71A224E31DE2F56600844D55 /* NSPredicate+FBFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSPredicate+FBFormat.h"; path = "../Utilities/NSPredicate+FBFormat.h"; sourceTree = "<group>"; };
 		71A224E41DE2F56600844D55 /* NSPredicate+FBFormat.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSPredicate+FBFormat.m"; path = "../Utilities/NSPredicate+FBFormat.m"; sourceTree = "<group>"; };
@@ -428,6 +453,9 @@
 		71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBClassChainTests.m; sourceTree = "<group>"; };
 		71B49EC51ED1A58100D51AD6 /* XCUIElement+FBUID.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBUID.h"; sourceTree = "<group>"; };
 		71B49EC61ED1A58100D51AD6 /* XCUIElement+FBUID.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBUID.m"; sourceTree = "<group>"; };
+		71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIApplication+FBTouchAction.h"; sourceTree = "<group>"; };
+		71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIApplication+FBTouchAction.m"; sourceTree = "<group>"; };
+		71BD20771F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBAppiumTouchActionsIntegrationTests.m; sourceTree = "<group>"; };
 		71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIElementAttributesTests.m; sourceTree = "<group>"; };
 		AD42DD2A1CF121E600806E5D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		AD42DD2B1CF1238500806E5D /* RoutingHTTPServer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RoutingHTTPServer.framework; path = Carthage/Build/iOS/RoutingHTTPServer.framework; sourceTree = "<group>"; };
@@ -884,6 +912,8 @@
 				EE006EAF1EBA1AA9006900A4 /* XCElementSnapshot+FBHitPoint.m */,
 				AD6C269A1CF2494200F8B5FF /* XCUIApplication+FBHelpers.h */,
 				AD6C269B1CF2494200F8B5FF /* XCUIApplication+FBHelpers.m */,
+				71BD20711F86116100B36EC2 /* XCUIApplication+FBTouchAction.h */,
+				71BD20721F86116100B36EC2 /* XCUIApplication+FBTouchAction.m */,
 				EEDFE11F1D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.h */,
 				EEDFE1201D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.m */,
 				AD6C26961CF2481700F8B5FF /* XCUIDevice+FBHelpers.h */,
@@ -938,6 +968,8 @@
 				EE9AB75F1CAEDF0C008C271F /* FBScreenshotCommands.m */,
 				EE9AB7601CAEDF0C008C271F /* FBSessionCommands.h */,
 				EE9AB7611CAEDF0C008C271F /* FBSessionCommands.m */,
+				71241D791FAE3D2500B9559F /* FBTouchActionCommands.h */,
+				71241D7A1FAE3D2500B9559F /* FBTouchActionCommands.m */,
 				EE9AB7621CAEDF0C008C271F /* FBTouchIDCommands.h */,
 				EE9AB7631CAEDF0C008C271F /* FBTouchIDCommands.m */,
 				EE9AB7641CAEDF0C008C271F /* FBUnknownCommands.h */,
@@ -992,6 +1024,10 @@
 		EE9AB78E1CAEDF0C008C271F /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				714097451FAE1B32008FB2C5 /* FBAppiumActionsSynthesizer.h */,
+				71241D771FAE31F100B9559F /* FBAppiumActionsSynthesizer.m */,
+				714097411FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h */,
+				7140974D1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m */,
 				71A7EAF71E224648001DA4F2 /* FBClassChainQueryParser.h */,
 				71A7EAF81E224648001DA4F2 /* FBClassChainQueryParser.m */,
 				EE9B76A11CF7A43900275851 /* FBConfiguration.h */,
@@ -1015,6 +1051,8 @@
 				EEE9B4711CD02B88009D2030 /* FBRunLoopSpinner.m */,
 				EE9AB7911CAEDF0C008C271F /* FBRuntimeUtils.h */,
 				EE9AB7921CAEDF0C008C271F /* FBRuntimeUtils.m */,
+				714097491FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h */,
+				7140974A1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m */,
 				EE5A24401F136C8D0078B1D9 /* FBXCodeCompatibility.h */,
 				EE5A24411F136C8D0078B1D9 /* FBXCodeCompatibility.m */,
 				EE7E271A1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.h */,
@@ -1066,8 +1104,12 @@
 				EE55B3261D1D54CF003AAAEC /* FBScrollingTests.m */,
 				EE26409A1D0EB5E8009BE6B0 /* FBTapTest.m */,
 				EE1E06DC1D1811C4007CF043 /* FBTestMacros.h */,
+				71BD20771F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m */,
+				719A97AB1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m */,
 				AD76723F1D6B826F00610457 /* FBTypingTest.m */,
 				714CA3C61DC23186000F12C9 /* FBXPathIntegrationTests.m */,
+				71241D7D1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m */,
+				71241D7F1FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m */,
 				EEBBDB9A1D1032F0000738CD /* XCElementSnapshotHelperTests.m */,
 				EE006EB21EBA1C7B006900A4 /* XCElementSnapshotHitPointTests.m */,
 				EE1E06E31D18213F007CF043 /* XCUIApplicationHelperTests.m */,
@@ -1317,6 +1359,7 @@
 				EE35AD241E3B77D600A02D78 /* XCAccessibilityElement.h in Headers */,
 				EE158AE41CBD456F00A3E3F0 /* FBSession.h in Headers */,
 				EE35AD0F1E3B77D600A02D78 /* _XCTestImplementation.h in Headers */,
+				71241D7B1FAE3D2500B9559F /* FBTouchActionCommands.h in Headers */,
 				EE158ACA1CBD456F00A3E3F0 /* FBTouchIDCommands.h in Headers */,
 				EE35AD6A1E3B77D600A02D78 /* XCUIApplication.h in Headers */,
 				EE158ABA1CBD456F00A3E3F0 /* FBCustomCommands.h in Headers */,
@@ -1411,6 +1454,7 @@
 				71B49EC71ED1A58100D51AD6 /* XCUIElement+FBUID.h in Headers */,
 				EE35AD381E3B77D600A02D78 /* XCSymbolicationRecord.h in Headers */,
 				EE35AD6E1E3B77D600A02D78 /* XCUIDevice.h in Headers */,
+				71BD20731F86116100B36EC2 /* XCUIApplication+FBTouchAction.h in Headers */,
 				EE158ACE1CBD456F00A3E3F0 /* FBCommandHandler.h in Headers */,
 				EE158AC81CBD456F00A3E3F0 /* FBSessionCommands.h in Headers */,
 				EE158AE31CBD456F00A3E3F0 /* FBSession-Private.h in Headers */,
@@ -1428,6 +1472,7 @@
 				EE35AD691E3B77D600A02D78 /* XCTWaiterManager.h in Headers */,
 				EE35AD481E3B77D600A02D78 /* XCTestDriverInterface-Protocol.h in Headers */,
 				EE35AD111E3B77D600A02D78 /* _XCTestSuiteImplementation.h in Headers */,
+				714097431FAE1B0B008FB2C5 /* FBBaseActionsSynthesizer.h in Headers */,
 				AD6C26941CF2379700F8B5FF /* FBAlert.h in Headers */,
 				EE35AD731E3B77D600A02D78 /* XCUIElementQuery.h in Headers */,
 				EE35AD331E3B77D600A02D78 /* XCPointerEvent.h in Headers */,
@@ -1462,10 +1507,12 @@
 				EE35AD6F1E3B77D600A02D78 /* XCUIElement.h in Headers */,
 				EE35AD2F1E3B77D600A02D78 /* XCKeyboardInputSolver.h in Headers */,
 				EE7E271E1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.h in Headers */,
+				714097471FAE1B32008FB2C5 /* FBAppiumActionsSynthesizer.h in Headers */,
 				EE7E271C1D06C69F001BEC7B /* FBDebugLogDelegateDecorator.h in Headers */,
 				EEDFE1211D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.h in Headers */,
 				EE35AD761E3B77D600A02D78 /* XCUIRecorderNodeFinderMatch.h in Headers */,
 				EE35AD6C1E3B77D600A02D78 /* XCUIApplicationProcess.h in Headers */,
+				7140974B1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.h in Headers */,
 				EE35AD151E3B77D600A02D78 /* CDStructures.h in Headers */,
 				EE35AD311E3B77D600A02D78 /* XCKeyboardLayout.h in Headers */,
 				EE35AD3B1E3B77D600A02D78 /* XCTAsyncActivity-Protocol.h in Headers */,
@@ -1730,6 +1777,8 @@
 				EEEC7C931F21F27A0053426C /* FBPredicate.m in Sources */,
 				7136A47A1E8918E60024FC3D /* XCUIElement+FBPickerWheel.m in Sources */,
 				711084451DA3AA7500F913D6 /* FBXPath.m in Sources */,
+				71241D781FAE31F100B9559F /* FBAppiumActionsSynthesizer.m in Sources */,
+				71BD20741F86116100B36EC2 /* XCUIApplication+FBTouchAction.m in Sources */,
 				EE158AE71CBD456F00A3E3F0 /* FBWebServer.m in Sources */,
 				EE3A18631CDE618F00DE4205 /* FBErrorBuilder.m in Sources */,
 				71A7EAF61E20516B001DA4F2 /* XCUIElement+FBClassChain.m in Sources */,
@@ -1738,6 +1787,7 @@
 				AD6C269D1CF2494200F8B5FF /* XCUIApplication+FBHelpers.m in Sources */,
 				EE3A18671CDE734B00DE4205 /* FBKeyboard.m in Sources */,
 				713C6DD01DDC772A00285B92 /* FBElementUtils.m in Sources */,
+				7140974C1FAE1B51008FB2C5 /* FBW3CActionsSynthesizer.m in Sources */,
 				EE158AFA1CBD456F00A3E3F0 /* FBApplicationProcessProxy.m in Sources */,
 				EE6A893B1D0B38640083E92B /* FBFailureProofTestCase.m in Sources */,
 				EE158AB11CBD456F00A3E3F0 /* XCUIElement+FBIsVisible.m in Sources */,
@@ -1756,7 +1806,9 @@
 				EEDFE1221D9C06F800E6FFE5 /* XCUIDevice+FBHealthCheck.m in Sources */,
 				EE158AF81CBD456F00A3E3F0 /* FBSpringboardApplication.m in Sources */,
 				EE158AD91CBD456F00A3E3F0 /* FBResponseFilePayload.m in Sources */,
+				7140974E1FAE20EE008FB2C5 /* FBBaseActionsSynthesizer.m in Sources */,
 				EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */,
+				71241D7C1FAE3D2500B9559F /* FBTouchActionCommands.m in Sources */,
 				EE158ACB1CBD456F00A3E3F0 /* FBTouchIDCommands.m in Sources */,
 				EE158ABD1CBD456F00A3E3F0 /* FBDebugCommands.m in Sources */,
 				716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */,
@@ -1797,7 +1849,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71241D801FAF087500B9559F /* FBW3CMultiTouchActionsIntegrationTests.m in Sources */,
+				71241D7E1FAF084E00B9559F /* FBW3CTouchActionsIntegrationTests.m in Sources */,
 				EE2202131ECC612200A29571 /* FBIntegrationTestCase.m in Sources */,
+				71BD20781F869E0F00B36EC2 /* FBAppiumTouchActionsIntegrationTests.m in Sources */,
+				719A97AC1F88E7370063B4BD /* FBAppiumMultiTouchActionsIntegrationTests.m in Sources */,
 				EE22021E1ECC618900A29571 /* FBTapTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.h
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+
+#import <XCTest/XCTest.h>
+#import "FBElementCache.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIApplication (FBTouchAction)
+
+/**
+ Perform complex touch action in scope of the current application.
+ Touch actions are represented as lists of dictionaries with predefined sets of values and keys.
+ Each dictionary must contain 'action' key, which is one of the following:
+ - 'tap' to perform a single tap
+ - 'longPress' to perform long tap
+ - 'press' to perform press
+ - 'release' to release the finger
+ - 'moveTo' to move the virtual finger
+ - 'wait' to modify the duration of the preceeding action
+ - 'cancel' to cancel all the preceeding actions in the chain
+ Each dictionary can also contain 'options' key with additional parameters dictionary related to the appropriate action.
+ 
+ The following options are mandatory for 'tap', 'longPress', 'press' and 'moveTo' actions:
+ - 'x' the X coordinate of the action
+ - 'y' the Y coordinate of the action
+ - 'element' the corresponding element instance, for which the action is going to be performed
+ If only 'element' is set then hit point coordinates of this element will be used.
+ If only 'x' and 'y' are set then these will be considered as absolute coordinates for 'tap', 'longPress', 'press' actions, but as relative coordinates for 'moveTo' action.
+ If both 'element' and 'x'/'y' are set then these will act as relative element coordinates.
+ 
+ It is also mandatory, that 'release', 'moveTo' and 'wait' actions are preceeded with at least one chain item, which contains absolute coordinates, like 'tap', 'press' or 'longPress'. Empty chains are not allowed.
+ 
+ The following additional options are available for different actions:
+ - 'tap': 'count' (defines count of taps to be performed in a row; 1 by default)
+ - 'longPress': 'duration' (number of milliseconds to hold/move the virtual finger; 500.0 ms by default)
+ - 'wait': 'ms' (number of milliseconds to wait for the preceeding action; 0.0 ms by default)
+ - 'press', 'longPress': 'pressure' (float number, which defines pressure value; 0.0 by default)
+ 
+ List of lists can be passed there is order to perform multi-finger touch action. Each single actions chain is going to be executed by a separate virtual finger in such case.
+ 
+ @param actions Either array of dictionaries, whose format is described above to peform single-finger touch action or array of array to perform multi-finger touch action.
+ @param elementCache Cached elements mapping for the currrent application. The method assumes all elements are already represented by their actual instances if nil value is set
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return YES If the touch action has been successfully performed without errors
+ */
+- (BOOL)fb_performAppiumTouchActions:(NSArray *)actions elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error;
+
+/**
+ Perform complex touch action in scope of the current application.
+ 
+ @param actions Array of dictionaries, whose format is described in W3C spec (https://github.com/jlipps/simple-wd-spec#perform-actions)
+ @param elementCache Cached elements mapping for the currrent application. The method assumes all elements are already represented by their actual instances if nil value is set
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return YES If the touch action has been successfully performed without errors
+ */
+- (BOOL)fb_performW3CTouchActions:(NSArray *)actions elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  - 'release' to release the finger
  - 'moveTo' to move the virtual finger
  - 'wait' to modify the duration of the preceeding action
- - 'cancel' to cancel all the preceeding actions in the chain
+ - 'cancel' to cancel the preceeding action in the chain
  Each dictionary can also contain 'options' key with additional parameters dictionary related to the appropriate action.
  
  The following options are mandatory for 'tap', 'longPress', 'press' and 'moveTo' actions:
@@ -33,10 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
  - 'y' the Y coordinate of the action
  - 'element' the corresponding element instance, for which the action is going to be performed
  If only 'element' is set then hit point coordinates of this element will be used.
- If only 'x' and 'y' are set then these will be considered as absolute coordinates for 'tap', 'longPress', 'press' actions, but as relative coordinates for 'moveTo' action.
+ If only 'x' and 'y' are set then these will be considered as absolute coordinates.
  If both 'element' and 'x'/'y' are set then these will act as relative element coordinates.
  
- It is also mandatory, that 'release', 'moveTo' and 'wait' actions are preceeded with at least one chain item, which contains absolute coordinates, like 'tap', 'press' or 'longPress'. Empty chains are not allowed.
+ It is also mandatory, that 'release' and 'wait' actions are preceeded with at least one chain item, which contains absolute coordinates, like 'tap', 'press' or 'longPress'. Empty chains are not allowed.
  
  The following additional options are available for different actions:
  - 'tap': 'count' (defines count of taps to be performed in a row; 1 by default)

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBTouchAction.m
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+
+#import "XCUIApplication+FBTouchAction.h"
+
+#import "FBAppiumActionsSynthesizer.h"
+#import "FBBaseActionsSynthesizer.h"
+#import "FBLogger.h"
+#import "FBRunLoopSpinner.h"
+#import "FBW3CActionsSynthesizer.h"
+#import "XCEventGenerator.h"
+#import "XCTRunnerDaemonSession.h"
+
+@implementation XCUIApplication (FBTouchAction)
+
+- (BOOL)fb_performActionsWithSynthesizerType:(Class)synthesizerType actions:(NSArray *)actions elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error
+{
+  FBBaseActionsSynthesizer *synthesizer = [[synthesizerType alloc] initWithActions:actions forApplication:self elementCache:elementCache error:error];
+  if (nil == synthesizer) {
+    return NO;
+  }
+  XCSynthesizedEventRecord *eventRecord = [synthesizer synthesizeWithError:error];
+  if (nil == eventRecord) {
+    return NO;
+  }
+  return [self fb_synthesizeEvent:eventRecord error:error];
+}
+
+- (BOOL)fb_performAppiumTouchActions:(NSArray *)actions elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error
+{
+  return [self fb_performActionsWithSynthesizerType:FBAppiumActionsSynthesizer.class actions:actions elementCache:elementCache error:error];
+}
+
+- (BOOL)fb_performW3CTouchActions:(NSArray *)actions elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error
+{
+  return [self fb_performActionsWithSynthesizerType:FBW3CActionsSynthesizer.class actions:actions elementCache:elementCache error:error];
+}
+
+- (BOOL)fb_synthesizeEvent:(XCSynthesizedEventRecord *)event error:(NSError *__autoreleasing*)error
+{
+  __block BOOL didSucceed;
+  [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)(void)){
+    XCEventGeneratorHandler handlerBlock = ^(XCSynthesizedEventRecord *record, NSError *commandError) {
+      if (commandError) {
+        [FBLogger logFmt:@"Failed to perform complex gesture: %@", commandError];
+      }
+      if (error) {
+        *error = commandError;
+      }
+      didSucceed = (commandError == nil);
+      completion();
+    };
+
+    [[XCTRunnerDaemonSession sharedSession] synthesizeEvent:event completion:^(NSError *invokeError){
+      handlerBlock(event, invokeError);
+    }];
+  }];
+  return didSucceed;
+}
+
+
+@end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBTap.m
@@ -9,82 +9,37 @@
 
 #import "XCUIElement+FBTap.h"
 
-#import "FBRunLoopSpinner.h"
-#import "FBLogger.h"
-#import "FBMacros.h"
-#import "FBMathUtils.h"
+#import "XCUIApplication+FBTouchAction.h"
 #import "XCUIElement+FBUtilities.h"
-#import "XCEventGenerator.h"
-#import "XCSynthesizedEventRecord.h"
-#import "XCElementSnapshot+FBHitPoint.h"
-#import "XCPointerEventPath.h"
-#import "XCTRunnerDaemonSession.h"
 
-const CGFloat FBTapDuration = 0.01f;
 
 @implementation XCUIElement (FBTap)
 
 - (BOOL)fb_tapWithError:(NSError **)error
 {
-  XCElementSnapshot *snapshot = self.fb_lastSnapshot;
-  CGPoint hitpoint = snapshot.fb_hitPoint;
-  if (CGPointEqualToPoint(hitpoint, CGPointMake(-1, -1))) {
-    hitpoint = [snapshot.suggestedHitpoints.lastObject CGPointValue];
-  }
-  return [self fb_performTapAtPoint:hitpoint error:error];
+  NSArray<NSDictionary<NSString *, id> *> *tapGesture =
+  @[
+    @{@"action": @"tap",
+      @"options": @{@"element": self}
+      }
+    ];
+  [self fb_waitUntilFrameIsStable];
+  return [self.application fb_performAppiumTouchActions:tapGesture elementCache:nil error:error];
 }
 
 - (BOOL)fb_tapCoordinate:(CGPoint)relativeCoordinate error:(NSError **)error
 {
-  CGPoint hitPoint = CGPointMake(self.frame.origin.x + relativeCoordinate.x, self.frame.origin.y + relativeCoordinate.y);
-  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-    /*
-     Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
-     even if the device is not in portait mode. That is why we need to recalculate them manually
-     based on the current orientation value
-     */
-    hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
-  }
-  return [self fb_performTapAtPoint:hitPoint error:error];
-}
-
-- (BOOL)fb_performTapAtPoint:(CGPoint)hitPoint error:(NSError *__autoreleasing*)error
-{
+  NSArray<NSDictionary<NSString *, id> *> *tapGesture =
+  @[
+    @{@"action": @"tap",
+      @"options": @{@"element": self,
+                    @"x": @(relativeCoordinate.x),
+                    @"y": @(relativeCoordinate.y)
+                    }
+      }
+    ];
   [self fb_waitUntilFrameIsStable];
-  __block BOOL didSucceed;
-  [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)(void)){
-    XCEventGeneratorHandler handlerBlock = ^(XCSynthesizedEventRecord *record, NSError *commandError) {
-      if (commandError) {
-        [FBLogger logFmt:@"Failed to perform tap: %@", commandError];
-      }
-      if (error) {
-        *error = commandError;
-      }
-      didSucceed = (commandError == nil);
-      completion();
-    };
-
-    XCSynthesizedEventRecord *event = [self fb_generateTapEvent:hitPoint orientation:self.interfaceOrientation];
-    [[XCTRunnerDaemonSession sharedSession] synthesizeEvent:event completion:^(NSError *invokeError){
-      handlerBlock(event, invokeError);
-    }];
-  }];
-  return didSucceed;
-}
-
-- (XCSynthesizedEventRecord *)fb_generateTapEvent:(CGPoint)hitPoint orientation:(UIInterfaceOrientation)orientation
-{
-  XCPointerEventPath *eventPath = [[XCPointerEventPath alloc] initForTouchAtPoint:hitPoint offset:0.0];
-  [eventPath liftUpAtOffset:FBTapDuration];
-  if (![XCTRunnerDaemonSession sharedSession].useLegacyEventCoordinateTransformationPath) {
-    orientation = UIInterfaceOrientationPortrait;
-  }
-  XCSynthesizedEventRecord *event =
-  [[XCSynthesizedEventRecord alloc]
-   initWithName:[NSString stringWithFormat:@"Tap on %@", NSStringFromCGPoint(hitPoint)]
-   interfaceOrientation:orientation];
-  [event addPointerEventPath:eventPath];
-  return event;
+  return [self.application fb_performAppiumTouchActions:tapGesture elementCache:nil error:error];
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -10,16 +10,16 @@
 #import "FBElementCommands.h"
 
 #import "FBApplication.h"
+#import "FBElementCache.h"
+#import "FBElementTypeTransformer.h"
+#import "FBErrorBuilder.h"
 #import "FBKeyboard.h"
+#import "FBMacros.h"
 #import "FBPredicate.h"
 #import "FBRoute.h"
 #import "FBRouteRequest.h"
 #import "FBRunLoopSpinner.h"
-#import "FBElementCache.h"
-#import "FBErrorBuilder.h"
 #import "FBSession.h"
-#import "FBApplication.h"
-#import "FBMacros.h"
 #import "FBMathUtils.h"
 #import "FBRuntimeUtils.h"
 #import "NSPredicate+FBFormat.h"
@@ -32,7 +32,6 @@
 #import "XCUIElement+FBTyping.h"
 #import "XCUIElement+FBUtilities.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
-#import "FBElementTypeTransformer.h"
 #import "XCUIElement.h"
 #import "XCUIElementQuery.h"
 
@@ -71,7 +70,7 @@
     [[FBRoute POST:@"/wda/touchAndHold"] respondWithTarget:self action:@selector(handleTouchAndHoldCoordinate:)],
     [[FBRoute POST:@"/wda/doubleTap"] respondWithTarget:self action:@selector(handleDoubleTapCoordinate:)],
     [[FBRoute POST:@"/wda/keys"] respondWithTarget:self action:@selector(handleKeys:)],
-    [[FBRoute POST:@"/wda/pickerwheel/:uuid/select"] respondWithTarget:self action:@selector(handleWheelSelect:)]
+    [[FBRoute POST:@"/wda/pickerwheel/:uuid/select"] respondWithTarget:self action:@selector(handleWheelSelect:)],
   ];
 }
 

--- a/WebDriverAgentLib/Commands/FBTouchActionCommands.h
+++ b/WebDriverAgentLib/Commands/FBTouchActionCommands.h
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <WebDriverAgentLib/FBCommandHandler.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBTouchActionCommands : NSObject <FBCommandHandler>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Commands/FBTouchActionCommands.m
+++ b/WebDriverAgentLib/Commands/FBTouchActionCommands.m
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBTouchActionCommands.h"
+
+#import "FBApplication.h"
+#import "FBRoute.h"
+#import "FBRouteRequest.h"
+#import "FBSession.h"
+#import "XCUIApplication+FBTouchAction.h"
+
+@implementation FBTouchActionCommands
+
+#pragma mark - <FBCommandHandler>
+
++ (NSArray *)routes
+{
+  return
+  @[
+    [[FBRoute POST:@"/wda/touch/perform"] respondWithTarget:self action:@selector(handlePerformAppiumTouchActions:)],
+    [[FBRoute POST:@"/wda/touch/multi/perform"] respondWithTarget:self action:@selector(handlePerformAppiumTouchActions:)],
+    [[FBRoute POST:@"/actions"] respondWithTarget:self action:@selector(handlePerformW3CTouchActions:)],
+  ];
+}
+
+#pragma mark - Commands
+
++ (id<FBResponsePayload>)handlePerformAppiumTouchActions:(FBRouteRequest *)request
+{
+  XCUIApplication *application = request.session.application;
+  NSArray *actions = (NSArray *)request.arguments[@"actions"];
+  NSError *error;
+  if (![application fb_performAppiumTouchActions:actions elementCache:request.session.elementCache error:&error]) {
+    return FBResponseWithError(error);
+  }
+  return FBResponseWithOK();
+}
+
++ (id<FBResponsePayload>)handlePerformW3CTouchActions:(FBRouteRequest *)request
+{
+  XCUIApplication *application = request.session.application;
+  NSArray *actions = (NSArray *)request.arguments[@"actions"];
+  NSError *error;
+  if (![application fb_performW3CTouchActions:actions elementCache:request.session.elementCache error:&error]) {
+    return FBResponseWithError(error);
+  }
+  return FBResponseWithOK();
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBBaseActionsSynthesizer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBAppiumActionsSynthesizer : FBBaseActionsSynthesizer
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -134,7 +134,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
     return nil;
   }
   NSValue *offset = (nil != x && nil != y) ? [NSValue valueWithCGPoint:CGPointMake(x.floatValue, y.floatValue)] : nil;
-  return [NSValue valueWithCGPoint:[self hitpointWithElement:element positionOffset:offset]];
+  return [self hitpointWithElement:element positionOffset:offset error:error];
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -25,10 +25,6 @@ static const double FB_LONG_TAP_DURATION_MS = 500.0;
 static NSString *const FB_OPTIONS_KEY = @"options";
 static NSString *const FB_ELEMENT_KEY = @"element";
 
-static double millisToSeconds (double msec) {
-  return msec / 1000.0;
-}
-
 @interface FBAppiumGestureItem : FBBaseGestureItem
 
 @end
@@ -144,17 +140,17 @@ static double millisToSeconds (double msec) {
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
   if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
-    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
+    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
   }
-  [eventPath liftUpAtOffset:millisToSeconds(self.offset + FB_TAP_DURATION_MS)];
+  [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset + FB_TAP_DURATION_MS)];
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
   if ([options isKindOfClass:NSDictionary.class]) {
     NSNumber *tapCount = [options objectForKey:@"count"] ?: @1;
     for (NSInteger times = 1; times < tapCount.integerValue; times++) {
-      [eventPath pressDownAtOffset:millisToSeconds(self.offset + FB_TAP_DURATION_MS * times)];
-      [eventPath liftUpAtOffset:millisToSeconds(self.offset + FB_TAP_DURATION_MS * (times + 1))];
+      [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset + FB_TAP_DURATION_MS * times)];
+      [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset + FB_TAP_DURATION_MS * (times + 1))];
     }
   }
   return YES;
@@ -191,15 +187,15 @@ static double millisToSeconds (double msec) {
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
   if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   }
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
   NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:@"pressure"] : nil;
   if (nil == pressure) {
-    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
   } else {
-    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:FBMillisToSeconds(self.offset)];
   }
   return YES;
 }
@@ -226,15 +222,15 @@ static double millisToSeconds (double msec) {
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
   if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   }
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
   NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:@"pressure"] : nil;
   if (nil == pressure) {
-    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
   } else {
-    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:FBMillisToSeconds(self.offset)];
   }
   return YES;
 }
@@ -262,7 +258,7 @@ static double millisToSeconds (double msec) {
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
-  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   return YES;
 }
 
@@ -314,7 +310,7 @@ static double millisToSeconds (double msec) {
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
-  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   return YES;
 }
 
@@ -334,7 +330,7 @@ static double millisToSeconds (double msec) {
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
-  [eventPath liftUpAtOffset:millisToSeconds(self.offset)];
+  [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset)];
   return YES;
 }
 

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -20,6 +20,20 @@
 #import "XCTRunnerDaemonSession.h"
 #import "XCPointerEventPath.h"
 
+static NSString *const FB_ACTION_KEY = @"action";
+static NSString *const FB_ACTION_TAP = @"tap";
+static NSString *const FB_ACTION_PRESS = @"press";
+static NSString *const FB_ACTION_LONG_PRESS = @"longPress";
+static NSString *const FB_ACTION_MOVE_TO = @"moveTo";
+static NSString *const FB_ACTION_RELEASE = @"release";
+static NSString *const FB_ACTION_CANCEL = @"cancel";
+static NSString *const FB_ACTION_WAIT = @"wait";
+
+static NSString *const FB_OPTION_DURATION = @"duration";
+static NSString *const FB_OPTION_PRESSURE = @"pressure";
+static NSString *const FB_OPTION_COUNT = @"count";
+static NSString *const FB_OPTION_MS = @"ms";
+
 static const double FB_TAP_DURATION_MS = 100.0;
 static const double FB_LONG_TAP_DURATION_MS = 500.0;
 static NSString *const FB_OPTIONS_KEY = @"options";
@@ -77,7 +91,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
     }
     self.duration = [self durationWithOptions:options];
     if (self.duration < 0) {
-      NSString *description = [NSString stringWithFormat:@"Duration value cannot be negative for '%@' action", self.class.actionName];
+      NSString *description = [NSString stringWithFormat:@"%@ value cannot be negative for '%@' action", FB_OPTION_DURATION, self.class.actionName];
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:description] build];
       }
@@ -95,8 +109,8 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
 {
-  return (options && [options objectForKey:@"duration"]) ?
-    ((NSNumber *)[options objectForKey:@"duration"]).doubleValue :
+  return (options && [options objectForKey:FB_OPTION_DURATION]) ?
+    ((NSNumber *)[options objectForKey:FB_OPTION_DURATION]).doubleValue :
     0.0;
 }
 
@@ -129,7 +143,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 + (NSString *)actionName
 {
-  return @"tap";
+  return FB_ACTION_TAP;
 }
 
 + (BOOL)hasAbsolutePositioning
@@ -147,7 +161,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
   if ([options isKindOfClass:NSDictionary.class]) {
-    NSNumber *tapCount = [options objectForKey:@"count"] ?: @1;
+    NSNumber *tapCount = [options objectForKey:FB_OPTION_COUNT] ?: @1;
     for (NSInteger times = 1; times < tapCount.integerValue; times++) {
       [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset + FB_TAP_DURATION_MS * times)];
       [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset + FB_TAP_DURATION_MS * (times + 1))];
@@ -160,7 +174,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 {
   NSNumber *tapCount = @1;
   if ([options isKindOfClass:NSDictionary.class]) {
-    tapCount = [options objectForKey:@"count"] ?: tapCount;
+    tapCount = [options objectForKey:FB_OPTION_COUNT] ?: tapCount;
   }
   return FB_TAP_DURATION_MS * tapCount.integerValue;
 }
@@ -176,7 +190,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 + (NSString *)actionName
 {
-  return @"press";
+  return FB_ACTION_PRESS;
 }
 
 + (BOOL)hasAbsolutePositioning
@@ -191,7 +205,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   }
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
-  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:@"pressure"] : nil;
+  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:FB_OPTION_PRESSURE] : nil;
   if (nil == pressure) {
     [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
   } else {
@@ -211,7 +225,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 + (NSString *)actionName
 {
-  return @"longPress";
+  return FB_ACTION_LONG_PRESS;
 }
 
 + (BOOL)hasAbsolutePositioning
@@ -226,7 +240,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   }
   
   id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
-  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:@"pressure"] : nil;
+  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:FB_OPTION_PRESSURE] : nil;
   if (nil == pressure) {
     [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
   } else {
@@ -237,9 +251,9 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
 {
-  return (options && [options objectForKey:@"duration"]) ?
-  ((NSNumber *)[options objectForKey:@"duration"]).doubleValue :
-  FB_LONG_TAP_DURATION_MS;
+  return (options && [options objectForKey:FB_OPTION_DURATION]) ?
+    ((NSNumber *)[options objectForKey:FB_OPTION_DURATION]).doubleValue :
+    FB_LONG_TAP_DURATION_MS;
 }
 
 @end
@@ -248,7 +262,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 + (NSString *)actionName
 {
-  return @"wait";
+  return FB_ACTION_WAIT;
 }
 
 + (BOOL)hasAbsolutePositioning
@@ -264,48 +278,23 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 - (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
 {
-  return (options && [options objectForKey:@"ms"]) ?
-  ((NSNumber *)[options objectForKey:@"ms"]).doubleValue :
-  0.0;
+  return (options && [options objectForKey:FB_OPTION_MS]) ?
+    ((NSNumber *)[options objectForKey:FB_OPTION_MS]).doubleValue :
+    0.0;
 }
 
 @end
 
 @implementation FBMoveToItem
 
-- (nullable instancetype)initWithActionItem:(NSDictionary<NSString *, id> *)item application:(XCUIApplication *)application atPosition:(NSValue *)atPosition offset:(double)offset error:(NSError **)error
-{
-  _recentPosition = atPosition;
-  
-  self = [super initWithActionItem:item application:application atPosition:nil offset:offset error:error];
-  if (!self) {
-    return nil;
-  }
-  return self;
-}
-
-- (CGPoint)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset
-{
-  if (nil == element) {
-    // if element is not set then we consider coordinates passed to moveTo action as relative
-    CGPoint recentPosition = [self.recentPosition CGPointValue];
-    CGPoint offsetRelativeToRecentPosition = [positionOffset CGPointValue];
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
-      offsetRelativeToRecentPosition = FBInvertOffsetForOrientation(offsetRelativeToRecentPosition, self.application.interfaceOrientation);
-    }
-    return CGPointMake(recentPosition.x + offsetRelativeToRecentPosition.x, recentPosition.y + offsetRelativeToRecentPosition.y);
-  }
-  return [super hitpointWithElement:element positionOffset:positionOffset];
-}
-
 + (NSString *)actionName
 {
-  return @"moveTo";
+  return FB_ACTION_MOVE_TO;
 }
 
 + (BOOL)hasAbsolutePositioning
 {
-  return NO;
+  return YES;
 }
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
@@ -320,7 +309,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 + (NSString *)actionName
 {
-  return @"release";
+  return FB_ACTION_RELEASE;
 }
 
 + (BOOL)hasAbsolutePositioning
@@ -373,31 +362,43 @@ static NSString *const FB_ELEMENT_KEY = @"element";
 
 @implementation FBAppiumActionsSynthesizer
 
-- (NSArray<NSDictionary<NSString *, id> *> *)preprocessAction:(NSArray<NSDictionary<NSString *, id> *> *)touchAction
+- (NSArray<NSDictionary<NSString *, id> *> *)preprocessAction:(NSArray<NSDictionary<NSString *, id> *> *)touchActionItems
 {
-  if (nil == self.elementCache) {
-    return touchAction;
-  }
   NSMutableArray<NSDictionary<NSString *, id> *> *result = [NSMutableArray array];
-  for (NSDictionary<NSString *, id> *touchItem in touchAction) {
+  BOOL shouldSkipNextItem = NO;
+  for (NSDictionary<NSString *, id> *touchItem in [touchActionItems reverseObjectEnumerator]) {
+    id actionItemName = [touchItem objectForKey:FB_ACTION_KEY];
+    if ([actionItemName isKindOfClass:NSString.class] && [actionItemName isEqualToString:FB_ACTION_CANCEL]) {
+      shouldSkipNextItem = YES;;
+      continue;
+    }
+    if (shouldSkipNextItem) {
+      shouldSkipNextItem = NO;
+      continue;
+    }
+    
     id options = [touchItem objectForKey:FB_OPTIONS_KEY];
-    if (![options isKindOfClass:NSDictionary.class] || ![options objectForKey:FB_ELEMENT_KEY]) {
+    if (![options isKindOfClass:NSDictionary.class]) {
+      [result addObject:touchItem];
+      continue;
+    }
+    NSString *uuid = [options objectForKey:FB_ELEMENT_KEY];
+    if (nil == uuid || nil == self.elementCache) {
+      [result addObject:touchItem];
+      continue;
+    }
+    XCUIElement *element = [self.elementCache elementForUUID:uuid];
+    if (nil == element) {
       [result addObject:touchItem];
       continue;
     }
     NSMutableDictionary<NSString *, id> *processedItem = touchItem.mutableCopy;
     NSMutableDictionary<NSString *, id> *processedOptions = ((NSDictionary *)[processedItem objectForKey:FB_OPTIONS_KEY]).mutableCopy;
-    NSString *uuid = [options objectForKey:FB_ELEMENT_KEY];
-    XCUIElement *element = [self.elementCache elementForUUID:uuid];
-    if (nil == element) {
-      [result addObject:touchItem];
-    } else {
-      [processedOptions setObject:element forKey:FB_ELEMENT_KEY];
-      [processedItem setObject:processedOptions.copy forKey:FB_OPTIONS_KEY];
-      [result addObject:processedItem.copy];
-    }
+    [processedOptions setObject:element forKey:FB_ELEMENT_KEY];
+    [processedItem setObject:processedOptions.copy forKey:FB_OPTIONS_KEY];
+    [result addObject:processedItem.copy];
   }
-  return result.copy;
+  return [[result reverseObjectEnumerator] allObjects];
 }
 
 - (nullable XCPointerEventPath *)eventPathWithAction:(NSArray<NSDictionary<NSString *, id> *> *)action error:(NSError **)error
@@ -420,23 +421,18 @@ static NSString *const FB_ELEMENT_KEY = @"element";
   FBAppiumGestureItemsChain *chain = [[FBAppiumGestureItemsChain alloc] init];
   BOOL isAbsoluteTouchPositionSet = NO;
   for (NSDictionary<NSString *, id> *actionItem in action) {
-    id actionItemName = [actionItem objectForKey:@"action"];
+    id actionItemName = [actionItem objectForKey:FB_ACTION_KEY];
     if (![actionItemName isKindOfClass:NSString.class]) {
-      NSString *description = [NSString stringWithFormat:@"'action' property is mandatory for gesture chain item %@", actionItem];
+      NSString *description = [NSString stringWithFormat:@"'%@' property is mandatory for gesture chain item %@", FB_ACTION_KEY, actionItem];
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:description] build];
       }
       return nil;
     }
-    
-    if ([actionItemName isEqualToString:@"cancel"]) {
-      [chain reset];
-      continue;
-    }
-    
+
     Class gestureItemClass = [gestureItemsMapping objectForKey:actionItemName];
     if (nil == gestureItemClass) {
-      NSString *description = [NSString stringWithFormat:@"Action value '%@' is unknown", actionItemName];
+      NSString *description = [NSString stringWithFormat:@"%@ value '%@' is unknown", FB_ACTION_KEY, actionItemName];
       if (error) {
         *error = [[FBErrorBuilder.builder withDescription:description] build];
       }
@@ -450,7 +446,7 @@ static NSString *const FB_ELEMENT_KEY = @"element";
     } else {
       if (!isAbsoluteTouchPositionSet) {
         if (error) {
-          NSString *description = [NSString stringWithFormat:@"'%@' action should be preceded by an item with absolute positioning", actionItemName];
+          NSString *description = [NSString stringWithFormat:@"'%@' %@ should be preceded by an item with absolute positioning", actionItemName, FB_ACTION_KEY];
           *error = [[FBErrorBuilder.builder withDescription:description] build];
         }
         return nil;

--- a/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBAppiumActionsSynthesizer.m
@@ -1,0 +1,496 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBAppiumActionsSynthesizer.h"
+
+#import "FBErrorBuilder.h"
+#import "FBElementCache.h"
+#import "FBLogger.h"
+#import "FBMacros.h"
+#import "FBMathUtils.h"
+#import "XCUIElement+FBUtilities.h"
+#import "XCUIElement.h"
+#import "XCSynthesizedEventRecord.h"
+#import "XCTRunnerDaemonSession.h"
+#import "XCPointerEventPath.h"
+
+static const double FB_TAP_DURATION_MS = 100.0;
+static const double FB_LONG_TAP_DURATION_MS = 500.0;
+static NSString *const FB_OPTIONS_KEY = @"options";
+static NSString *const FB_ELEMENT_KEY = @"element";
+
+static double millisToSeconds (double msec) {
+  return msec / 1000.0;
+}
+
+@interface FBAppiumGestureItem : FBBaseGestureItem
+
+@end
+
+@interface FBTapItem : FBAppiumGestureItem
+
+@end
+
+@interface FBPressItem : FBAppiumGestureItem
+
+@end
+
+@interface FBLongPressItem : FBAppiumGestureItem
+
+@end
+
+@interface FBWaitItem : FBAppiumGestureItem
+
+@end
+
+@interface FBMoveToItem : FBAppiumGestureItem
+
+@property (nonatomic, nonnull) NSValue *recentPosition;
+
+@end
+
+@interface FBReleaseItem : FBAppiumGestureItem
+
+@end
+
+
+@implementation FBAppiumGestureItem
+
+- (nullable instancetype)initWithActionItem:(NSDictionary<NSString *, id> *)item application:(XCUIApplication *)application atPosition:(nullable NSValue *)atPosition offset:(double)offset error:(NSError **)error
+{
+  self = [super init];
+  if (self) {
+    self.actionItem = item;
+    self.application = application;
+    self.offset = offset;
+    id options = [item objectForKey:FB_OPTIONS_KEY];
+    if (atPosition) {
+      self.atPosition = [atPosition CGPointValue];
+    } else {
+      NSValue *result = [self coordinatesWithOptions:options error:error];
+      if (nil == result) {
+        return nil;
+      }
+      self.atPosition = [result CGPointValue];
+    }
+    self.duration = [self durationWithOptions:options];
+    if (self.duration < 0) {
+      NSString *description = [NSString stringWithFormat:@"Duration value cannot be negative for '%@' action", self.class.actionName];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+  }
+  return self;
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  @throw [[FBErrorBuilder.builder withDescription:@"Override this method in subclasses"] build];
+  return NO;
+}
+
+- (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
+{
+  return (options && [options objectForKey:@"duration"]) ?
+    ((NSNumber *)[options objectForKey:@"duration"]).doubleValue :
+    0.0;
+}
+
+- (nullable NSValue *)coordinatesWithOptions:(nullable NSDictionary<NSString *, id> *)options error:(NSError **)error
+{
+  if (![options isKindOfClass:NSDictionary.class]) {
+    NSString *description = [NSString stringWithFormat:@"'%@' key is mandatory for '%@' action", FB_OPTIONS_KEY, self.class.actionName];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  XCUIElement *element = [options objectForKey:FB_ELEMENT_KEY];
+  NSNumber *x = [options objectForKey:@"x"];
+  NSNumber *y = [options objectForKey:@"y"];
+  if ((nil != x && nil == y) || (nil != y && nil == x) || (nil == x && nil == y && nil == element)) {
+    NSString *description = [NSString stringWithFormat:@"Either '%@' or 'x' and 'y' options should be set for '%@' action", FB_ELEMENT_KEY, self.class.actionName];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  NSValue *offset = (nil != x && nil != y) ? [NSValue valueWithCGPoint:CGPointMake(x.floatValue, y.floatValue)] : nil;
+  return [NSValue valueWithCGPoint:[self hitpointWithElement:element positionOffset:offset]];
+}
+
+@end
+
+@implementation FBTapItem
+
++ (NSString *)actionName
+{
+  return @"tap";
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  return YES;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  if (index > 0) {
+    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+  }
+  [eventPath liftUpAtOffset:millisToSeconds(self.offset + FB_TAP_DURATION_MS)];
+  
+  id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
+  if ([options isKindOfClass:NSDictionary.class]) {
+    NSNumber *tapCount = [options objectForKey:@"count"] ?: @1;
+    for (NSInteger times = 1; times < tapCount.integerValue; times++) {
+      [eventPath pressDownAtOffset:millisToSeconds(self.offset + FB_TAP_DURATION_MS * times)];
+      [eventPath liftUpAtOffset:millisToSeconds(self.offset + FB_TAP_DURATION_MS * (times + 1))];
+    }
+  }
+  return YES;
+}
+
+- (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
+{
+  NSNumber *tapCount = @1;
+  if ([options isKindOfClass:NSDictionary.class]) {
+    tapCount = [options objectForKey:@"count"] ?: tapCount;
+  }
+  return FB_TAP_DURATION_MS * tapCount.integerValue;
+}
+
+- (BOOL)increaseDuration:(double)value
+{
+  return NO;
+}
+
+@end
+
+@implementation FBPressItem
+
++ (NSString *)actionName
+{
+  return @"press";
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  return YES;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  if (index > 0) {
+    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  }
+  
+  id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
+  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:@"pressure"] : nil;
+  if (nil == pressure) {
+    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+  } else {
+    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:millisToSeconds(self.offset)];
+  }
+  return YES;
+}
+
+- (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
+{
+  return 0.0;
+}
+
+@end
+
+@implementation FBLongPressItem
+
++ (NSString *)actionName
+{
+  return @"longPress";
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  return YES;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  if (index > 0) {
+    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  }
+  
+  id options = [self.actionItem objectForKey:FB_OPTIONS_KEY];
+  NSNumber *pressure = [options isKindOfClass:NSDictionary.class] ? [options objectForKey:@"pressure"] : nil;
+  if (nil == pressure) {
+    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+  } else {
+    [eventPath pressDownWithPressure:pressure.doubleValue atOffset:millisToSeconds(self.offset)];
+  }
+  return YES;
+}
+
+- (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
+{
+  return (options && [options objectForKey:@"duration"]) ?
+  ((NSNumber *)[options objectForKey:@"duration"]).doubleValue :
+  FB_LONG_TAP_DURATION_MS;
+}
+
+@end
+
+@implementation FBWaitItem
+
++ (NSString *)actionName
+{
+  return @"wait";
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  return NO;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  return YES;
+}
+
+- (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
+{
+  return (options && [options objectForKey:@"ms"]) ?
+  ((NSNumber *)[options objectForKey:@"ms"]).doubleValue :
+  0.0;
+}
+
+@end
+
+@implementation FBMoveToItem
+
+- (nullable instancetype)initWithActionItem:(NSDictionary<NSString *, id> *)item application:(XCUIApplication *)application atPosition:(NSValue *)atPosition offset:(double)offset error:(NSError **)error
+{
+  _recentPosition = atPosition;
+  
+  self = [super initWithActionItem:item application:application atPosition:nil offset:offset error:error];
+  if (!self) {
+    return nil;
+  }
+  return self;
+}
+
+- (CGPoint)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset
+{
+  if (nil == element) {
+    // if element is not set then we consider coordinates passed to moveTo action as relative
+    CGPoint recentPosition = [self.recentPosition CGPointValue];
+    CGPoint offsetRelativeToRecentPosition = [positionOffset CGPointValue];
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+      offsetRelativeToRecentPosition = FBInvertOffsetForOrientation(offsetRelativeToRecentPosition, self.application.interfaceOrientation);
+    }
+    return CGPointMake(recentPosition.x + offsetRelativeToRecentPosition.x, recentPosition.y + offsetRelativeToRecentPosition.y);
+  }
+  return [super hitpointWithElement:element positionOffset:positionOffset];
+}
+
++ (NSString *)actionName
+{
+  return @"moveTo";
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  return NO;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  return YES;
+}
+
+@end
+
+@implementation FBReleaseItem
+
++ (NSString *)actionName
+{
+  return @"release";
+}
+
++ (BOOL)hasAbsolutePositioning
+{
+  return NO;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  [eventPath liftUpAtOffset:millisToSeconds(self.offset)];
+  return YES;
+}
+
+- (BOOL)increaseDuration:(double)value
+{
+  return NO;
+}
+
+- (double)durationWithOptions:(nullable NSDictionary<NSString *, id> *)options
+{
+  return 0.0;
+}
+
+@end
+
+
+@interface FBAppiumGestureItemsChain : FBBaseGestureItemsChain
+
+@end
+
+@implementation FBAppiumGestureItemsChain
+
+- (void)addItem:(FBBaseGestureItem *)item
+{
+  self.durationOffset += item.duration;
+  if ([item isKindOfClass:FBWaitItem.class] && [self.items.lastObject increaseDuration:item.duration]) {
+    // Merge wait duration to the recent action if possible
+    return;
+  }
+  [self.items addObject:item];
+}
+
+- (void)reset
+{
+  [self.items removeAllObjects];
+  self.durationOffset = 0.0;
+}
+
+@end
+
+@implementation FBAppiumActionsSynthesizer
+
+- (NSArray<NSDictionary<NSString *, id> *> *)preprocessAction:(NSArray<NSDictionary<NSString *, id> *> *)touchAction
+{
+  if (nil == self.elementCache) {
+    return touchAction;
+  }
+  NSMutableArray<NSDictionary<NSString *, id> *> *result = [NSMutableArray array];
+  for (NSDictionary<NSString *, id> *touchItem in touchAction) {
+    id options = [touchItem objectForKey:FB_OPTIONS_KEY];
+    if (![options isKindOfClass:NSDictionary.class] || ![options objectForKey:FB_ELEMENT_KEY]) {
+      [result addObject:touchItem];
+      continue;
+    }
+    NSMutableDictionary<NSString *, id> *processedItem = touchItem.mutableCopy;
+    NSMutableDictionary<NSString *, id> *processedOptions = ((NSDictionary *)[processedItem objectForKey:FB_OPTIONS_KEY]).mutableCopy;
+    NSString *uuid = [options objectForKey:FB_ELEMENT_KEY];
+    XCUIElement *element = [self.elementCache elementForUUID:uuid];
+    if (nil == element) {
+      [result addObject:touchItem];
+    } else {
+      [processedOptions setObject:element forKey:FB_ELEMENT_KEY];
+      [processedItem setObject:processedOptions.copy forKey:FB_OPTIONS_KEY];
+      [result addObject:processedItem.copy];
+    }
+  }
+  return result.copy;
+}
+
+- (nullable XCPointerEventPath *)eventPathWithAction:(NSArray<NSDictionary<NSString *, id> *> *)action error:(NSError **)error
+{
+  static NSDictionary<NSString *, Class> *gestureItemsMapping;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSMutableDictionary<NSString *, Class> *itemsMapping = [NSMutableDictionary dictionary];
+    for (Class cls in @[FBTapItem.class,
+                        FBPressItem.class,
+                        FBLongPressItem.class,
+                        FBMoveToItem.class,
+                        FBWaitItem.class,
+                        FBReleaseItem.class]) {
+      [itemsMapping setObject:cls forKey:[cls actionName]];
+    }
+    gestureItemsMapping = itemsMapping.copy;
+  });
+  
+  FBAppiumGestureItemsChain *chain = [[FBAppiumGestureItemsChain alloc] init];
+  BOOL isAbsoluteTouchPositionSet = NO;
+  for (NSDictionary<NSString *, id> *actionItem in action) {
+    id actionItemName = [actionItem objectForKey:@"action"];
+    if (![actionItemName isKindOfClass:NSString.class]) {
+      NSString *description = [NSString stringWithFormat:@"'action' property is mandatory for gesture chain item %@", actionItem];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    
+    if ([actionItemName isEqualToString:@"cancel"]) {
+      [chain reset];
+      continue;
+    }
+    
+    Class gestureItemClass = [gestureItemsMapping objectForKey:actionItemName];
+    if (nil == gestureItemClass) {
+      NSString *description = [NSString stringWithFormat:@"Action value '%@' is unknown", actionItemName];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    
+    FBAppiumGestureItem *gestureItem = nil;
+    if ([gestureItemClass hasAbsolutePositioning]) {
+      gestureItem = [[gestureItemClass alloc] initWithActionItem:actionItem application:self.application atPosition:nil offset:chain.durationOffset error:error];
+      isAbsoluteTouchPositionSet = YES;
+    } else {
+      if (!isAbsoluteTouchPositionSet) {
+        if (error) {
+          NSString *description = [NSString stringWithFormat:@"'%@' action should be preceded by an item with absolute positioning", actionItemName];
+          *error = [[FBErrorBuilder.builder withDescription:description] build];
+        }
+        return nil;
+      }
+      FBBaseGestureItem *lastItem = [chain.items lastObject];
+      gestureItem = [[gestureItemClass alloc] initWithActionItem:actionItem application:self.application atPosition:[NSValue valueWithCGPoint:lastItem.atPosition] offset:chain.durationOffset error:error];
+    }
+    if (nil == gestureItem) {
+      return nil;
+    }
+    
+    [chain addItem:gestureItem];
+  }
+  
+  return [chain asEventPathWithError:error];
+}
+
+- (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error
+{
+  UIInterfaceOrientation orientation = self.application.interfaceOrientation;
+  if (![XCTRunnerDaemonSession sharedSession].useLegacyEventCoordinateTransformationPath) {
+    orientation = UIInterfaceOrientationPortrait;
+  }
+  XCSynthesizedEventRecord *eventRecord;
+  BOOL isMultiTouch = [self.actions.firstObject isKindOfClass:NSArray.class];
+  eventRecord = [[XCSynthesizedEventRecord alloc] initWithName:(isMultiTouch ? @"Multi-Finger Touch Action" : @"Single-Finger Touch Action") interfaceOrientation:orientation];
+  for (NSArray<NSDictionary<NSString *, id> *> *action in (isMultiTouch ? self.actions : @[self.actions])) {
+    NSArray<NSDictionary<NSString *, id> *> *preprocessedAction = [self preprocessAction:action];
+    XCPointerEventPath *eventPath = [self eventPathWithAction:preprocessedAction error:error];
+    if (nil == eventPath) {
+      return nil;
+    }
+    [eventRecord addPointerEventPath:eventPath];
+  }
+  return eventRecord;
+}
+
+@end
+

--- a/WebDriverAgentLib/Utilities/FBBaseActionsParser.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsParser.m
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBBaseActionsSynthesizer.h"
+
+#import "FBErrorBuilder.h"
+
+@implementation FBBaseActionsSynthesizer
+
+- (instancetype)initWithActions:(NSArray *)actions forApplication:(XCUIApplication *)application
+{
+  self = [super init];
+  if (self) {
+    _actions = actions;
+    _application = application;
+  }
+  return self;
+}
+
+- (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error
+{
+  @throw [[FBErrorBuilder.builder withDescription:@"Override this method in subclasses"] build];
+  return nil;
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
@@ -9,6 +9,7 @@
 
 #import "FBElementCache.h"
 #import "XCUIApplication.h"
+#import "XCElementSnapshot.h"
 #import "XCSynthesizedEventRecord.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -52,13 +53,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)increaseDuration:(double)value;
 
 /**
+ Recursively calculates the visible frame of the current element inside its container window.
+ 
+ @param selfSnapshot The snapshot of the current element
+ @param frame The intersection between the current element's frame and the parent's one. Set to to nil for the initial call
+ @param window The parent window of the current element's snapshot
+ @return The coordinates of the visible element's rectange. If this rectange has zero width or height then this element is not visible
+ */
++ (CGRect)visibleFrameWithSnapshot:(XCElementSnapshot *)selfSnapshot currentIntersection:(nullable NSValue *)frame containerWindow:(XCElementSnapshot *)window;
+
+/**
  Calculate absolute gesture position on the screen based on provided element and positionOffset values.
  
  @param element The element instance to perform the gesture on. If element equals to nil then positionOffset is considered as absolute coordinates
  @param positionOffset The actual coordinate offset. If this calue equals to nil then element's hitpoint is taken as gesture position. If element is not nil then this offset is calculated relatively to the top-left cordner of the element's position
- @return Adbsolute gesture position on the screen
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return Adbsolute gesture position on the screen or nil if the calculation fails (for example, the element is invisible)
  */
-- (CGPoint)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset;
+- (nullable NSValue *)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset error:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBElementCache.h"
+#import "XCUIApplication.h"
+#import "XCSynthesizedEventRecord.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+
+@interface FBBaseGestureItem : NSObject
+
+/*! Raw JSON representation of the corresponding action item */
+@property (nonatomic) NSDictionary<NSString *, id> *actionItem;
+/*! Current application instance */
+@property (nonatomic) XCUIApplication *application;
+/*! Absolute position on the screen where the gesure should be performed */
+@property (nonatomic) CGPoint atPosition;
+/*! Gesture duration in milliseconds */
+@property (nonatomic) double duration;
+/*! Gesture offset in the chain in milliseconds */
+@property (nonatomic) double offset;
+
+/**
+ Get the name of the corresponding raw action item. This method is expected to be overriden in subclasses.
+ 
+ @return The corresponding action item key in object's raw JSON reprsentation
+ */
++ (NSString *)actionName;
+
+/**
+ Add the current gesture to XCPointerEventPath instance. This method is expected to be overriden in subclasses.
+ 
+ @param eventPath The destination XCPointerEventPath instance
+ @param index The index of the current gesture in the chain. Starts from zero
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return YES if the gesture has been successully added to the XCPointerEventPath instance
+ */
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error;
+
+/**
+ Increase duration of the current gesture.
+ 
+ @param value The duration value to add in milliseconds
+ @return YES if the gesture supports duration increment
+ */
+- (BOOL)increaseDuration:(double)value;
+
+/**
+ Calculate absolute gesture position on the screen based on provided element and positionOffset values.
+ 
+ @param element The element instance to perform the gesture on. If element equals to nil then positionOffset is considered as absolute coordinates
+ @param positionOffset The actual coordinate offset. If this calue equals to nil then element's hitpoint is taken as gesture position. If element is not nil then this offset is calculated relatively to the top-left cordner of the element's position
+ @return Adbsolute gesture position on the screen
+ */
+- (CGPoint)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset;
+
+@end
+
+
+@interface FBBaseGestureItemsChain : NSObject
+
+/*! All gesture items collected in the chain */
+@property (readonly, nonatomic) NSMutableArray<FBBaseGestureItem *> *items;
+/*! Total length of all the gestures in the chain in milliseconds */
+@property (nonatomic) double durationOffset;
+
+/**
+ Add a new gesture item to the current chain. The method is expected to be overriden in subclasses.
+ 
+ @param item The actual gesture instance to be added
+ */
+- (void)addItem:(FBBaseGestureItem *)item;
+
+/**
+ Represents the chain as XCPointerEventPath instance.
+ 
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return The constructed XCPointerEventPath instance or nil if there was a failure
+ */
+- (nullable XCPointerEventPath *)asEventPathWithError:(NSError **)error;
+
+@end
+
+
+@interface FBBaseActionsSynthesizer : NSObject
+
+/*! Raw actions chain received from request's JSON */
+@property (readonly, nonatomic) NSArray *actions;
+/*! Current application instance */
+@property (readonly, nonatomic) XCUIApplication *application;
+/*! Current elements cache */
+@property (readonly, nonatomic, nullable) FBElementCache *elementCache;
+
+/**
+ Initializes actions synthesizer. This initializer should be used only by subclasses.
+ 
+ @param actions The raw actions chain received from request's JSON. The format of this chain is defined by the standard, implemented in the correspoding subclass.
+ @param application Current application instance
+ @param elementCache Elements cache, which is used to replace elements references in the chain with their instances. We assume the chain already contains element instances if this parameter is set to nil
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return The corresponding synthesizer instance or nil in case of failure (for example if `actions` is nil or empty)
+ */
+- (nullable instancetype)initWithActions:(NSArray *)actions forApplication:(XCUIApplication *)application elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error;
+
+/**
+ Synthesizes XCTest-compatible event record to be performed in the UI. This method is supposed to be overriden by subclasses.
+ 
+ @param error If there is an error, upon return contains an NSError object that describes the problem
+ @return The generated event record or nil in case of failure
+ */
+- (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.h
@@ -13,7 +13,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-
 @interface FBBaseGestureItem : NSObject
 
 /*! Raw JSON representation of the corresponding action item */

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBBaseActionsSynthesizer.h"
+
+#import "FBErrorBuilder.h"
+#import "FBMacros.h"
+#import "FBMathUtils.h"
+#import "XCElementSnapshot.h"
+#import "XCElementSnapshot+FBHelpers.h"
+#import "XCElementSnapshot+FBHitPoint.h"
+#import "XCPointerEventPath.h"
+#import "XCSynthesizedEventRecord.h"
+#import "XCUIElement+FBUtilities.h"
+
+
+@implementation FBBaseGestureItem
+
++ (NSString *)actionName
+{
+  @throw [[FBErrorBuilder.builder withDescription:@"Override this method in subclasses"] build];
+  return nil;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  @throw [[FBErrorBuilder.builder withDescription:@"Override this method in subclasses"] build];
+  return NO;
+}
+
+- (BOOL)increaseDuration:(double)value
+{
+  self.duration += value;
+  return YES;
+}
+
+- (CGPoint)hitpointWithElement:(nullable XCUIElement *)element positionOffset:(nullable NSValue *)positionOffset
+{
+  CGPoint hitPoint;
+  if (nil == element) {
+    // Only absolute offset is defined
+    hitPoint = [positionOffset CGPointValue];
+  } else {
+    if (nil == positionOffset) {
+      // Only element to tap is defined
+      // Calculating the default hitpoint
+      XCElementSnapshot *snapshot = element.fb_lastSnapshot;
+      hitPoint = snapshot.fb_hitPoint;
+      if (CGPointEqualToPoint(hitPoint, CGPointMake(-1, -1))) {
+        hitPoint = [snapshot.suggestedHitpoints.lastObject CGPointValue];
+      }
+      return hitPoint;
+    } else {
+      // Relative element offset is defined
+      CGPoint offsetValue = [positionOffset CGPointValue];
+      hitPoint = CGPointMake(element.frame.origin.x + offsetValue.x, element.frame.origin.y + offsetValue.y);
+    }
+  }
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+    /*
+     Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
+     even if the device is not in portait mode. That is why we need to recalculate them manually
+     based on the current orientation value
+     */
+    hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+  }
+  return hitPoint;
+}
+
+@end
+
+
+@implementation FBBaseGestureItemsChain
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _items = [NSMutableArray array];
+    _durationOffset = 0.0;
+  }
+  return self;
+}
+
+- (void)addItem:(FBBaseGestureItem *)item __attribute__((noreturn))
+{
+  @throw [[FBErrorBuilder.builder withDescription:@"Override this method in subclasses"] build];
+}
+
+- (nullable XCPointerEventPath *)asEventPathWithError:(NSError **)error
+{
+  if (0 == self.items.count) {
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:@"Action items list cannot be empty"] build];
+    }
+    return nil;
+  }
+  
+  XCPointerEventPath *result = [[XCPointerEventPath alloc] initForTouchAtPoint:self.items.firstObject.atPosition offset:0.0];
+  NSUInteger index = 0;
+  for (FBBaseGestureItem *item in self.items.copy) {
+    if (![item addToEventPath:result index:index++ error:error]) {
+      return nil;
+    }
+  }
+  return result;
+}
+
+@end
+
+
+@implementation FBBaseActionsSynthesizer
+
+- (instancetype)initWithActions:(NSArray *)actions forApplication:(XCUIApplication *)application elementCache:(nullable FBElementCache *)elementCache error:(NSError **)error
+{
+  self = [super init];
+  if (self) {
+    if ((nil == actions || 0 == actions.count) && error) {
+      *error = [[FBErrorBuilder.builder withDescription:@"Actions list cannot be empty"] build];
+      return nil;
+    }
+    _actions = actions;
+    _application = application;
+    _elementCache = elementCache;
+  }
+  return self;
+}
+
+- (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error
+{
+  @throw [[FBErrorBuilder.builder withDescription:@"Override synthesizeWithError method in subclasses"] build];
+  return nil;
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBBaseActionsSynthesizer.m
@@ -44,9 +44,9 @@
 {
   XCElementSnapshot *parent = selfSnapshot.parent;
   CGRect intersectionRect = frame == nil ?
-  CGRectIntersection(selfSnapshot.frame, parent.frame) :
-  CGRectIntersection([frame CGRectValue], parent.frame);
-  if (parent == window) {
+    CGRectIntersection(selfSnapshot.frame, parent.frame) :
+    CGRectIntersection([frame CGRectValue], parent.frame);
+  if (CGRectIsEmpty(intersectionRect) || parent == window) {
     return intersectionRect;
   }
   return [self.class visibleFrameWithSnapshot:parent currentIntersection:[NSValue valueWithCGRect:intersectionRect] containerWindow:window];

--- a/WebDriverAgentLib/Utilities/FBMacros.h
+++ b/WebDriverAgentLib/Utilities/FBMacros.h
@@ -46,3 +46,6 @@
 #define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN(v)                 ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedAscending)
 #define SYSTEM_VERSION_LESS_THAN_OR_EQUAL_TO(v)     ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedDescending)
+
+/*! Converts the given number of milliseconds into seconds */
+#define FBMillisToSeconds(ms) ((ms) / 1000.0)

--- a/WebDriverAgentLib/Utilities/FBMathUtils.h
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.h
@@ -31,5 +31,8 @@ BOOL FBRectFuzzyEqualToRect(CGRect rect1, CGRect rect2, CGFloat threshold);
 /*! Inverts point if necessary to match location on screen */
 CGPoint FBInvertPointForApplication(CGPoint point, CGSize screenSize, UIInterfaceOrientation orientation);
 
+/*! Inverts offset if necessary to match screen orientation */
+CGPoint FBInvertOffsetForOrientation(CGPoint offset, UIInterfaceOrientation orientation);
+
 /*! Inverts size if necessary to match current screen orientation */
 CGSize FBAdjustDimensionsForApplication(CGSize actualSize, UIInterfaceOrientation orientation);

--- a/WebDriverAgentLib/Utilities/FBMathUtils.m
+++ b/WebDriverAgentLib/Utilities/FBMathUtils.m
@@ -53,6 +53,21 @@ CGPoint FBInvertPointForApplication(CGPoint point, CGSize screenSize, UIInterfac
   }
 }
 
+CGPoint FBInvertOffsetForOrientation(CGPoint offset, UIInterfaceOrientation orientation)
+{
+  switch (orientation) {
+    case UIInterfaceOrientationUnknown:
+    case UIInterfaceOrientationPortrait:
+      return offset;
+    case UIInterfaceOrientationPortraitUpsideDown:
+      return CGPointMake(-offset.x, -offset.y);
+    case UIInterfaceOrientationLandscapeLeft:
+      return CGPointMake(offset.y, -offset.x);
+    case UIInterfaceOrientationLandscapeRight:
+      return CGPointMake(-offset.y, offset.x);
+  }
+}
+
 CGSize FBAdjustDimensionsForApplication(CGSize actualSize, UIInterfaceOrientation orientation)
 {
   if (orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight) {

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.h
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.h
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBBaseActionsSynthesizer.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface FBW3CActionsSynthesizer : FBBaseActionsSynthesizer
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -1,0 +1,451 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "FBW3CActionsSynthesizer.h"
+
+#import "FBErrorBuilder.h"
+#import "FBElementCache.h"
+#import "FBLogger.h"
+#import "FBMacros.h"
+#import "FBMathUtils.h"
+#import "XCUIElement+FBUtilities.h"
+#import "XCUIElement.h"
+#import "XCSynthesizedEventRecord.h"
+#import "XCTRunnerDaemonSession.h"
+#import "XCPointerEventPath.h"
+
+
+static NSString *const FB_KEY_TYPE = @"type";
+static NSString *const FB_ACTION_TYPE_POINTER = @"pointer";
+static NSString *const FB_ACTION_TYPE_KEY = @"key";
+static NSString *const FB_ACTION_TYPE_NONE = @"none";
+
+static NSString *const FB_PARAMETERS_KEY_POINTER_TYPE = @"pointerType";
+static NSString *const FB_POINTER_TYPE_MOUSE = @"mouse";
+static NSString *const FB_POINTER_TYPE_PEN = @"pen";
+static NSString *const FB_POINTER_TYPE_TOUCH = @"touch";
+
+static NSString *const FB_ACTION_ITEM_KEY_ORIGIN = @"origin";
+static NSString *const FB_ORIGIN_TYPE_VIEWPORT = @"viewport";
+static NSString *const FB_ORIGIN_TYPE_POINTER = @"pointer";
+
+static NSString *const FB_ACTION_ITEM_KEY_TYPE = @"type";
+static NSString *const FB_ACTION_ITEM_TYPE_POINTER_MOVE = @"pointerMove";
+static NSString *const FB_ACTION_ITEM_TYPE_POINTER_DOWN = @"pointerDown";
+static NSString *const FB_ACTION_ITEM_TYPE_POINTER_UP = @"pointerUp";
+static NSString *const FB_ACTION_ITEM_TYPE_POINTER_CANCEL = @"pointerCancel";
+static NSString *const FB_ACTION_ITEM_TYPE_PAUSE = @"pause";
+
+static NSString *const FB_ACTION_ITEM_KEY_DURATION = @"duration";
+static NSString *const FB_ACTION_ITEM_KEY_X = @"x";
+static NSString *const FB_ACTION_ITEM_KEY_Y = @"y";
+static NSString *const FB_ACTION_ITEM_KEY_BUTTON = @"button";
+static NSString *const FB_ACTION_ITEM_KEY_PRESSURE = @"pressure";
+
+static NSString *const FB_KEY_ID = @"id";
+static NSString *const FB_KEY_PARAMETERS = @"parameters";
+static NSString *const FB_KEY_ACTIONS = @"actions";
+
+static double millisToSeconds (double msec) {
+  return msec / 1000.0;
+}
+
+@interface FBW3CGestureItem : FBBaseGestureItem
+
+@property (nullable, readonly, nonatomic) FBBaseGestureItem *previousItem;
+
+@end
+
+@interface FBPointerDownItem : FBW3CGestureItem
+
+@property (readonly, nonatomic) double pressure;
+
+@end
+
+@interface FBPauseItem : FBW3CGestureItem
+
+@end
+
+@interface FBPointerMoveItem : FBW3CGestureItem
+
+@end
+
+@interface FBPointerUpItem : FBW3CGestureItem
+
+@end
+
+
+@implementation FBW3CGestureItem
+
+- (nullable instancetype)initWithActionItem:(NSDictionary<NSString *, id> *)actionItem application:(XCUIApplication *)application previousItem:(nullable FBBaseGestureItem *)previousItem offset:(double)offset error:(NSError **)error
+{
+  self = [super init];
+  if (self) {
+    self.actionItem = actionItem;
+    self.application = application;
+    self.offset = offset;
+    _previousItem = previousItem;
+    self.duration = 0.0;
+    NSNumber *durationObj = [actionItem objectForKey:FB_ACTION_ITEM_KEY_DURATION];
+    if (nil != durationObj && [self increaseDuration:[durationObj doubleValue]] && self.duration < 0.0) {
+      NSString *description = [NSString stringWithFormat:@"Duration value cannot be negative for '%@' action item", self.actionItem];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    NSValue *position = [self positionWithError:error];
+    if (nil == position) {
+      return nil;
+    }
+    self.atPosition = [position CGPointValue];
+  }
+  return self;
+}
+
+- (nullable NSValue *)positionWithError:(NSError **)error
+{
+  if (nil == self.previousItem) {
+    NSString *errorDescription = [NSString stringWithFormat:@"The '%@' action item must be preceded by %@ item", self.actionItem, FB_ACTION_ITEM_TYPE_POINTER_MOVE];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:errorDescription] build];
+    }
+    return nil;
+  }
+  return [NSValue valueWithCGPoint:self.previousItem.atPosition];
+}
+
+@end
+
+@implementation FBPointerDownItem
+
+- (nullable instancetype)initWithActionItem:(NSDictionary<NSString *, id> *)actionItem application:(XCUIApplication *)application previousItem:(nullable FBBaseGestureItem *)previousItem offset:(double)offset error:(NSError **)error
+{
+  self = [super initWithActionItem:actionItem application:application previousItem:previousItem offset:offset error:error];
+  if (self) {
+    _pressure = 0.0;
+    NSNumber *pressureObj = [actionItem objectForKey:FB_ACTION_ITEM_KEY_PRESSURE];
+    if (nil != pressureObj) {
+      _pressure = [pressureObj doubleValue];
+    }
+  }
+  return self;
+}
+
++ (NSString *)actionName
+{
+  return FB_ACTION_ITEM_TYPE_POINTER_DOWN;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  if (index > 0) {
+    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  }
+  if (self.pressure > 0.0) {
+    [eventPath pressDownWithPressure:self.pressure atOffset:millisToSeconds(self.offset)];
+  } else {
+    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+  }
+  return YES;
+}
+
+- (BOOL)increaseDuration:(double)value
+{
+  return NO;
+}
+
+@end
+
+@implementation FBPointerMoveItem
+
+- (nullable NSValue *)positionWithError:(NSError **)error
+{
+  static NSArray<NSString *> *supportedOriginTypes;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    supportedOriginTypes = @[FB_ORIGIN_TYPE_POINTER, FB_ORIGIN_TYPE_VIEWPORT];
+  });
+  id origin = [self.actionItem objectForKey:FB_ACTION_ITEM_KEY_ORIGIN] ?: FB_ORIGIN_TYPE_VIEWPORT;
+  BOOL isOriginAnElement = [origin isKindOfClass:XCUIElement.class] && [(XCUIElement *)origin exists];
+  if (!isOriginAnElement && ![supportedOriginTypes containsObject:origin]) {
+    NSString *description = [NSString stringWithFormat:@"Unsupported %@ type '%@' is set for '%@' action item. Supported origin types: %@ or an element instance", FB_ACTION_ITEM_KEY_ORIGIN, origin, self.actionItem, supportedOriginTypes];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  
+  XCUIElement *element = isOriginAnElement ? (XCUIElement *)origin : nil;
+  NSNumber *x = [self.actionItem objectForKey:FB_ACTION_ITEM_KEY_X];
+  NSNumber *y = [self.actionItem objectForKey:FB_ACTION_ITEM_KEY_Y];
+  if ((nil != x && nil == y) || (nil != y && nil == x) ||
+      ([origin isKindOfClass:NSString.class] && [origin isEqualToString:FB_ORIGIN_TYPE_VIEWPORT] && (nil == x || nil == y))) {
+    NSString *errorDescription = [NSString stringWithFormat:@"Both 'x' and 'y' options should be set for '%@' action item", self.actionItem];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:errorDescription] build];
+    }
+    return nil;
+  }
+  
+  if (nil != element) {
+    if (nil == x && nil == y) {
+      return [NSValue valueWithCGPoint:[self hitpointWithElement:element positionOffset:nil]];
+    }
+    return [NSValue valueWithCGPoint:[self hitpointWithElement:element positionOffset:[NSValue valueWithCGPoint:CGPointMake(x.floatValue, y.floatValue)]]];
+  }
+  
+  if ([origin isKindOfClass:NSString.class] && [origin isEqualToString:FB_ORIGIN_TYPE_VIEWPORT]) {
+    return [NSValue valueWithCGPoint:[self hitpointWithElement:nil positionOffset:[NSValue valueWithCGPoint:CGPointMake(x.floatValue, y.floatValue)]]];
+  }
+  
+  // origin == FB_ORIGIN_TYPE_POINTER
+  if (nil == self.previousItem) {
+    NSString *errorDescription = [NSString stringWithFormat:@"There is no previous item for '%@' action item, however %@ is set to '%@'", self.actionItem, FB_ACTION_ITEM_KEY_ORIGIN, FB_ORIGIN_TYPE_POINTER];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:errorDescription] build];
+    }
+    return nil;
+  }
+  CGPoint recentPosition = self.previousItem.atPosition;
+  CGPoint offsetRelativeToRecentPosition = (nil == x && nil == y) ? CGPointMake(0.0, 0.0) : CGPointMake(x.floatValue, y.floatValue);
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+    offsetRelativeToRecentPosition = FBInvertOffsetForOrientation(offsetRelativeToRecentPosition, self.application.interfaceOrientation);
+  }
+  return [NSValue valueWithCGPoint:CGPointMake(recentPosition.x + offsetRelativeToRecentPosition.x, recentPosition.y + offsetRelativeToRecentPosition.y)];
+}
+
++ (NSString *)actionName
+{
+  return FB_ACTION_ITEM_TYPE_POINTER_MOVE;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  return YES;
+}
+
+@end
+
+@implementation FBPauseItem
+
++ (NSString *)actionName
+{
+  return FB_ACTION_ITEM_TYPE_PAUSE;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  return YES;
+}
+
+@end
+
+@implementation FBPointerUpItem
+
++ (NSString *)actionName
+{
+  return FB_ACTION_ITEM_TYPE_POINTER_UP;
+}
+
+- (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
+{
+  [eventPath liftUpAtOffset:millisToSeconds(self.offset)];
+  return YES;
+}
+
+- (BOOL)increaseDuration:(double)value
+{
+  return NO;
+}
+
+@end
+
+
+@interface FBW3CGestureItemsChain : FBBaseGestureItemsChain
+
+@end
+
+@implementation FBW3CGestureItemsChain
+
+- (void)addItem:(FBBaseGestureItem *)item
+{
+  self.durationOffset += item.duration;
+  if ([item isKindOfClass:FBPauseItem.class] && [self.items.lastObject increaseDuration:item.duration]) {
+    // Merge wait duration to the recent action if possible
+    return;
+  }
+  [self.items addObject:item];
+}
+
+@end
+
+@implementation FBW3CActionsSynthesizer
+
+- (NSArray<NSDictionary<NSString *, id> *> *)preprocessedActionItemsWith:(NSArray<NSDictionary<NSString *, id> *> *)actionItems
+{
+  NSMutableArray<NSDictionary<NSString *, id> *> *result = [NSMutableArray array];
+  BOOL shouldCancelNextItem = NO;
+  for (NSDictionary<NSString *, id> *actionItem in [actionItems reverseObjectEnumerator]) {
+    if (shouldCancelNextItem) {
+      shouldCancelNextItem = NO;
+      continue;
+    }
+    NSString *actionItemType = [actionItem objectForKey:FB_ACTION_ITEM_KEY_TYPE];
+    if (actionItemType != nil && [actionItemType isEqualToString:FB_ACTION_ITEM_TYPE_POINTER_CANCEL]) {
+      shouldCancelNextItem = YES;
+      continue;
+    }
+    
+    if (nil == self.elementCache) {
+      [result addObject:actionItem];
+      continue;
+    }
+    id origin = [actionItem objectForKey:FB_ACTION_ITEM_KEY_ORIGIN];
+    if (nil == origin || [@[FB_ORIGIN_TYPE_POINTER, FB_ORIGIN_TYPE_VIEWPORT] containsObject:origin]) {
+      [result addObject:actionItem];
+      continue;
+    }
+    XCUIElement *instance = [self.elementCache elementForUUID:origin];
+    if (nil == instance) {
+      [result addObject:actionItem];
+      continue;
+    }
+    NSMutableDictionary<NSString *, id> *processedItem = actionItem.mutableCopy;
+    [processedItem setObject:instance forKey:FB_ACTION_ITEM_KEY_ORIGIN];
+    [result addObject:processedItem.copy];
+  }
+  return [[result reverseObjectEnumerator] allObjects];
+}
+
+- (nullable XCPointerEventPath *)eventPathWithActionDescription:(NSDictionary<NSString *, id> *)actionDescription forActionId:(NSString *)actionId error:(NSError **)error
+{
+  static NSDictionary<NSString *, Class> *gestureItemsMapping;
+  static NSArray<NSString *> *supportedActionItemTypes;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSMutableDictionary<NSString *, Class> *itemsMapping = [NSMutableDictionary dictionary];
+    for (Class cls in @[FBPointerDownItem.class,
+                        FBPointerMoveItem.class,
+                        FBPauseItem.class,
+                        FBPointerUpItem.class]) {
+      [itemsMapping setObject:cls forKey:[cls actionName]];
+    }
+    gestureItemsMapping = itemsMapping.copy;
+    supportedActionItemTypes = @[FB_ACTION_ITEM_TYPE_PAUSE,
+                                 FB_ACTION_ITEM_TYPE_POINTER_UP,
+                                 FB_ACTION_ITEM_TYPE_POINTER_DOWN,
+                                 FB_ACTION_ITEM_TYPE_POINTER_MOVE];
+  });
+  
+  id actionType = [actionDescription objectForKey:FB_KEY_TYPE];
+  if (![actionType isKindOfClass:NSString.class] || ![actionType isEqualToString:FB_ACTION_TYPE_POINTER]) {
+    NSString *description = [NSString stringWithFormat:@"Only actions of '%@' type are supported. '%@' is given instead for action with id '%@'", FB_ACTION_TYPE_POINTER, actionType, actionId];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  
+  id parameters = [actionDescription objectForKey:FB_KEY_PARAMETERS];
+  id pointerType = FB_POINTER_TYPE_MOUSE;
+  if ([parameters isKindOfClass:NSDictionary.class]) {
+    pointerType = [parameters objectForKey:FB_PARAMETERS_KEY_POINTER_TYPE] ?: FB_POINTER_TYPE_MOUSE;
+  }
+  if (![pointerType isKindOfClass:NSString.class] || ![pointerType isEqualToString:FB_POINTER_TYPE_TOUCH]) {
+    NSString *description = [NSString stringWithFormat:@"Only pointer type '%@' is supported. '%@' is given instead for action with id '%@'", FB_POINTER_TYPE_TOUCH, pointerType, actionId];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  
+  NSArray<NSDictionary<NSString *, id> *> *actionItems = [actionDescription objectForKey:FB_KEY_ACTIONS];
+  if (nil == actionItems || 0 == actionItems.count) {
+   NSString *description = [NSString stringWithFormat:@"It is mandatory to have at least one gesture item defined for each action. Action with id '%@' contains none", actionId];
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:description] build];
+    }
+    return nil;
+  }
+  
+  FBW3CGestureItemsChain *chain = [[FBW3CGestureItemsChain alloc] init];
+  NSArray<NSDictionary<NSString *, id> *> *processedItems = [self preprocessedActionItemsWith:actionItems];
+  for (NSDictionary<NSString *, id> *actionItem in processedItems) {
+    id actionItemType = [actionItem objectForKey:FB_ACTION_ITEM_KEY_TYPE];
+    if (![actionItemType isKindOfClass:NSString.class]) {
+      NSString *description = [NSString stringWithFormat:@"The %@ property is mandatory to set for '%@' action item", FB_ACTION_ITEM_KEY_TYPE, actionItem];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    
+    Class gestureItemClass = [gestureItemsMapping objectForKey:actionItemType];
+    if (nil == gestureItemClass) {
+      NSString *description = [NSString stringWithFormat:@"'%@' action item type '%@' is not supported. Only the following action item types are supported: %@", actionId, actionItemType, supportedActionItemTypes];
+      if (error) {
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    
+    FBW3CGestureItem *gestureItem = [[gestureItemClass alloc] initWithActionItem:actionItem application:self.application previousItem:[chain.items lastObject] offset:chain.durationOffset error:error];
+    if (nil == gestureItem) {
+      return nil;
+    }
+    
+    [chain addItem:gestureItem];
+  }
+  
+  return [chain asEventPathWithError:error];
+}
+
+- (nullable XCSynthesizedEventRecord *)synthesizeWithError:(NSError **)error
+{
+  UIInterfaceOrientation orientation = self.application.interfaceOrientation;
+  if (![XCTRunnerDaemonSession sharedSession].useLegacyEventCoordinateTransformationPath) {
+    orientation = UIInterfaceOrientationPortrait;
+  }
+  XCSynthesizedEventRecord *eventRecord = [[XCSynthesizedEventRecord alloc] initWithName:@"W3C Touch Action" interfaceOrientation:orientation];
+  NSMutableDictionary<NSString *, NSDictionary<NSString *, id> *> *actionsMapping = [NSMutableDictionary new];
+  NSMutableArray<NSString *> *actionIds = [NSMutableArray new];
+  for (NSDictionary<NSString *, id> *action in self.actions) {
+    id actionId = [action objectForKey:FB_KEY_ID];
+    if (![actionId isKindOfClass:NSString.class] || 0 == [actionId length]) {
+      if (error) {
+        NSString *description = [NSString stringWithFormat:@"The mandatory action %@ field is missing or empty for '%@'", FB_KEY_ID, action];
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    if (nil != [actionsMapping objectForKey:actionId]) {
+      if (error) {
+        NSString *description = [NSString stringWithFormat:@"Action %@ '%@' is not unique for '%@'", FB_KEY_ID, actionId, action];
+        *error = [[FBErrorBuilder.builder withDescription:description] build];
+      }
+      return nil;
+    }
+    [actionIds addObject:actionId];
+    [actionsMapping setObject:action forKey:actionId];
+  }
+  for (NSString *actionId in actionIds.copy) {
+    NSDictionary<NSString *, id> *actionDescription = [actionsMapping objectForKey:actionId];
+    XCPointerEventPath *eventPath = [self eventPathWithActionDescription:actionDescription forActionId:actionId error:error];
+    if (nil == eventPath) {
+      return nil;
+    }
+    [eventRecord addPointerEventPath:eventPath];
+  }
+  return eventRecord;
+}
+
+@end

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -52,9 +52,6 @@ static NSString *const FB_KEY_ID = @"id";
 static NSString *const FB_KEY_PARAMETERS = @"parameters";
 static NSString *const FB_KEY_ACTIONS = @"actions";
 
-static double millisToSeconds (double msec) {
-  return msec / 1000.0;
-}
 
 @interface FBW3CGestureItem : FBBaseGestureItem
 
@@ -146,12 +143,12 @@ static double millisToSeconds (double msec) {
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
   if (index > 0) {
-    [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+    [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   }
   if (self.pressure > 0.0) {
-    [eventPath pressDownWithPressure:self.pressure atOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownWithPressure:self.pressure atOffset:FBMillisToSeconds(self.offset)];
   } else {
-    [eventPath pressDownAtOffset:millisToSeconds(self.offset)];
+    [eventPath pressDownAtOffset:FBMillisToSeconds(self.offset)];
   }
   return YES;
 }
@@ -228,7 +225,7 @@ static double millisToSeconds (double msec) {
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
-  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   return YES;
 }
 
@@ -243,7 +240,7 @@ static double millisToSeconds (double msec) {
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
-  [eventPath moveToPoint:self.atPosition atOffset:millisToSeconds(self.offset)];
+  [eventPath moveToPoint:self.atPosition atOffset:FBMillisToSeconds(self.offset)];
   return YES;
 }
 
@@ -258,7 +255,7 @@ static double millisToSeconds (double msec) {
 
 - (BOOL)addToEventPath:(XCPointerEventPath*)eventPath index:(NSUInteger)index error:(NSError **)error
 {
-  [eventPath liftUpAtOffset:millisToSeconds(self.offset)];
+  [eventPath liftUpAtOffset:FBMillisToSeconds(self.offset)];
   return YES;
 }
 

--- a/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
+++ b/WebDriverAgentLib/Utilities/FBW3CActionsSynthesizer.m
@@ -311,6 +311,18 @@ static NSString *const FB_KEY_ACTIONS = @"actions";
       [result addObject:actionItem];
       continue;
     }
+    // Selenium Python client passes 'origin' element in the following format:
+    //
+    // if isinstance(origin, WebElement):
+    //    action["origin"] = {"element-6066-11e4-a52e-4f735466cecf": origin.id}
+    if ([origin isKindOfClass:NSDictionary.class]) {
+      for (NSString* key in [origin copy]) {
+        if ([[key lowercaseString] containsString:@"element"]) {
+          origin = [origin objectForKey:key];
+          break;
+        }
+      }
+    }
     XCUIElement *instance = [self.elementCache elementForUUID:origin];
     if (nil == instance) {
       [result addObject:actionItem];

--- a/WebDriverAgentTests/IntegrationTests/FBAppiumMultiTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAppiumMultiTouchActionsIntegrationTests.m
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+
+#import "XCUIElement.h"
+#import "XCUIApplication+FBTouchAction.h"
+#import "FBAlert.h"
+#import "FBTestMacros.h"
+#import "XCUIDevice+FBRotation.h"
+#import "FBRunLoopSpinner.h"
+
+@interface FBAppiumMultiTouchActionsIntegrationTests : FBIntegrationTestCase
+@end
+
+
+@implementation FBAppiumMultiTouchActionsIntegrationTests
+
+- (void)verifyGesture:(NSArray<NSArray<NSDictionary<NSString *, id> *> *> *)gesture orientation:(UIDeviceOrientation)orientation
+{
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  NSError *error;
+  XCTAssertTrue(self.testedApplication.alerts.count == 0);
+  XCTAssertTrue([self.testedApplication fb_performAppiumTouchActions:gesture elementCache:nil error:&error]);
+  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
+}
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAlertsPage];
+  });
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+  [[FBAlert alertWithApplication:self.testedApplication] dismissWithError:nil];
+}
+
+- (void)testErroneousGestures
+{
+  NSArray<NSArray<NSDictionary<NSString *, id> *> *> *invalidGestures =
+  @[
+    // One of the chains is empty
+    @[
+      @[],
+      @[@{@"action": @"tap",
+          @"options": @{
+              @"element": self.testedApplication.buttons[FBShowAlertButtonName],
+              }
+          }
+      ],
+    ],
+    
+  ];
+  
+  for (NSArray<NSArray<NSDictionary<NSString *, id> *> *> *invalidGesture in invalidGestures) {
+    NSError *error;
+    XCTAssertFalse([self.testedApplication fb_performAppiumTouchActions:invalidGesture elementCache:nil  error:&error]);
+    XCTAssertNotNil(error);
+  }
+}
+
+- (void)testSymmetricTwoFingersTap
+{
+  XCUIElement *element = self.testedApplication.buttons[FBShowAlertButtonName];
+  NSArray<NSArray<NSDictionary<NSString *, id> *> *> *gesture =
+  @[
+    @[@{
+      @"action": @"tap",
+      @"options": @{
+          @"element": element
+          }
+      }
+    ],
+    @[@{
+        @"action": @"tap",
+        @"options": @{
+            @"element": element
+            }
+        }
+    ],
+  ];
+  
+  [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
@@ -1,0 +1,388 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+
+#import "XCUIElement.h"
+#import "XCUIApplication+FBTouchAction.h"
+#import "FBAlert.h"
+#import "FBTestMacros.h"
+#import "XCUIDevice+FBRotation.h"
+#import "FBRunLoopSpinner.h"
+
+@interface FBAppiumTouchActionsIntegrationTestsPart1 : FBIntegrationTestCase
+@end
+
+@interface FBAppiumTouchActionsIntegrationTestsPart2 : FBIntegrationTestCase
+@property (nonatomic) XCUIElement *pickerWheel;
+@end
+
+
+@implementation FBAppiumTouchActionsIntegrationTestsPart1
+
+- (void)verifyGesture:(NSArray<NSDictionary<NSString *, id> *> *)gesture orientation:(UIDeviceOrientation)orientation
+{
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  NSError *error;
+  XCTAssertTrue(self.testedApplication.alerts.count == 0);
+  XCTAssertTrue([self.testedApplication fb_performAppiumTouchActions:gesture elementCache:nil error:&error]);
+  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
+}
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAlertsPage];
+  });
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+  [[FBAlert alertWithApplication:self.testedApplication] dismissWithError:nil];
+}
+
+- (void)testErroneousGestures
+{
+  NSArray<NSArray<NSDictionary<NSString *, id> *> *> *invalidGestures =
+  @[
+    // Empty chain
+    @[],
+    
+    // Chain element without 'action' key
+    @[@{
+        @"options": @{
+            @"ms": @100
+            }
+        },
+      ],
+    
+    // Empty chain because of cancel
+    @[@{
+        @"action": @"tap",
+        @"options": @{
+            @"element": self.testedApplication.buttons[FBShowAlertButtonName],
+            }
+        },
+      @{
+        @"action": @"wait",
+        @"options": @{
+            @"ms": @100
+            }
+        },
+      @{
+        @"action": @"cancel"
+        },
+      ],
+    
+    // Chain with unknown action
+    @[@{
+        @"action": @"tapP",
+        @"options": @{
+            @"element": self.testedApplication.buttons[FBShowAlertButtonName],
+            }
+        },
+      ],
+    
+    // Wait without preceeding coordinate
+    @[@{
+        @"action": @"wait"
+        }
+      ],
+
+    // Wait with negative duration
+    @[@{
+        @"action": @"press",
+        @"options": @{
+            @"x": @1,
+            @"y": @1
+            }
+        },
+      @{
+        @"action": @"wait",
+        @"options": @{
+            @"ms": @-1.0
+            }
+        },
+      ],
+
+    // Release without preceeding coordinate
+    @[@{
+        @"action": @"release"
+        },
+      @{
+        @"action": @"tap",
+        @"options": @{
+            @"x": @1,
+            @"y": @1
+            }
+        },
+      ],
+
+    // Press without coordinates
+    @[@{
+        @"action": @"press"
+        }
+      ],
+
+    // longPress with invalid coordinates
+    @[@{
+        @"action": @"longPress",
+        @"options": @{
+            @"x": @1
+            }
+        },
+      ],
+    
+    // longPress with negative duration
+    @[@{
+        @"action": @"longPress",
+        @"options": @{
+            @"x": @1,
+            @"y": @1,
+            @"duration": @-0.01
+            }
+        },
+      ],
+    
+  ];
+  
+  for (NSArray<NSDictionary<NSString *, id> *> *invalidGesture in invalidGestures) {
+    NSError *error;
+    XCTAssertFalse([self.testedApplication fb_performAppiumTouchActions:invalidGesture elementCache:nil error:&error]);
+    XCTAssertNotNil(error);
+  }
+}
+
+- (void)testTap
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"tap",
+      @"options": @{
+          @"element": self.testedApplication.buttons[FBShowAlertButtonName]
+          }
+      }
+  ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
+- (void)testDoubleTap
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"tap",
+      @"options": @{
+          @"element": self.testedApplication.buttons[FBShowAlertButtonName],
+          @"count": @2
+          }
+      },
+  ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationLandscapeLeft];
+}
+
+- (void)testPress
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"press",
+      @"options": @{
+          @"element": self.testedApplication.buttons[FBShowAlertButtonName],
+          @"x": @1,
+          @"y": @1
+          }
+      },
+    @{
+      @"action": @"wait",
+      @"options": @{
+          @"ms": @300
+          }
+      },
+    @{
+      @"action": @"wait",
+      @"options": @{
+          @"ms": @300
+          }
+      },
+    @{
+      @"action": @"wait",
+      @"options": @{
+          @"ms": @300
+          }
+      },
+    @{
+      @"action": @"release"
+      }
+  ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationLandscapeRight];
+}
+
+- (void)testLongPress
+{
+  UIDeviceOrientation orientation = UIDeviceOrientationLandscapeLeft;
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  CGRect elementFrame = self.testedApplication.buttons[FBShowAlertButtonName].frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"longPress",
+      @"options": @{
+          @"x": @(elementFrame.origin.x + 1),
+          @"y": @(elementFrame.origin.y + 1),
+          @"duration": @5,
+          @"pressure": @0.1
+          }
+      },
+    @{
+      @"action": @"wait",
+      @"options": @{
+          @"ms": @500
+          }
+      },
+    @{
+      @"action": @"release"
+      }
+  ];
+  [self verifyGesture:gesture orientation:orientation];
+}
+
+@end
+
+
+@implementation FBAppiumTouchActionsIntegrationTestsPart2
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAttributesPage];
+  });
+  self.pickerWheel = [self.testedApplication.pickerWheels elementBoundByIndex:0];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)verifyPickerWheelPositionChangeWithGesture:(NSArray<NSDictionary<NSString *, id> *> *)gesture
+{
+  NSString *previousValue = self.pickerWheel.value;
+  NSError *error;
+  XCTAssertTrue([self.testedApplication fb_performAppiumTouchActions:gesture elementCache:nil error:&error]);
+  XCTAssertNil(error);
+  XCTAssertTrue([[[[FBRunLoopSpinner new]
+                   timeout:2.0]
+                  timeoutErrorMessage:@"Picker wheel value has not been changed after 2 seconds timeout"]
+                 spinUntilTrue:^BOOL{
+                   [self.pickerWheel resolve];
+                   return ![self.pickerWheel.value isEqualToString:previousValue];
+                 }
+                 error:&error]);
+  XCTAssertNil(error);
+}
+
+- (void)testSwipePickerWheelWithElementCoordinates
+{
+  CGRect pickerFrame = self.pickerWheel.frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"press",
+      @"options": @{
+          @"element": self.pickerWheel,
+          @"x": @(pickerFrame.size.width / 2),
+          @"y": @(pickerFrame.size.height / 2),
+          }
+      },
+    @{
+      @"action": @"wait",
+      @"options": @{
+          @"ms": @500,
+          }
+      },
+    @{
+      @"action": @"moveTo",
+      @"options": @{
+          @"element": self.pickerWheel,
+          @"x": @(pickerFrame.size.width / 2),
+          @"y": @(pickerFrame.size.height),
+          }
+      },
+    @{
+      @"action": @"release"
+      }
+  ];
+  [self verifyPickerWheelPositionChangeWithGesture:gesture];
+}
+
+- (void)testSwipePickerWheelWithRelativeCoordinates
+{
+  CGRect pickerFrame = self.pickerWheel.frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"press",
+      @"options": @{
+          @"element": self.pickerWheel,
+          @"x": @(pickerFrame.size.width / 2),
+          @"y": @(pickerFrame.size.height / 2),
+          }
+      },
+    @{
+      @"action": @"wait",
+      @"options": @{
+          @"ms": @500,
+          }
+      },
+    @{
+      @"action": @"moveTo",
+      @"options": @{
+          @"x": @0,
+          @"y": @(-pickerFrame.size.height / 2),
+          }
+      },
+    @{
+      @"action": @"release"
+      }
+    ];
+  [self verifyPickerWheelPositionChangeWithGesture:gesture];
+}
+
+- (void)testSwipePickerWheelWithAbsoluteCoordinates
+{
+  CGRect pickerFrame = self.pickerWheel.frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"action": @"longPress",
+      @"options": @{
+          @"x": @(pickerFrame.origin.x + pickerFrame.size.width / 2),
+          @"y": @(pickerFrame.origin.y + pickerFrame.size.height / 2),
+          }
+      },
+    @{
+      @"action": @"moveTo",
+      @"options": @{
+          @"x": @0,
+          @"y": @(pickerFrame.size.height / 2),
+          }
+      },
+    @{
+      @"action": @"release"
+      }
+    ];
+  [self verifyPickerWheelPositionChangeWithGesture:gesture];
+}
+
+@end
+

--- a/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBAppiumTouchActionsIntegrationTests.m
@@ -55,6 +55,8 @@
 
 - (void)testErroneousGestures
 {
+  XCUIElement *dstButton = self.testedApplication.buttons[FBShowAlertButtonName];
+  
   NSArray<NSArray<NSDictionary<NSString *, id> *> *> *invalidGestures =
   @[
     // Empty chain
@@ -70,15 +72,9 @@
     
     // Empty chain because of cancel
     @[@{
-        @"action": @"tap",
+        @"action": @"moveTo",
         @"options": @{
-            @"element": self.testedApplication.buttons[FBShowAlertButtonName],
-            }
-        },
-      @{
-        @"action": @"wait",
-        @"options": @{
-            @"ms": @100
+            @"element": dstButton,
             }
         },
       @{
@@ -90,7 +86,7 @@
     @[@{
         @"action": @"tapP",
         @"options": @{
-            @"element": self.testedApplication.buttons[FBShowAlertButtonName],
+            @"element": dstButton,
             }
         },
       ],
@@ -348,8 +344,8 @@
     @{
       @"action": @"moveTo",
       @"options": @{
-          @"x": @0,
-          @"y": @(-pickerFrame.size.height / 2),
+          @"x": @(pickerFrame.origin.x),
+          @"y": @(pickerFrame.origin.y),
           }
       },
     @{
@@ -373,8 +369,8 @@
     @{
       @"action": @"moveTo",
       @"options": @{
-          @"x": @0,
-          @"y": @(pickerFrame.size.height / 2),
+          @"x": @(pickerFrame.origin.x),
+          @"y": @(pickerFrame.origin.y + pickerFrame.size.height),
           }
       },
     @{

--- a/WebDriverAgentTests/IntegrationTests/FBW3CMultiTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CMultiTouchActionsIntegrationTests.m
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+
+#import "XCUIElement.h"
+#import "XCUIApplication+FBTouchAction.h"
+#import "FBAlert.h"
+#import "FBTestMacros.h"
+#import "XCUIDevice+FBRotation.h"
+#import "FBRunLoopSpinner.h"
+
+@interface FBW3CMultiTouchActionsIntegrationTests : FBIntegrationTestCase
+
+@end
+
+
+@implementation FBW3CMultiTouchActionsIntegrationTests
+
+- (void)verifyGesture:(NSArray<NSDictionary<NSString *, id> *> *)gesture orientation:(UIDeviceOrientation)orientation
+{
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  NSError *error;
+  XCTAssertTrue(self.testedApplication.alerts.count == 0);
+  XCTAssertTrue([self.testedApplication fb_performW3CTouchActions:gesture elementCache:nil error:&error]);
+  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
+}
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAlertsPage];
+  });
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+  [[FBAlert alertWithApplication:self.testedApplication] dismissWithError:nil];
+}
+
+- (void)testErroneousGestures
+{
+  NSArray<NSArray<NSDictionary<NSString *, id> *> *> *invalidGestures =
+  @[
+    // One of the chains has duplicated id
+    @[
+      @{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      @{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    ];
+  
+  for (NSArray<NSDictionary<NSString *, id> *> *invalidGesture in invalidGestures) {
+    NSError *error;
+    XCTAssertFalse([self.testedApplication fb_performW3CTouchActions:invalidGesture elementCache:nil  error:&error]);
+    XCTAssertNotNil(error);
+  }
+}
+
+- (void)testSymmetricTwoFingersTap
+{
+  XCUIElement *element = self.testedApplication.buttons[FBShowAlertButtonName];
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[
+    @{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": element},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    @{
+      @"type": @"pointer",
+      @"id": @"finger2",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": element},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  
+  [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
+@end
+

--- a/WebDriverAgentTests/IntegrationTests/FBW3CMultiTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CMultiTouchActionsIntegrationTests.m
@@ -99,7 +99,7 @@
       @"id": @"finger1",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": element},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": element, @"x": @0, @"y": @0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @100},
           @{@"type": @"pointerUp"},
@@ -110,7 +110,7 @@
       @"id": @"finger2",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": element},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": element, @"x": @0, @"y": @0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @100},
           @{@"type": @"pointerUp"},

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -271,7 +271,7 @@
       @"id": @"finger1",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName]},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName], @"x": @0, @"y": @0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @100},
           @{@"type": @"pointerUp"},
@@ -289,7 +289,7 @@
       @"id": @"finger1",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName]},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName], @"x": @0, @"y": @0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @100},
           @{@"type": @"pointerUp"},
@@ -390,10 +390,10 @@
       @"id": @"finger1",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @(pickerFrame.size.width / 2), @"y": @(pickerFrame.size.height / 2)},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @0, @"y":@0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @500},
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @(pickerFrame.size.width / 2), @"y": @(pickerFrame.size.height)},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @0, @"y": @(pickerFrame.size.height / 2)},
           @{@"type": @"pointerUp"},
           ],
       },
@@ -410,7 +410,7 @@
       @"id": @"finger1",
       @"parameters": @{@"pointerType": @"touch"},
       @"actions": @[
-          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @(pickerFrame.size.width / 2), @"y": @(pickerFrame.size.height / 2)},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @0, @"y": @0},
           @{@"type": @"pointerDown"},
           @{@"type": @"pause", @"duration": @500},
           @{@"type": @"pointerMove", @"duration": @0, @"origin": @"pointer", @"x": @0, @"y": @(-pickerFrame.size.height / 2)},

--- a/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBW3CTouchActionsIntegrationTests.m
@@ -1,0 +1,446 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+
+#import "XCUIElement.h"
+#import "XCUIApplication+FBTouchAction.h"
+#import "FBAlert.h"
+#import "FBTestMacros.h"
+#import "XCUIDevice+FBRotation.h"
+#import "FBRunLoopSpinner.h"
+
+@interface FBW3CTouchActionsIntegrationTestsPart1 : FBIntegrationTestCase
+@end
+
+@interface FBW3CTouchActionsIntegrationTestsPart2 : FBIntegrationTestCase
+@property (nonatomic) XCUIElement *pickerWheel;
+@end
+
+
+@implementation FBW3CTouchActionsIntegrationTestsPart1
+
+- (void)verifyGesture:(NSArray<NSDictionary<NSString *, id> *> *)gesture orientation:(UIDeviceOrientation)orientation
+{
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  NSError *error;
+  XCTAssertTrue(self.testedApplication.alerts.count == 0);
+  XCTAssertTrue([self.testedApplication fb_performW3CTouchActions:gesture elementCache:nil error:&error]);
+  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
+}
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAlertsPage];
+  });
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+  [[FBAlert alertWithApplication:self.testedApplication] dismissWithError:nil];
+}
+
+- (void)testErroneousGestures
+{
+  NSArray<NSArray<NSDictionary<NSString *, id> *> *> *invalidGestures =
+  @[
+    // Empty chain
+    @[],
+    
+    // Chain element without 'actions' key
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        },
+      ],
+    
+    // Chain element with empty 'actions'
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[],
+        },
+      ],
+    
+    // Chain element without type
+    @[@{
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @100, @"y": @100},
+            ],
+        },
+      ],
+    
+    // Chain element without id
+    @[@{
+        @"type": @"pointer",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @100, @"y": @100},
+            ],
+        },
+      ],
+    
+    // Chain element with empty id
+    @[@{
+        @"type": @"pointer",
+        @"id": @"",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @100, @"y": @100},
+            ],
+        },
+      ],
+    
+    // Chain element with unsupported type
+    @[@{
+        @"type": @"key",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @100, @"y": @100},
+            ],
+        },
+      ],
+    
+    // Chain element with unsupported pointerType (default)
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @100, @"y": @100},
+            ],
+        },
+      ],
+ 
+    // Chain element with unsupported pointerType (non-default)
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"pen"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @100, @"y": @100},
+            ],
+        },
+      ],
+    
+    // Chain element without action item type
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element containing action item without y coordinate
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element containing action item with an unknown type
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMoved", @"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element where action items start with an incorrect item
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element where pointerMove action item does not contain coordinates
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element where pointerMove action item cannot use coordinates of the previous item
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"origin": @"pointer"},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element where action items contains negative duration
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @-100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    // Chain element where action items start with an incorrect one, because the correct one is canceled
+    @[@{
+        @"type": @"pointer",
+        @"id": @"finger1",
+        @"parameters": @{@"pointerType": @"touch"},
+        @"actions": @[
+            @{@"type": @"pointerMove", @"duration": @0, @"x": @1, @"y": @1},
+            @{@"type": @"pointerCancel"},
+            @{@"type": @"pointerDown"},
+            @{@"type": @"pause", @"duration": @-100},
+            @{@"type": @"pointerUp"},
+            ],
+        },
+      ],
+    
+    ];
+  
+  for (NSArray<NSDictionary<NSString *, id> *> *invalidGesture in invalidGestures) {
+    NSError *error;
+    XCTAssertFalse([self.testedApplication fb_performW3CTouchActions:invalidGesture elementCache:nil error:&error]);
+    XCTAssertNotNil(error);
+  }
+}
+
+- (void)testTap
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName]},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationPortrait];
+}
+
+- (void)testDoubleTap
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName]},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationLandscapeLeft];
+}
+
+- (void)testLongPressWithCombinedPause
+{
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.testedApplication.buttons[FBShowAlertButtonName], @"x": @5, @"y": @5},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @200},
+          @{@"type": @"pause", @"duration": @200},
+          @{@"type": @"pause", @"duration": @100},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyGesture:gesture orientation:UIDeviceOrientationLandscapeRight];
+}
+
+- (void)testLongPressWithPressure
+{
+  UIDeviceOrientation orientation = UIDeviceOrientationLandscapeLeft;
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  CGRect elementFrame = self.testedApplication.buttons[FBShowAlertButtonName].frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"x": @(elementFrame.origin.x + 1), @"y": @(elementFrame.origin.y + 1)},
+          @{@"type": @"pointerDown", @"pressure": @0.1},
+          @{@"type": @"pause", @"duration": @500},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyGesture:gesture orientation:orientation];
+}
+
+@end
+
+
+@implementation FBW3CTouchActionsIntegrationTestsPart2
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAttributesPage];
+  });
+  self.pickerWheel = [self.testedApplication.pickerWheels elementBoundByIndex:0];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)verifyPickerWheelPositionChangeWithGesture:(NSArray<NSDictionary<NSString *, id> *> *)gesture
+{
+  NSString *previousValue = self.pickerWheel.value;
+  NSError *error;
+  XCTAssertTrue([self.testedApplication fb_performW3CTouchActions:gesture elementCache:nil error:&error]);
+  XCTAssertNil(error);
+  XCTAssertTrue([[[[FBRunLoopSpinner new]
+                   timeout:2.0]
+                  timeoutErrorMessage:@"Picker wheel value has not been changed after 2 seconds timeout"]
+                 spinUntilTrue:^BOOL{
+                   [self.pickerWheel resolve];
+                   return ![self.pickerWheel.value isEqualToString:previousValue];
+                 }
+                 error:&error]);
+  XCTAssertNil(error);
+}
+
+- (void)testSwipePickerWheelWithElementCoordinates
+{
+  CGRect pickerFrame = self.pickerWheel.frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @(pickerFrame.size.width / 2), @"y": @(pickerFrame.size.height / 2)},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @500},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @(pickerFrame.size.width / 2), @"y": @(pickerFrame.size.height)},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyPickerWheelPositionChangeWithGesture:gesture];
+}
+
+- (void)testSwipePickerWheelWithRelativeCoordinates
+{
+  CGRect pickerFrame = self.pickerWheel.frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": self.pickerWheel, @"x": @(pickerFrame.size.width / 2), @"y": @(pickerFrame.size.height / 2)},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @500},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": @"pointer", @"x": @0, @"y": @(-pickerFrame.size.height / 2)},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyPickerWheelPositionChangeWithGesture:gesture];
+}
+
+- (void)testSwipePickerWheelWithAbsoluteCoordinates
+{
+  CGRect pickerFrame = self.pickerWheel.frame;
+  NSArray<NSDictionary<NSString *, id> *> *gesture =
+  @[@{
+      @"type": @"pointer",
+      @"id": @"finger1",
+      @"parameters": @{@"pointerType": @"touch"},
+      @"actions": @[
+          @{@"type": @"pointerMove", @"duration": @0, @"x": @(pickerFrame.origin.x + pickerFrame.size.width / 2), @"y": @(pickerFrame.origin.y + pickerFrame.size.height / 2)},
+          @{@"type": @"pointerDown"},
+          @{@"type": @"pause", @"duration": @500},
+          @{@"type": @"pointerMove", @"duration": @0, @"origin": @"pointer", @"x": @0, @"y": @(pickerFrame.size.height / 2)},
+          @{@"type": @"pointerUp"},
+          ],
+      },
+    ];
+  [self verifyPickerWheelPositionChangeWithGesture:gesture];
+}
+
+@end
+
+


### PR DESCRIPTION
Implements touch actions support for Appium's and [W3C](https://github.com/jlipps/simple-wd-spec#perform-actions) protocols. The Appium's protocol might be considered as [temporary](https://github.com/appium/appium/issues/9579), since all the current versions of Appium client libs support it, which means we can start to use it immediately having minimal changes in the server code.