### PR TITLE
Use the native 'activate' method for application activation

### DIFF
--- a/PrivateHeaders/XCTest/XCUIApplication.h
+++ b/PrivateHeaders/XCTest/XCUIApplication.h
@@ -34,15 +34,14 @@
 @property(readonly, nonatomic) UIInterfaceOrientation interfaceOrientation; //TODO tvos
 @property(readonly, nonatomic) BOOL running;
 @property(nonatomic) pid_t processID; // @synthesize processID=_processID;
-#if __IPHONE_OS_VERSION_MAX_ALLOWED <= __IPHONE_10_0
-@property(nonatomic, readwrite) NSUInteger state; // @synthesize state=_state;
-#endif
 @property(readonly) XCAccessibilityElement *accessibilityElement;
 
 /*! DO NOT USE DIRECTLY! Please use fb_applicationWithPID instead */
 + (instancetype)appWithPID:(pid_t)processID;
 /*! DO NOT USE DIRECTLY! Please use fb_applicationWithPID instead */
 + (instancetype)applicationWithPID:(pid_t)processID;
+/*! DO NOT USE DIRECTLY! Please use fb_activate instead */
+- (void)activate;
 
 - (void)dismissKeyboard;
 - (BOOL)setFauxCollectionViewCellsEnabled:(BOOL)arg1 error:(id *)arg2;

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -33,10 +33,10 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
   if (self.class.fb_isActivateSupported) {
     [self fb_activate];
-  } else if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
-    return NO;
+    return YES;
   }
-  return YES;
+  
+  return [[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error];
 }
 
 - (NSDictionary *)fb_tree

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -35,7 +35,6 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
     [self fb_activate];
     return YES;
   }
-  
   return [[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error];
 }
 

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -13,6 +13,7 @@
 #import "XCElementSnapshot.h"
 #import "FBElementTypeTransformer.h"
 #import "FBMacros.h"
+#import "FBXCodeCompatibility.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
 #import "XCUIElement+FBIsVisible.h"
@@ -30,7 +31,9 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
     return NO;
   }
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
-  if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
+  if (self.class.fb_isActivateSupported) {
+    [self fb_activate];
+  } else if (![[FBSpringboardApplication fb_springboard] fb_tapApplicationWithIdentifier:applicationIdentifier error:error]) {
     return NO;
   }
   return YES;

--- a/WebDriverAgentLib/FBSpringboardApplication.h
+++ b/WebDriverAgentLib/FBSpringboardApplication.h
@@ -11,7 +11,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString *const SPRINGBOARD_BUNDLE_ID = @"com.apple.springboard";
+/*! Bundle identifier of Springboard app */
+extern NSString *const SPRINGBOARD_BUNDLE_ID;
 
 @interface FBSpringboardApplication : FBApplication
 

--- a/WebDriverAgentLib/FBSpringboardApplication.h
+++ b/WebDriverAgentLib/FBSpringboardApplication.h
@@ -9,9 +9,11 @@
 
 #import <WebDriverAgentLib/FBApplication.h>
 
-@interface FBSpringboardApplication : FBApplication
-
 NS_ASSUME_NONNULL_BEGIN
+
+static NSString *const SPRINGBOARD_BUNDLE_ID = @"com.apple.springboard";
+
+@interface FBSpringboardApplication : FBApplication
 
 /**
  @return FBApplication that is attached to SpringBoard

--- a/WebDriverAgentLib/FBSpringboardApplication.m
+++ b/WebDriverAgentLib/FBSpringboardApplication.m
@@ -29,7 +29,7 @@
   static FBSpringboardApplication *_springboardApp;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    _springboardApp = [[FBSpringboardApplication alloc] initPrivateWithPath:nil bundleID:@"com.apple.springboard"];
+    _springboardApp = [[FBSpringboardApplication alloc] initPrivateWithPath:nil bundleID:SPRINGBOARD_BUNDLE_ID];
   });
   [_springboardApp query];
   [_springboardApp resolve];

--- a/WebDriverAgentLib/FBSpringboardApplication.m
+++ b/WebDriverAgentLib/FBSpringboardApplication.m
@@ -22,6 +22,8 @@
 #import "XCUIElement.h"
 #import "XCUIElementQuery.h"
 
+NSString *const SPRINGBOARD_BUNDLE_ID = @"com.apple.springboard";
+
 @implementation FBSpringboardApplication
 
 + (instancetype)fb_springboard

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -19,8 +19,37 @@
 
 @end
 
+/**
+ The exception happends if one tries to call application method,
+ which is not supported in the current iOS version
+ */
+extern NSString *const FBApplicationMethodNotSupportedException;
+
 @interface XCUIApplication (FBCompatibility)
 
 + (instancetype)fb_applicationWithPID:(pid_t)processID;
+
+/**
+ Get the state of the application. This method only returns reliable results on Xcode SDK 9+
+ 
+ @return State value as enum item. See https://developer.apple.com/documentation/xctest/xcuiapplicationstate?language=objc for more details.
+ */
+- (NSUInteger)fb_state;
+
+/**
+ Activate the application by restoring it from the background.
+ Nothing will happen if the application is already in foreground.
+ This method is only supported since Xcode9.
+ 
+ @throws FBApplicationMethodNotSupportedException if the method is called on Xcode SDK older than 9.
+ */
+- (void)fb_activate;
+
+/**
+ Use this method to check whether application activation is supported by the current iOS SDK.
+ 
+ @return YES if application activation is supported.
+ */
++ (BOOL)fb_isActivateSupported;
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -26,8 +26,13 @@ static dispatch_once_t onceRootElementToken;
 
 @end
 
+
+NSString *const FBApplicationMethodNotSupportedException = @"FBApplicationMethodNotSupportedException";
+
 static BOOL FBShouldUseOldAppWithPIDSelector = NO;
 static dispatch_once_t onceAppWithPIDToken;
+static BOOL FBCanUseActivate = NO;
+static dispatch_once_t onceActivate;
 @implementation XCUIApplication (FBCompatibility)
 
 + (instancetype)fb_applicationWithPID:(pid_t)processID
@@ -39,6 +44,30 @@ static dispatch_once_t onceAppWithPIDToken;
     return [self appWithPID:processID];
   }
   return [self applicationWithPID:processID];
+}
+
+- (void)fb_activate
+{
+  dispatch_once(&onceActivate, ^{
+    FBCanUseActivate = [self respondsToSelector:@selector(activate)];
+  });
+  if (!FBCanUseActivate) {
+    [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
+  }
+  [self activate];
+}
+
+- (NSUInteger)fb_state
+{
+  return [[self valueForKey:@"state"] intValue];
+}
+
++ (BOOL)fb_isActivateSupported
+{
+  dispatch_once(&onceActivate, ^{
+    FBCanUseActivate = [self respondsToSelector:@selector(activate)];
+  });
+  return FBCanUseActivate;
 }
 
 @end

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -48,10 +48,7 @@ static dispatch_once_t onceActivate;
 
 - (void)fb_activate
 {
-  dispatch_once(&onceActivate, ^{
-    FBCanUseActivate = [self respondsToSelector:@selector(activate)];
-  });
-  if (!FBCanUseActivate) {
+  if (!self.class.fb_isActivateSupported) {
     [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
   }
   [self activate];

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
@@ -11,4 +11,5 @@
 
 @interface FBApplicationDouble : NSObject
 @property (nonatomic, assign, readonly) BOOL didTerminate;
+@property (nonatomic) NSString* bundleID;
 @end

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.h
@@ -11,5 +11,5 @@
 
 @interface FBApplicationDouble : NSObject
 @property (nonatomic, assign, readonly) BOOL didTerminate;
-@property (nonatomic) NSString* bundleID;
+@property (nonatomic, strong) NSString* bundleID;
 @end

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
@@ -15,6 +15,15 @@
 
 @implementation FBApplicationDouble
 
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    self.bundleID = @"some.bundle.identifier";
+  }
+  return self;
+}
+
 - (void)terminate
 {
   self.didTerminate = YES;

--- a/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
+++ b/WebDriverAgentTests/UnitTests/Doubles/FBApplicationDouble.m
@@ -19,7 +19,7 @@
 {
   self = [super init];
   if (self) {
-    self.bundleID = @"some.bundle.identifier";
+    _bundleID = @"some.bundle.identifier";
   }
   return self;
 }


### PR DESCRIPTION
Since Xcode9 SDK Apple has added support for multiple applications in scope of a single session. This PR adds _activate_ endpoint to XCUIApplication instances and simplifies/makes more stable the implementation of _deactivateApp_ feature. This is going to be used as the base for the further PR, which adds multiple applications support to WDA.