### PR TITLE
Exclude time-intensive checks from visibility verification

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -17,7 +17,6 @@
 #import "XCUIElement+FBUtilities.h"
 #import "XCTestPrivateSymbols.h"
 #import <XCTest/XCUIDevice.h>
-#import "XCElementSnapshot+FBHitPoint.h"
 
 @implementation XCUIElement (FBIsVisible)
 
@@ -49,14 +48,6 @@
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
   if (self == hitElement || [self._allDescendants.copy containsObject:hitElement]) {
     return YES;
-  }
-  if (CGRectContainsPoint(appFrame, self.fb_hitPoint)) {
-    return YES;
-  }
-  for (XCElementSnapshot *elementSnapshot in self._allDescendants.copy) {
-    if (CGRectContainsPoint(appFrame, elementSnapshot.fb_hitPoint)) {
-      return YES;
-    }
   }
   return NO;
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -44,7 +44,13 @@
   if (!CGRectIntersectsRect(frame, screenFrame)) {
     return NO;
   }
-  CGPoint midPoint = [self.suggestedHitpoints.lastObject CGPointValue];
+  CGPoint midPoint;
+  @try {	
+    midPoint = [self hitPoint];
+  } @catch (NSException *e) {
+    [FBLogger logFmt:@"Failed to fetch hit point for %@ - %@", self.debugDescription, e.reason];
+    midPoint = [self.suggestedHitpoints.lastObject CGPointValue];
+  }
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
   if (self == hitElement || [self._allDescendants.copy containsObject:hitElement]) {
     return YES;


### PR DESCRIPTION
_hitPoint_ calculation is super-time intensive and it's even more time-intensive if we do it for all the descendant elements, which can greatly slow down source generation, because it's repeated for each node. My pure assumption is that

```objc
CGPoint midPoint = [self.suggestedHitpoints.lastObject CGPointValue];
   XCElementSnapshot *hitElement = [self hitTest:midPoint];
   if (self == hitElement || [self._allDescendants.copy containsObject:hitElement]) {
     return YES;
   }
```

verification should also cover the two conditions, which were removed in this PR.

I'd like to ask other people to test this change.