### PR TITLE
Cache snapshot values to improve performance

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBScrolling.m
@@ -106,7 +106,7 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
 
          cellSnapshots = [snapshot fb_descendantsCellSnapshots];
 
-         visibleCellSnapshots = [cellSnapshots filteredArrayUsingPredicate:[FBPredicate predicateWithFormat:@"%K == YES", FBStringify(XCUIElement, fb_isVisible)]];
+         visibleCellSnapshots = [cellSnapshots filteredArrayUsingPredicate:[FBPredicate predicateWithFormat:@"%K == YES", FBStringify(XCUIElement, isWDVisible)]];
 
          if (visibleCellSnapshots.count > 1) {
            return YES;
@@ -189,7 +189,7 @@ const CGFloat FBMinimumTouchEventDelay = 0.1f;
   }
   for (XCElementSnapshot *elementSnapshot in self.application.fb_lastSnapshot._allDescendants.copy) {
     // We are comparing pre-scroll snapshot so frames are irrelevant.
-    if ([snapshot fb_framelessFuzzyMatchesElement:elementSnapshot] && elementSnapshot.fb_isVisible) {
+    if ([snapshot fb_framelessFuzzyMatchesElement:elementSnapshot] && elementSnapshot.wdVisible) {
       return YES;
     }
   }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface XCElementSnapshot (WebDriverAttributes) <FBElement>
 
+/*! Stores cached attribute values, which imrpoves queries performance */
+@property (nonatomic) NSMutableDictionary<NSString *, id> *fb_cachedAttributes;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -73,7 +73,9 @@ static char const * const FBCachedAttributesKey = "FBCachedAttributes";
     }
     return result;
   }
-  return valueGetter();
+  result = valueGetter();
+  [self fb_setCachedValue:result forAttributeName:attributeName];
+  return result;
 }
 
 - (void)fb_setCachedValue:(id)value forAttributeName:(NSString *)name

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -153,7 +153,7 @@ static char const * const FBCachedAttributesKey = "FBCachedAttributes";
 - (CGRect)wdFrame
 {
   id (^valueGetter)(void) = ^id(void) {
-    return @(CGRectIntegral(self.frame));
+    return [NSValue valueWithCGRect:CGRectIntegral(self.frame)];
   };
   return [[self fb_cachedValueFor:@"wdFrame" valueGetter:valueGetter] CGRectValue];
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -87,10 +87,12 @@ static char const * const FBCachedAttributesKey = "FBCachedAttributes";
     id value = self.value;
     NSUInteger elementType = self.elementType;
     if (elementType == XCUIElementTypeStaticText) {
-      value = FBFirstNonEmptyValue(value, self.label);
+      NSString *label = self.label;
+      value = FBFirstNonEmptyValue(value, label);
     }
     if (elementType == XCUIElementTypeButton) {
-      value = FBFirstNonEmptyValue(value, (self.isSelected ? @YES : nil));
+      BOOL isSelected = self.isSelected;
+      value = FBFirstNonEmptyValue(value, (isSelected ? @YES : nil));
     }
     if (elementType == XCUIElementTypeSwitch) {
       value = @([value boolValue]);
@@ -98,7 +100,8 @@ static char const * const FBCachedAttributesKey = "FBCachedAttributes";
     if (elementType == XCUIElementTypeTextView ||
         elementType == XCUIElementTypeTextField ||
         elementType == XCUIElementTypeSecureTextField) {
-      value = FBFirstNonEmptyValue(value, self.placeholderValue);
+      NSString *placeholderValue = self.placeholderValue;
+      value = FBFirstNonEmptyValue(value, placeholderValue);
     }
     value = FBTransferEmptyStringToNil(value);
     if (nil != value) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBWebDriverAttributes.m
@@ -40,125 +40,195 @@
 
 @end
 
+static char const * const FBCachedAttributesKey = "FBCachedAttributes";
 
 @implementation XCElementSnapshot (WebDriverAttributes)
+
+@dynamic fb_cachedAttributes;
 
 - (id)fb_valueForWDAttributeName:(NSString *)name
 {
   return [self valueForKey:[FBElementUtils wdAttributeNameForAttributeName:name]];
 }
 
+- (NSMutableDictionary<NSString *, id> *)fb_cachedAttributes
+{
+  return (NSMutableDictionary<NSString *, id> *)objc_getAssociatedObject(self, FBCachedAttributesKey);
+}
+
+- (void)setFb_cachedAttributes:(NSMutableDictionary<NSString *, id> *)newCachedAttributes
+{
+  objc_setAssociatedObject(self, FBCachedAttributesKey, newCachedAttributes, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (id)fb_cachedValueFor:(NSString *)attributeName valueGetter:(id (^)(void))valueGetter
+{
+  if (nil == self.fb_cachedAttributes) {
+    [self setFb_cachedAttributes:[NSMutableDictionary new]];
+  }
+  id result = [self.fb_cachedAttributes objectForKey:attributeName];
+  if (nil != result) {
+    if ([NSNull null] == result) {
+      return nil;
+    }
+    return result;
+  }
+  return valueGetter();
+}
+
+- (void)fb_setCachedValue:(id)value forAttributeName:(NSString *)name
+{
+  [self.fb_cachedAttributes setObject:nil == value ? [NSNull null] : value forKey:name];
+}
+
 - (NSString *)wdValue
 {
-  id value = self.value;
-  if (self.elementType == XCUIElementTypeStaticText) {
-    value = FBFirstNonEmptyValue(self.value, self.label);
-  }
-  if (self.elementType == XCUIElementTypeButton) {
-    value = FBFirstNonEmptyValue(self.value, (self.isSelected ? @YES : nil));
-  }
-  if (self.elementType == XCUIElementTypeSwitch) {
-    value = @([self.value boolValue]);
-  }
-  if (self.elementType == XCUIElementTypeTextView ||
-      self.elementType == XCUIElementTypeTextField ||
-      self.elementType == XCUIElementTypeSecureTextField) {
-    value = FBFirstNonEmptyValue(self.value, self.placeholderValue);
-  }
-  value = FBTransferEmptyStringToNil(value);
-  if (value) {
-    value = [NSString stringWithFormat:@"%@", value];
-  }
-  return value;
+  id (^valueGetter)(void) = ^id(void) {
+    id value = self.value;
+    NSUInteger elementType = self.elementType;
+    if (elementType == XCUIElementTypeStaticText) {
+      value = FBFirstNonEmptyValue(value, self.label);
+    }
+    if (elementType == XCUIElementTypeButton) {
+      value = FBFirstNonEmptyValue(value, (self.isSelected ? @YES : nil));
+    }
+    if (elementType == XCUIElementTypeSwitch) {
+      value = @([value boolValue]);
+    }
+    if (elementType == XCUIElementTypeTextView ||
+        elementType == XCUIElementTypeTextField ||
+        elementType == XCUIElementTypeSecureTextField) {
+      value = FBFirstNonEmptyValue(value, self.placeholderValue);
+    }
+    value = FBTransferEmptyStringToNil(value);
+    if (nil != value) {
+      value = [NSString stringWithFormat:@"%@", value];
+    }
+    return value;
+  };
+  return [self fb_cachedValueFor:@"wdValue" valueGetter:valueGetter];
 }
 
 - (NSString *)wdName
 {
-  return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(self.identifier, self.label));
+  id (^valueGetter)(void) = ^id(void) {
+    NSString *identifier = self.identifier;
+    NSString *label = self.label;
+    return FBTransferEmptyStringToNil(FBFirstNonEmptyValue(identifier, label));
+  };
+  return [self fb_cachedValueFor:@"wdName" valueGetter:valueGetter];
 }
 
 - (NSString *)wdLabel
 {
-  if (self.elementType == XCUIElementTypeTextField) {
-    return self.label;
-  }
-  return FBTransferEmptyStringToNil(self.label);
+  id (^valueGetter)(void) = ^id(void) {
+    NSString *label = self.label;
+    if (self.elementType == XCUIElementTypeTextField) {
+      return label;
+    }
+    return FBTransferEmptyStringToNil(label);
+  };
+  return [self fb_cachedValueFor:@"wdLabel" valueGetter:valueGetter];
 }
 
 - (NSString *)wdType
 {
-  return [FBElementTypeTransformer stringWithElementType:self.elementType];
+  id (^valueGetter)(void) = ^id(void) {
+    return [FBElementTypeTransformer stringWithElementType:self.elementType];
+  };
+  return [self fb_cachedValueFor:@"wdType" valueGetter:valueGetter];
 }
 
 - (NSUInteger)wdUID
 {
-  return self.fb_uid;
+  id (^valueGetter)(void) = ^id(void) {
+    return @(self.fb_uid);
+  };
+  return [[self fb_cachedValueFor:@"wdUID" valueGetter:valueGetter] integerValue];
 }
 
 - (CGRect)wdFrame
 {
-  return CGRectIntegral(self.frame);
+  id (^valueGetter)(void) = ^id(void) {
+    return @(CGRectIntegral(self.frame));
+  };
+  return [[self fb_cachedValueFor:@"wdFrame" valueGetter:valueGetter] CGRectValue];
 }
 
 - (BOOL)isWDVisible
 {
-  return self.fb_isVisible;
+  id (^valueGetter)(void) = ^id(void) {
+    return @(self.fb_isVisible);
+  };
+  return [[self fb_cachedValueFor:@"isWDVisible" valueGetter:valueGetter] boolValue];
 }
 
 - (BOOL)isWDAccessible
 {
-  // Special cases:
-  // Table view cell: we consider it accessible if it's container is accessible
-  // Text fields: actual accessible element isn't text field itself, but nested element
-  if (self.elementType == XCUIElementTypeCell) {
-    if (!self.fb_isAccessibilityElement) {
-      XCElementSnapshot *containerView = [[self children] firstObject];
-      if (!containerView.fb_isAccessibilityElement) {
-        return NO;
+  id (^valueGetter)(void) = ^id(void) {
+    // Special cases:
+    // Table view cell: we consider it accessible if it's container is accessible
+    // Text fields: actual accessible element isn't text field itself, but nested element
+    if (self.elementType == XCUIElementTypeCell) {
+      if (!self.fb_isAccessibilityElement) {
+        XCElementSnapshot *containerView = [[self children] firstObject];
+        if (!containerView.fb_isAccessibilityElement) {
+          return @(NO);
+        }
+      }
+    } else if (self.elementType != XCUIElementTypeTextField && self.elementType != XCUIElementTypeSecureTextField) {
+      if (!self.fb_isAccessibilityElement) {
+        return @(NO);
       }
     }
-  } else if (self.elementType != XCUIElementTypeTextField && self.elementType != XCUIElementTypeSecureTextField) {
-    if (!self.fb_isAccessibilityElement) {
-      return NO;
+    XCElementSnapshot *parentSnapshot = self.parent;
+    while (parentSnapshot) {
+      // In the scenario when table provides Search results controller, table could be marked as accessible element, even though it isn't
+      // As it is highly unlikely that table view should ever be an accessibility element itself,
+      // for now we work around that by skipping Table View in container checks
+      if (parentSnapshot.fb_isAccessibilityElement && parentSnapshot.elementType != XCUIElementTypeTable) {
+        return @(NO);
+      }
+      parentSnapshot = parentSnapshot.parent;
     }
-  }
-  XCElementSnapshot *parentSnapshot = self.parent;
-  while (parentSnapshot) {
-    // In the scenario when table provides Search results controller, table could be marked as accessible element, even though it isn't
-    // As it is highly unlikely that table view should ever be an accessibility element itself,
-    // for now we work around that by skipping Table View in container checks
-    if (parentSnapshot.fb_isAccessibilityElement && parentSnapshot.elementType != XCUIElementTypeTable) {
-      return NO;
-    }
-    parentSnapshot = parentSnapshot.parent;
-  }
-  return YES;
+    return @(YES);
+  };
+  return [[self fb_cachedValueFor:@"isWDAccessible" valueGetter:valueGetter] boolValue];
 }
 
 - (BOOL)isWDAccessibilityContainer
 {
-  for (XCElementSnapshot *child in self.children) {
-    if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
-      return YES;
+  id (^valueGetter)(void) = ^id(void) {
+    for (XCElementSnapshot *child in self.children) {
+      if (child.isWDAccessibilityContainer || child.fb_isAccessibilityElement) {
+        return @(YES);
+      }
     }
-  }
-  return NO;
+    return @(NO);
+  };
+  return [[self fb_cachedValueFor:@"isWDAccessibilityContainer" valueGetter:valueGetter] boolValue];
 }
 
 - (BOOL)isWDEnabled
 {
-  return self.isEnabled;
+  id (^valueGetter)(void) = ^id(void) {
+    return @(self.isEnabled);
+  };
+  return [[self fb_cachedValueFor:@"isWDEnabled" valueGetter:valueGetter] boolValue];
 }
 
 - (NSDictionary *)wdRect
 {
-  CGRect frame = self.wdFrame;
-  return @{
-    @"x": @(CGRectGetMinX(frame)),
-    @"y": @(CGRectGetMinY(frame)),
-    @"width": @(CGRectGetWidth(frame)),
-    @"height": @(CGRectGetHeight(frame)),
+  id (^valueGetter)(void) = ^id(void) {
+    CGRect frame = self.wdFrame;
+    return @{
+             @"x": @(CGRectGetMinX(frame)),
+             @"y": @(CGRectGetMinY(frame)),
+             @"width": @(CGRectGetWidth(frame)),
+             @"height": @(CGRectGetHeight(frame)),
+             };
   };
+  return [self fb_cachedValueFor:@"wdRect" valueGetter:valueGetter];
 }
 
 @end

--- a/WebDriverAgentLib/FBAlert.m
+++ b/WebDriverAgentLib/FBAlert.m
@@ -114,8 +114,11 @@ NSString *const FBAlertObstructingElementException = @"FBAlertObstructingElement
     return nil;
   }
   NSArray<XCUIElement *> *buttons = [alertElement descendantsMatchingType:XCUIElementTypeButton].allElementsBoundByIndex;
-  for(XCUIElement *button in buttons) {
-    [value addObject:[button wdLabel]];
+  for (XCUIElement *button in buttons) {
+    NSString *label = button.wdLabel;
+    if (nil != label) {
+      [value addObject:label];
+    }
   }
   return value;
 }

--- a/WebDriverAgentLib/Routing/FBElement.h
+++ b/WebDriverAgentLib/Routing/FBElement.h
@@ -24,10 +24,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy) NSDictionary *wdRect;
 
 /*! Element's name */
-@property (nonatomic, readonly, copy) NSString *wdName;
+@property (nonatomic, readonly, copy, nullable) NSString *wdName;
 
 /*! Element's label */
-@property (nonatomic, readonly, copy) NSString *wdLabel;
+@property (nonatomic, readonly, copy, nullable) NSString *wdLabel;
 
 /*! Element's type */
 @property (nonatomic, readonly, copy) NSString *wdType;


### PR DESCRIPTION
I did some performance measurements for xml source building and got the following results for the current implementation (perf logs were added to each `wd...` call of `XCElementSnapshot (WebDriverAttributes)` category):

```
2017-10-31 21:35:26.745135+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdType = 0.004431009292602539
2017-10-31 21:35:26.746132+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdType = 1.001358032226562e-05
2017-10-31 21:35:26.755784+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdValue = 0.003981947898864746
2017-10-31 21:35:26.764480+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdName = 0.007960021495819092
2017-10-31 21:35:26.765202+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdName = 3.993511199951172e-06
2017-10-31 21:35:26.767403+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdLabel = 3.993511199951172e-06
2017-10-31 21:35:26.768643+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdLabel = 4.947185516357422e-06
2017-10-31 21:35:26.772012+0100 IntegrationTests_2-Runner[68723:1470635] >>> isWDEnabled = 9.000301361083984e-06
2017-10-31 21:35:26.788419+0100 IntegrationTests_2-Runner[68723:1470635] >>> isWDVisible = 0.01613003015518188
2017-10-31 21:35:26.788853+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdFrame = 1.966953277587891e-06
2017-10-31 21:35:26.789252+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdRect = 0.0004010200500488281
2017-10-31 21:35:26.789681+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdFrame = 1.966953277587891e-06
2017-10-31 21:35:26.789965+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdRect = 0.0002859830856323242
2017-10-31 21:35:26.790386+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdFrame = 1.966953277587891e-06
2017-10-31 21:35:26.790555+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdRect = 0.0001729726791381836
2017-10-31 21:35:26.790722+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdFrame = 2.026557922363281e-06
2017-10-31 21:35:26.790813+0100 IntegrationTests_2-Runner[68723:1470635] >>> wdRect = 9.500980377197266e-05
```

These calls are performed for each particular snapshot, so the overall xml building time time is a sum of these.

And here is the log with PR changes applied:

```
2017-11-01 08:38:52.792836+0100 IntegrationTests_2-Runner[72405:1813278] >>> wdType = 0.003904998302459717
2017-11-01 08:38:52.796257+0100 IntegrationTests_2-Runner[72405:1813278] >>> wdValue = 0.003201961517333984
2017-11-01 08:38:52.801930+0100 IntegrationTests_2-Runner[72405:1813278] >>> wdName = 0.005366981029510498
2017-11-01 08:38:52.802164+0100 IntegrationTests_2-Runner[72405:1813278] >>> wdLabel = 2.026557922363281e-06
2017-11-01 08:38:52.802348+0100 IntegrationTests_2-Runner[72405:1813278] >>> isWDEnabled = 2.980232238769531e-06
2017-11-01 08:38:52.810267+0100 IntegrationTests_2-Runner[72405:1813278] >>> isWDVisible = 0.007732987403869629
2017-11-01 08:38:52.811194+0100 IntegrationTests_2-Runner[72405:1813278] >>> wdFrame = 6.020069122314453e-06
2017-11-01 08:38:52.811343+0100 IntegrationTests_2-Runner[72405:1813278] >>> wdRect = 0.000162005424499511
```