### PR TITLE
Fix parsing of a chain with indirect descendants

### DIFF
--- a/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
+++ b/WebDriverAgentLib/Utilities/FBClassChainQueryParser.m
@@ -175,7 +175,7 @@ static NSString *const STAR_TOKEN = @"*";
 {
   if ([self.class.allowedCharacters characterIsMember:character]) {
     if (self.asString.length >= 1) {
-      FBDescendantMarkerToken *nextToken = [[FBDescendantMarkerToken alloc] initWithStringValue:STAR_TOKEN];
+      FBDescendantMarkerToken *nextToken = [[FBDescendantMarkerToken alloc] initWithStringValue:[NSString stringWithFormat:@"%@%@", STAR_TOKEN, STAR_TOKEN]];
       nextToken.previousItemsCountToOverride = 1;
       return nextToken;
     }

--- a/WebDriverAgentTests/UnitTests/FBClassChainTests.m
+++ b/WebDriverAgentTests/UnitTests/FBClassChainTests.m
@@ -104,6 +104,42 @@
   XCTAssertFalse(thirdElement.isDescendant);
 }
 
+- (void)testValidDoubleIndirectChainAndStar
+{
+  NSError *error;
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"**/XCUIElementTypeButton/**/*" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.elements.count, 2);
+  
+  FBClassChainItem *firstElement = [result.elements firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(firstElement.position, 1);
+  XCTAssertTrue(firstElement.isDescendant);
+  
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeAny);
+  XCTAssertEqual(secondElement.position, 0);
+  XCTAssertTrue(secondElement.isDescendant);
+}
+
+- (void)testValidDoubleIndirectChainAndClassName
+{
+  NSError *error;
+  FBClassChain *result = [FBClassChainQueryParser parseQuery:@"**/XCUIElementTypeButton/**/XCUIElementTypeImage" error:&error];
+  XCTAssertNotNil(result);
+  XCTAssertEqual(result.elements.count, 2);
+  
+  FBClassChainItem *firstElement = [result.elements firstObject];
+  XCTAssertEqual(firstElement.type, XCUIElementTypeButton);
+  XCTAssertEqual(firstElement.position, 1);
+  XCTAssertTrue(firstElement.isDescendant);
+  
+  FBClassChainItem *secondElement = [result.elements objectAtIndex:1];
+  XCTAssertEqual(secondElement.type, XCUIElementTypeImage);
+  XCTAssertEqual(secondElement.position, 0);
+  XCTAssertTrue(secondElement.isDescendant);
+}
+
 - (void)testValidChainWithNegativeIndex
 {
   NSError *error;


### PR DESCRIPTION
Thanks to @imurchie found an issue there where parsing of some special chain queries like `**/XCUIElementTypeButton/**/*` was failing due to a mistake in the parser. Now it's fixed.