### PR TITLE
A new word in visibility detection

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -27,19 +27,19 @@
 
 @implementation XCElementSnapshot (FBIsVisible)
 
-+ (BOOL)fb_isVisibleInContainerWindow:(XCElementSnapshot *)window selfElement:(XCElementSnapshot *)element hierarchyIntersection:(nullable NSValue *)intersectionRectange appFrame:(CGRect)appFrame
+- (BOOL)fb_isVisibleInContainerWindow:(XCElementSnapshot *)window hierarchyIntersection:(nullable NSValue *)intersectionRectange appFrame:(CGRect)appFrame
 {
-  CGRect currentRectangle = nil == intersectionRectange ? element.frame : [intersectionRectange CGRectValue];
-  XCElementSnapshot *parent = element.parent;
+  CGRect currentRectangle = nil == intersectionRectange ? self.frame : [intersectionRectange CGRectValue];
+  XCElementSnapshot *parent = self.parent;
   CGRect intersectionWithParent = CGRectIntersection(currentRectangle, parent.frame);
   if (CGRectIsEmpty(intersectionWithParent)) {
     return NO;
   }
   if (parent == window) {
     // Assume the element is visible if its root container is hittable and the frame is onscreen
-    return CGRectContainsPoint(appFrame, element.fb_hitPoint);
+    return CGRectContainsPoint(appFrame, self.fb_hitPoint);
   }
-  return [self.class fb_isVisibleInContainerWindow:window selfElement:parent hierarchyIntersection:[NSValue valueWithCGRect:intersectionWithParent] appFrame:appFrame];
+  return [parent fb_isVisibleInContainerWindow:window hierarchyIntersection:[NSValue valueWithCGRect:intersectionWithParent] appFrame:appFrame];
 }
 
 - (BOOL)fb_isVisible
@@ -53,7 +53,7 @@
   CGRect appFrame = [self fb_rootElement].frame;
   XCElementSnapshot *containerWindow = [self fb_parentMatchingType:XCUIElementTypeWindow];
   if (nil != containerWindow) {
-    return [self.class fb_isVisibleInContainerWindow:containerWindow selfElement:self hierarchyIntersection:nil appFrame:appFrame];
+    return [self fb_isVisibleInContainerWindow:containerWindow hierarchyIntersection:nil appFrame:appFrame];
   }
   return CGRectContainsPoint(appFrame, self.fb_hitPoint);
 }

--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -9,15 +9,12 @@
 
 #import "XCUIElement+FBIsVisible.h"
 
-#import "FBApplication.h"
 #import "FBConfiguration.h"
-#import "FBMathUtils.h"
 #import "FBXCodeCompatibility.h"
 #import "XCElementSnapshot+FBHelpers.h"
-#import "XCUIElement+FBUtilities.h"
-#import "XCTestPrivateSymbols.h"
-#import <XCTest/XCUIDevice.h>
 #import "XCElementSnapshot+FBHitPoint.h"
+#import "XCTestPrivateSymbols.h"
+#import "XCUIElement+FBUtilities.h"
 
 @implementation XCUIElement (FBIsVisible)
 
@@ -30,35 +27,35 @@
 
 @implementation XCElementSnapshot (FBIsVisible)
 
++ (BOOL)fb_isVisibleInContainerWindow:(XCElementSnapshot *)window selfElement:(XCElementSnapshot *)element hierarchyIntersection:(nullable NSValue *)intersectionRectange appFrame:(CGRect)appFrame
+{
+  CGRect currentRectangle = nil == intersectionRectange ? element.frame : [intersectionRectange CGRectValue];
+  XCElementSnapshot *parent = element.parent;
+  CGRect intersectionWithParent = CGRectIntersection(currentRectangle, parent.frame);
+  if (CGRectIsEmpty(intersectionWithParent)) {
+    return NO;
+  }
+  if (parent == window) {
+    // Assume the element is visible if its root container is hittable and the frame is onscreen
+    return CGRectContainsPoint(appFrame, element.fb_hitPoint);
+  }
+  return [self.class fb_isVisibleInContainerWindow:window selfElement:parent hierarchyIntersection:[NSValue valueWithCGRect:intersectionWithParent] appFrame:appFrame];
+}
+
 - (BOOL)fb_isVisible
 {
-  CGRect frame = self.frame;
-  if (CGRectIsEmpty(frame)) {
+  if (CGRectIsEmpty(self.frame)) {
     return NO;
   }
   if ([FBConfiguration shouldUseTestManagerForVisibilityDetection]) {
     return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
   }
   CGRect appFrame = [self fb_rootElement].frame;
-  CGSize screenSize = FBAdjustDimensionsForApplication(appFrame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
-  CGRect screenFrame = CGRectMake(0, 0, screenSize.width, screenSize.height);
-  if (!CGRectIntersectsRect(frame, screenFrame)) {
-    return NO;
+  XCElementSnapshot *containerWindow = [self fb_parentMatchingType:XCUIElementTypeWindow];
+  if (nil != containerWindow) {
+    return [self.class fb_isVisibleInContainerWindow:containerWindow selfElement:self hierarchyIntersection:nil appFrame:appFrame];
   }
-  CGPoint midPoint = [self.suggestedHitpoints.lastObject CGPointValue];
-  XCElementSnapshot *hitElement = [self hitTest:midPoint];
-  if (self == hitElement || [self._allDescendants.copy containsObject:hitElement]) {
-    return YES;
-  }
-  if (CGRectContainsPoint(appFrame, self.fb_hitPoint)) {
-    return YES;
-  }
-  for (XCElementSnapshot *elementSnapshot in self.children.copy) {
-    if (elementSnapshot.fb_isVisible) {
-      return YES;
-    }
-  }
-  return NO;
+  return CGRectContainsPoint(appFrame, self.fb_hitPoint);
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
@@ -54,7 +54,7 @@
   FBAssertWaitTillBecomesTrue(self.springboard.icons[@"Contacts"].fb_isVisible);
   NSArray *elements = self.springboard.pageIndicators.allElementsBoundByIndex;
   for (XCUIElement *element in elements) {
-    XCTAssertFalse(element.fb_isVisible);
+    XCTAssertTrue(element.fb_isVisible);
   }
 }
 

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -321,9 +321,9 @@
 
 - (void)testInvisibleDescendantWithXPathQuery
 {
-  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypePageIndicator[@visible='false']" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *matchingSnapshots = [self.testedApplication fb_descendantsMatchingXPathQuery:@"//XCUIElementTypeWindow[@visible='false']" shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(matchingSnapshots.count, 1);
-  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypePageIndicator);
+  XCTAssertEqual(matchingSnapshots.lastObject.elementType, XCUIElementTypeWindow);
   XCTAssertFalse(matchingSnapshots.lastObject.fb_isVisible);
 }
 


### PR DESCRIPTION
This PR speeds up visibility detection in general, fixes it for landscape mode and also fixes scrolling to element for Xcode9+
Previously visibility detection was based on _hittable_ property value, but this property does not work for static elements, like an image in a cell, since hittablity for such elements is defined by gesture recogniser. Now we use another approach: we detect the visibility of the particular element based on the intersection between its own frame and all ancestor frames. This gives better results, since even if the element is not hittable the viability value is calculated properly for it:
![before](https://user-images.githubusercontent.com/7767781/32890265-5340e8ce-cace-11e7-9aae-26ebbcac73b8.png)
![now](https://user-images.githubusercontent.com/7767781/32890270-567eacb0-cace-11e7-9236-9da607f8325f.png)

As a result, the issues like https://github.com/facebook/WebDriverAgent/issues/746 should be addresses after the PR is merged and the overall visibility detection speed should be better.