### PR TITLE
Fix the way 'activate' method support is checked for XCUIApplication instances

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -31,7 +31,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
     return NO;
   }
   [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:MAX(duration, FBMinimumAppSwitchWait)]];
-  if (self.class.fb_isActivateSupported) {
+  if (self.fb_isActivateSupported) {
     [self fb_activate];
     return YES;
   }

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.h
@@ -52,7 +52,7 @@ extern NSString *const FBApplicationMethodNotSupportedException;
  
  @return YES if application activation is supported.
  */
-+ (BOOL)fb_isActivateSupported;
+- (BOOL)fb_isActivateSupported;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
+++ b/WebDriverAgentLib/Utilities/FBXCodeCompatibility.m
@@ -50,7 +50,7 @@ static dispatch_once_t onceActivate;
 
 - (void)fb_activate
 {
-  if (!self.class.fb_isActivateSupported) {
+  if (!self.fb_isActivateSupported) {
     [[NSException exceptionWithName:FBApplicationMethodNotSupportedException reason:@"'activate' method is not supported by the current iOS SDK" userInfo:@{}] raise];
   }
   [self activate];
@@ -61,7 +61,7 @@ static dispatch_once_t onceActivate;
   return [[self valueForKey:@"state"] intValue];
 }
 
-+ (BOOL)fb_isActivateSupported
+- (BOOL)fb_isActivateSupported
 {
   dispatch_once(&onceActivate, ^{
     FBCanUseActivate = [self respondsToSelector:@selector(activate)];
@@ -70,6 +70,7 @@ static dispatch_once_t onceActivate;
 }
 
 @end
+
 
 static BOOL FBShouldUseFirstMatchSelector = NO;
 static dispatch_once_t onceFirstMatchToken;


### PR DESCRIPTION
The current implementation tries to verify method presence for the class rather than to the class instance, which always results in false response.

This issue has been also addressed in https://github.com/facebook/WebDriverAgent/pull/776, but I see it is not going to be merged soon, so I decided to extract the fix into the separate PR.