### PR TITLE
Add W3C element screenshot endpoint support

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */; };
+		7126FF0E1FD99C7E00DEFB38 /* FBElementScreenshotTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7126FF0D1FD99C7E00DEFB38 /* FBElementScreenshotTests.m */; };
 		712A0C851DA3E459007D02E5 /* FBXPathTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 712A0C841DA3E459007D02E5 /* FBXPathTests.m */; };
 		712A0C871DA3E55D007D02E5 /* FBXPath-Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */; };
 		712A0C8C1DA3F25B007D02E5 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 7174AF031D9D39AF008C8AD5 /* libxml2.tbd */; };
@@ -401,6 +402,7 @@
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
 		7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBPickerWheelSelectTests.m; sourceTree = "<group>"; };
+		7126FF0D1FD99C7E00DEFB38 /* FBElementScreenshotTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBElementScreenshotTests.m; sourceTree = "<group>"; };
 		712A0C841DA3E459007D02E5 /* FBXPathTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPathTests.m; sourceTree = "<group>"; };
 		712A0C861DA3E55D007D02E5 /* FBXPath-Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "FBXPath-Private.h"; sourceTree = "<group>"; };
 		7136A4771E8918E60024FC3D /* XCUIElement+FBPickerWheel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBPickerWheel.h"; sourceTree = "<group>"; };
@@ -1058,6 +1060,7 @@
 			children = (
 				EE9B76991CF799F400275851 /* FBAlertTests.m */,
 				EE26409C1D0EBA25009BE6B0 /* FBElementAttributeTests.m */,
+				7126FF0D1FD99C7E00DEFB38 /* FBElementScreenshotTests.m */,
 				EE006EAC1EB99B15006900A4 /* FBElementVisibilityTests.m */,
 				EE6A89361D0B35920083E92B /* FBFailureProofTestCaseTests.m */,
 				EE1E06DB1D18090F007CF043 /* FBIntegrationTestCase.h */,
@@ -1801,6 +1804,7 @@
 			files = (
 				EE2202131ECC612200A29571 /* FBIntegrationTestCase.m in Sources */,
 				EE22021E1ECC618900A29571 /* FBTapTest.m in Sources */,
+				7126FF0E1FD99C7E00DEFB38 /* FBElementScreenshotTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.h
@@ -59,6 +59,13 @@ NS_ASSUME_NONNULL_BEGIN
 */
 - (BOOL)fb_waitUntilSnapshotIsStable;
 
+/**
+ Returns screenshot of the particular element
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return Element screenshot as PNG-encoded data or nil in case of failure
+ */
+- (nullable NSData *)fb_screenshotWithError:(NSError**)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -18,6 +18,7 @@
 #import "FBXCodeCompatibility.h"
 #import "XCAXClient_iOS.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
+#import "XCUIScreen.h"
 
 @implementation XCUIElement (FBUtilities)
 
@@ -122,6 +123,50 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
     [FBLogger logFmt:@"There are still some active animations in progress after %.2f seconds timeout. Visibility detection may cause unexpected delays.", FBANIMATION_TIMEOUT];
   }
   return result;
+}
+
+- (NSData *)fb_screenshotWithError:(NSError**)error
+{
+  if (CGRectIsEmpty(self.frame)) {
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:@"Cannot get a screenshot of zero-sized element"] build];
+    }
+    return nil;
+  }
+  
+  Class xcScreenClass = NSClassFromString(@"XCUIScreen");
+  if (nil == xcScreenClass) {
+    if (error) {
+      *error = [[FBErrorBuilder.builder withDescription:@"Element screenshots are only available since Xcode9 SDK"] build];
+    }
+    return nil;
+  }
+  
+  XCUIScreen *mainScreen = (XCUIScreen *)[xcScreenClass mainScreen];
+  NSData *result = [mainScreen screenshotDataForQuality:1 rect:self.frame error:error];
+  if (nil == result) {
+    return nil;
+  }
+  
+  UIImage *image = [UIImage imageWithData:result];
+  UIInterfaceOrientation orientation = self.application.interfaceOrientation;
+  UIImageOrientation imageOrientation = UIImageOrientationUp;
+  // The received element screenshot will be rotated, if the current interface orientation differs from portrait, so we need to fix that first
+  if (orientation == UIInterfaceOrientationLandscapeRight) {
+    imageOrientation = UIImageOrientationLeft;
+  } else if (orientation == UIInterfaceOrientationLandscapeLeft) {
+    imageOrientation = UIImageOrientationRight;
+  } else if (orientation == UIInterfaceOrientationPortraitUpsideDown) {
+    imageOrientation = UIImageOrientationDown;
+  }
+  CGSize size = image.size;
+  UIGraphicsBeginImageContext(CGSizeMake(size.width, size.height));
+  [[UIImage imageWithCGImage:(CGImageRef)[image CGImage] scale:1.0 orientation:imageOrientation] drawInRect:CGRectMake(0, 0, size.width, size.height)];
+  UIImage* fixedImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  
+  // The resulting data is a JPEG image, so we need to convert it to PNG representation
+  return (NSData *)UIImagePNGRepresentation(fixedImage);
 }
 
 @end

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -57,6 +57,7 @@
     [[FBRoute POST:@"/element/:uuid/value"] respondWithTarget:self action:@selector(handleSetValue:)],
     [[FBRoute POST:@"/element/:uuid/click"] respondWithTarget:self action:@selector(handleClick:)],
     [[FBRoute POST:@"/element/:uuid/clear"] respondWithTarget:self action:@selector(handleClear:)],
+    [[FBRoute GET:@"/element/:uuid/screenshot"] respondWithTarget:self action:@selector(handleElementScreenshot:)],
     [[FBRoute GET:@"/wda/element/:uuid/accessible"] respondWithTarget:self action:@selector(handleGetAccessible:)],
     [[FBRoute GET:@"/wda/element/:uuid/accessibilityContainer"] respondWithTarget:self action:@selector(handleGetIsAccessibilityContainer:)],
     [[FBRoute POST:@"/wda/element/:uuid/swipe"] respondWithTarget:self action:@selector(handleSwipe:)],
@@ -379,6 +380,19 @@
     @"width": @(screenSize.width),
     @"height": @(screenSize.height),
   });
+}
+
++ (id<FBResponsePayload>)handleElementScreenshot:(FBRouteRequest *)request
+{
+  FBElementCache *elementCache = request.session.elementCache;
+  XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
+  NSError *error;
+  NSData *screenshotData = [element fb_screenshotWithError:&error];
+  if (nil == screenshotData) {
+    return FBResponseWithError(error);
+  }
+  NSString *screenshot = [screenshotData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+  return FBResponseWithObject(screenshot);
 }
 
 static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;

--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+#import "XCUIDevice+FBRotation.h"
+#import "XCUIElement+FBUtilities.h"
+
+@interface FBElementScreenshotTests : FBIntegrationTestCase
+@end
+
+@implementation FBElementScreenshotTests
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAlertsPage];
+  });
+}
+
+- (void)testElementScreenshot
+{
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:UIDeviceOrientationLandscapeLeft];
+  XCUIElement *button = self.testedApplication.buttons[FBShowAlertButtonName];
+  NSError *error = nil;
+  NSData *screenshotData = [button fb_screenshotWithError:&error];
+  XCTAssertNotNil(screenshotData);
+  XCTAssertNil(error);
+  UIImage *image = [UIImage imageWithData:screenshotData];
+  XCTAssertNotNil(image);
+  XCTAssertTrue(image.size.width > image.size.height);
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementScreenshotTests.m
@@ -34,6 +34,9 @@
   XCUIElement *button = self.testedApplication.buttons[FBShowAlertButtonName];
   NSError *error = nil;
   NSData *screenshotData = [button fb_screenshotWithError:&error];
+  if (nil == screenshotData && [error.description containsString:@"available since Xcode9"]) {
+    return;
+  }
   XCTAssertNotNil(screenshotData);
   XCTAssertNil(error);
   UIImage *image = [UIImage imageWithData:screenshotData];


### PR DESCRIPTION
Sometimes it is useful to get a screenshot of the particular element. This is especially useful for non-portrait mode, where things natively available from XCTest are kind of broken.

Unfortunately, this endpoint only works since Xcode9 SDK and requires `screenshotDataForQuality` selector to be available.