### PR TITLE
Get Source Performance increase

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -34,6 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSDictionary *)fb_accessibilityTree;
 
+-(void) fb_application_resolve;
+
+- (XCElementSnapshot *)fb_application_lastSnapshot;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -34,9 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSDictionary *)fb_accessibilityTree;
 
--(void) fb_application_resolve;
-
-- (XCElementSnapshot *)fb_application_lastSnapshot;
+/**
+ Makes sure the application is active and in the foreground
+ **/
+-(void) fb_resolve;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -110,11 +110,12 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 
 -(void) fb_resolve
 {
-  if (self.fb_isActivateSupported) {
-    if(self.state != XCUIApplicationStateRunningForeground) {
-      [self activate];
+  @try {
+    if(self.fb_state != XCUIApplicationStateRunningForeground) {
+      [self fb_activate];
     }
-  } else {
+  }
+  @catch (NSException *) {
     [self query];
     [self resolve];
   }

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -108,4 +108,21 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   return info;
 }
 
+-(void) fb_application_resolve
+{
+  if (self.fb_isActivateSupported) {
+    [self activate];
+  }
+  else
+  {
+    [self query];
+    [self resolve];
+  }
+}
+
+- (XCElementSnapshot *)fb_application_lastSnapshot
+{
+  [self fb_application_resolve];
+  return self.lastSnapshot;
+}
 @end

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -111,13 +111,10 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 -(void) fb_resolve
 {
   if (self.fb_isActivateSupported) {
-    
-    if(self.state != XCUIApplicationStateRunningForeground)
-    {
+    if(self.state != XCUIApplicationStateRunningForeground) {
       [self activate];
     }
-  }
-  else {
+  } else {
     [self query];
     [self resolve];
   }

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -41,7 +41,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 - (NSDictionary *)fb_tree
 {
   [self fb_waitUntilSnapshotIsStable];
-  return [self.class dictionaryForElement:self.fb_lastSnapshot];
+  return [self.class dictionaryForElement:self.fb_application_lastSnapshot];
 }
 
 - (NSDictionary *)fb_accessibilityTree

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -41,7 +41,7 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
 - (NSDictionary *)fb_tree
 {
   [self fb_waitUntilSnapshotIsStable];
-  return [self.class dictionaryForElement:self.fb_application_lastSnapshot];
+  return [self.class dictionaryForElement:self.fb_lastSnapshot];
 }
 
 - (NSDictionary *)fb_accessibilityTree
@@ -108,21 +108,19 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
   return info;
 }
 
--(void) fb_application_resolve
+-(void) fb_resolve
 {
   if (self.fb_isActivateSupported) {
-    [self activate];
+    
+    if(self.state != XCUIApplicationStateRunningForeground)
+    {
+      [self activate];
+    }
   }
-  else
-  {
+  else {
     [self query];
     [self resolve];
   }
 }
 
-- (XCElementSnapshot *)fb_application_lastSnapshot
-{
-  [self fb_application_resolve];
-  return self.lastSnapshot;
-}
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -21,6 +21,7 @@
 #import "XCAXClient_iOS.h"
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "XCUIScreen.h"
+#import "XCElementSnapshot+FBHelpers.h"
 
 @implementation XCUIElement (FBUtilities)
 
@@ -65,11 +66,10 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 
 - (XCElementSnapshot *)fb_lastSnapshot
 {
-  [self query];
-  [self resolve];
-  return self.lastSnapshot;
+  XCElementSnapshot *snapshot=self.lastSnapshot;
+  [snapshot.application fb_resolve];
+  return snapshot;
 }
-
 - (NSArray<XCUIElement *> *)fb_filterDescendantsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots
 {
   if (0 == snapshots.count) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -72,9 +72,7 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 
 - (void)fb_resolve
 {
-  if ([self isKindOfClass:XCUIApplication.class]) {
-    [((XCUIApplication *)self) fb_resolve];
-  } else if (self.application.fb_isActivateSupported) {
+  if (self.application.fb_isActivateSupported) {
     [self.application fb_resolve];
   } else {
     [self query];

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -66,10 +66,24 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 
 - (XCElementSnapshot *)fb_lastSnapshot
 {
-  XCElementSnapshot *snapshot=self.lastSnapshot;
-  [snapshot.application fb_resolve];
-  return snapshot;
+  [self fb_resolve];
+  return self.lastSnapshot;
 }
+
+- (void)fb_resolve
+{
+  if ([self isKindOfClass:XCUIApplication.class]) {
+    [((XCUIApplication *)self) fb_resolve];
+  }
+  else if (self.application.fb_isActivateSupported) {
+    [self.application fb_resolve];
+  }
+  else {
+    [self query];
+    [self resolve];
+  }
+}
+
 - (NSArray<XCUIElement *> *)fb_filterDescendantsWithSnapshots:(NSArray<XCElementSnapshot *> *)snapshots
 {
   if (0 == snapshots.count) {

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -74,11 +74,9 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 {
   if ([self isKindOfClass:XCUIApplication.class]) {
     [((XCUIApplication *)self) fb_resolve];
-  }
-  else if (self.application.fb_isActivateSupported) {
+  } else if (self.application.fb_isActivateSupported) {
     [self.application fb_resolve];
-  }
-  else {
+  } else {
     [self query];
     [self resolve];
   }

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -45,7 +45,7 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
   id result;
   if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_XML] == NSOrderedSame) {
     [application fb_waitUntilSnapshotIsStable];
-    result = [FBXPath xmlStringWithSnapshot:application.fb_application_lastSnapshot];
+    result = [FBXPath xmlStringWithSnapshot:application.fb_lastSnapshot];
     
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_JSON] == NSOrderedSame) {
     result = application.fb_tree;

--- a/WebDriverAgentLib/Commands/FBDebugCommands.m
+++ b/WebDriverAgentLib/Commands/FBDebugCommands.m
@@ -45,7 +45,8 @@ static NSString *const SOURCE_FORMAT_DESCRIPTION = @"description";
   id result;
   if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_XML] == NSOrderedSame) {
     [application fb_waitUntilSnapshotIsStable];
-    result = [FBXPath xmlStringWithSnapshot:application.fb_lastSnapshot];
+    result = [FBXPath xmlStringWithSnapshot:application.fb_application_lastSnapshot];
+    
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_JSON] == NSOrderedSame) {
     result = application.fb_tree;
   } else if ([sourceType caseInsensitiveCompare:SOURCE_FORMAT_DESCRIPTION] == NSOrderedSame) {

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -42,8 +42,7 @@
   }
   FBApplication *application = [FBApplication fb_applicationWithPID:activeApplicationElement.processIdentifier];
   NSAssert(nil != application, @"Active application instance is not expected to be equal to nil", nil);
-  
-  [application fb_application_resolve];
+  [application fb_resolve];
   return application;
 }
 

--- a/WebDriverAgentLib/FBApplication.m
+++ b/WebDriverAgentLib/FBApplication.m
@@ -20,6 +20,7 @@
 #import "XCUIApplicationProcess.h"
 #import "XCUIElement.h"
 #import "XCUIElementQuery.h"
+#import "FBRuntimeUtils.h"
 
 @interface FBApplication ()
 @property (nonatomic, assign) BOOL fb_isObservingAppImplCurrentProcess;
@@ -41,8 +42,8 @@
   }
   FBApplication *application = [FBApplication fb_applicationWithPID:activeApplicationElement.processIdentifier];
   NSAssert(nil != application, @"Active application instance is not expected to be equal to nil", nil);
-  [application query];
-  [application resolve];
+  
+  [application fb_application_resolve];
   return application;
 }
 


### PR DESCRIPTION
Idea taken from this stackoverflow post https://stackoverflow.com/questions/35295090/possible-to-bring-the-app-from-background-to-foreground. I have made changes to call activate instead of query + resolve for Getting the Page source in iOS11, there is a performance increase

This is my first go at coding in objective-c so be kind :worried: