### PR TITLE
Fix remote bridged views detection in xpath source

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -33,7 +33,7 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsMatchingXPathQuery:(NSString *)xpathQuery
 {
-  return (NSArray<XCElementSnapshot *> *)[FBXPath findMatchesIn:self xpathQuery:xpathQuery];
+  return [FBXPath matchesWithRootElement:self forQuery:xpathQuery];
 }
 
 - (XCElementSnapshot *)fb_parentMatchingType:(XCUIElementType)type

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.h
@@ -34,6 +34,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSDictionary *)fb_accessibilityTree;
 
+/**
+ Return application elements tree in form of xml string
+ */
+- (nullable NSString *)fb_xmlRepresentation;
+
+/**
+ Return application elements tree in form of internal XCTest debugDescription string
+ */
+- (NSString *)fb_descriptionRepresentation;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCUIApplication+FBHelpers.m
@@ -14,6 +14,7 @@
 #import "FBElementTypeTransformer.h"
 #import "FBMacros.h"
 #import "FBXCodeCompatibility.h"
+#import "FBXPath.h"
 #import "XCElementSnapshot+FBHelpers.h"
 #import "XCUIDevice+FBHelpers.h"
 #import "XCUIElement+FBIsVisible.h"
@@ -106,6 +107,23 @@ const static NSTimeInterval FBMinimumAppSwitchWait = 3.0;
     return nil;
   }
   return info;
+}
+
+- (NSString *)fb_xmlRepresentation
+{
+  return [FBXPath xmlStringWithRootElement:self];
+}
+
+- (NSString *)fb_descriptionRepresentation
+{
+  NSMutableArray<NSString *> *childrenDescriptions = [NSMutableArray array];
+  for (XCUIElement *child in [self childrenMatchingType:XCUIElementTypeAny].allElementsBoundByIndex) {
+    [childrenDescriptions addObject:child.debugDescription];
+  }
+  // debugDescription property of XCUIApplication instance shows descendants addresses in memory
+  // instead of the actual information about them, however the representation works properly
+  // for all descendant elements
+  return (0 == childrenDescriptions.count) ? self.debugDescription : [childrenDescriptions componentsJoinedByString:@"\n\n"];
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBFind.m
@@ -20,6 +20,7 @@
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "FBElementUtils.h"
 #import "FBXCodeCompatibility.h"
+#import "FBXPath.h"
 
 @implementation XCUIElement (FBFind)
 
@@ -108,17 +109,11 @@
 
 #pragma mark - Search by xpath
 
-- (NSArray<XCElementSnapshot *> *)getMatchedSnapshotsByXPathQuery:(NSString *)xpathQuery
+- (NSArray<XCUIElement *> *)fb_descendantsMatchingXPathQuery:(NSString *)xpathQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
 {
   // XPath will try to match elements only class name, so requesting elements by XCUIElementTypeAny will not work. We should use '*' instead.
   xpathQuery = [xpathQuery stringByReplacingOccurrencesOfString:@"XCUIElementTypeAny" withString:@"*"];
-  [self fb_waitUntilSnapshotIsStable];
-  return [self.fb_lastSnapshot fb_descendantsMatchingXPathQuery:xpathQuery];
-}
-
-- (NSArray<XCUIElement *> *)fb_descendantsMatchingXPathQuery:(NSString *)xpathQuery shouldReturnAfterFirstMatch:(BOOL)shouldReturnAfterFirstMatch
-{
-  NSArray *matchingSnapshots = [self getMatchedSnapshotsByXPathQuery:xpathQuery];
+  NSArray<XCElementSnapshot *> *matchingSnapshots = [FBXPath matchesWithRootElement:self forQuery:xpathQuery];
   if (0 == [matchingSnapshots count]) {
     return @[];
   }
@@ -128,7 +123,6 @@
   }
   return [self fb_filterDescendantsWithSnapshots:matchingSnapshots];
 }
-
 
 #pragma mark - Search by Accessibility Id
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -66,7 +66,6 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 
 - (XCElementSnapshot *)fb_lastSnapshot
 {
-  [self resolve];
   return [[self query] elementSnapshotForDebugDescription];
 }
 

--- a/WebDriverAgentLib/Utilities/FBXPath-Private.h
+++ b/WebDriverAgentLib/Utilities/FBXPath-Private.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param query Optional XPath query value. By analyzing this query we may optimize the lookup speed.
  @return zero if the method has completed successfully
  */
-+ (int)getSnapshotAsXML:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore query:(nullable NSString*)query;
++ (int)xmlRepresentationWithRootElement:(XCElementSnapshot *)root writer:(xmlTextWriterPtr)writer elementStore:(nullable NSMutableDictionary *)elementStore query:(nullable NSString*)query;
 
 /**
  Gets the list of matched snapshots from xmllib2-compatible xmlNodeSetPtr structure

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -7,8 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-#import <Foundation/Foundation.h>
-#import <XCTest/XCUIElementTypes.h>
+#import <XCTest/XCTest.h>
 #import <WebDriverAgentLib/FBElement.h>
 #import <WebDriverAgentLib/XCElementSnapshot.h>
 
@@ -46,9 +45,10 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
  
  @param root the root element to execute XPath query for
  @param xpathQuery requested xpath query
- @return an array of descendants matching given xpath query
+ @return an array of descendants matching the given xpath query or an empty array if no matches were found
+ @throws NSException if there is an unexpected internal error during xml parsing
  */
-+ (nullable NSArray<XCElementSnapshot *> *)findMatchesIn:(XCElementSnapshot *)root xpathQuery:(NSString *)xpathQuery;
++ (NSArray<XCElementSnapshot *> *)matchesWithRootElement:(id<FBElement>)root forQuery:(NSString *)xpathQuery;
 
 /**
  Gets XML representation of XCElementSnapshot with all its descendants. This method generates the same
@@ -57,7 +57,7 @@ extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
  @param root the root element
  @return valid XML document as string or nil in case of failure
  */
-+ (nullable NSString *)xmlStringWithSnapshot:(XCElementSnapshot *)root;
++ (nullable NSString *)xmlStringWithRootElement:(id<FBElement>)root;
 
 @end
 

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -120,7 +120,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
 + (NSArray<XCElementSnapshot *> *)matchesWithRootElement:(id<FBElement>)root forQuery:(NSString *)xpathQuery
 {
   xmlDocPtr doc;
-  
+
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
   if (NULL == writer) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlNewTextWriterDoc for XPath query \"%@\"", xpathQuery];
@@ -140,7 +140,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     xmlFreeDoc(doc);
     return [self throwException:XCElementSnapshotInvalidXPathException forQuery:xpathQuery];
   }
-  
+
   NSArray *matchingSnapshots = [self collectMatchingSnapshots:queryResult->nodesetval elementStore:elementStore];
   xmlXPathFreeObject(queryResult);
   xmlFreeTextWriter(writer);
@@ -219,17 +219,17 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   if (0 == input) {
     return NULL;
   }
-  
+
   xmlCharEncodingHandlerPtr handler = xmlFindCharEncodingHandler(_UTF8Encoding);
   if (!handler) {
     [FBLogger log:@"Failed to invoke libxml2>xmlFindCharEncodingHandler"];
     return NULL;
   }
-  
+
   int size = (int) strlen(input) + 1;
   int outputSize = size * 2 - 1;
   xmlChar *output = (unsigned char *) xmlMalloc((size_t) outputSize);
-  
+
   if (0 != output) {
     int temp = size - 1;
     int ret = handler->input(output, &outputSize, (const xmlChar *) input, &temp);
@@ -241,7 +241,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       output[outputSize] = 0;
     }
   }
-  
+
   return output;
 }
 
@@ -253,7 +253,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
     return NULL;
   }
   xpathCtx->node = doc->children;
-  
+
   xmlXPathObjectPtr xpathObj = xmlXPathEvalExpression([self xmlCharPtrForInput:[xpathQuery cStringUsingEncoding:NSUTF8StringEncoding]], xpathCtx);
   if (NULL == xpathObj) {
     xmlXPathFreeContext(xpathCtx);
@@ -286,7 +286,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       return rc;
     }
   }
-  
+
   if (nil != indexPath) {
     // index path is the special case
     return [FBIndexAttribute recordWithWriter:writer forValue:indexPath];
@@ -354,7 +354,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
       return rc;
     }
   }
-  
+
   rc = xmlTextWriterEndElement(writer);
   if (rc < 0) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlTextWriterEndElement. Error code: %d", rc];

--- a/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBXPathIntegrationTests.m
@@ -40,7 +40,7 @@
   XCUIElement *matchingElement = [[self.testedView fb_descendantsMatchingXPathQuery:[NSString stringWithFormat:@"//%@", expectedType] shouldReturnAfterFirstMatch:YES] firstObject];
   XCElementSnapshot *matchingSnapshot = matchingElement.fb_lastSnapshot;
 
-  NSString *xmlStr = [FBXPath xmlStringWithSnapshot:matchingSnapshot];
+  NSString *xmlStr = [FBXPath xmlStringWithRootElement:matchingSnapshot];
   XCTAssertNotNil(xmlStr);
 
   NSString *expectedXml = [NSString stringWithFormat:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<%@ type=\"%@\" name=\"%@\" label=\"%@\" enabled=\"%@\" visible=\"%@\" x=\"%@\" y=\"%@\" width=\"%@\" height=\"%@\"/>\n", expectedType, expectedType, matchingSnapshot.wdName, matchingSnapshot.wdLabel, matchingSnapshot.wdEnabled ? @"true" : @"false", matchingSnapshot.wdVisible ? @"true" : @"false", [matchingSnapshot.wdRect[@"x"] stringValue], [matchingSnapshot.wdRect[@"y"] stringValue], [matchingSnapshot.wdRect[@"width"] stringValue], [matchingSnapshot.wdRect[@"height"] stringValue]];
@@ -49,7 +49,7 @@
 
 - (void)testFindMatchesInElement
 {
-  NSArray *matchingSnapshots = [FBXPath findMatchesIn:self.testedView.fb_lastSnapshot xpathQuery:@"//XCUIElementTypeButton"];
+  NSArray *matchingSnapshots = [FBXPath matchesWithRootElement:self.testedView.fb_lastSnapshot forQuery:@"//XCUIElementTypeButton"];
   XCTAssertEqual([matchingSnapshots count], 4);
   for (id<FBElement> element in matchingSnapshots) {
     XCTAssertTrue([element.wdType isEqualToString:@"XCUIElementTypeButton"]);
@@ -58,7 +58,7 @@
 
 - (void)testFindMatchesInElementWithDotNotation
 {
-  NSArray *matchingSnapshots = [FBXPath findMatchesIn:self.testedView.fb_lastSnapshot xpathQuery:@".//XCUIElementTypeButton"];
+  NSArray *matchingSnapshots = [FBXPath matchesWithRootElement:self.testedView.fb_lastSnapshot forQuery:@".//XCUIElementTypeButton"];
   XCTAssertEqual([matchingSnapshots count], 4);
   for (id<FBElement> element in matchingSnapshots) {
     XCTAssertTrue([element.wdType isEqualToString:@"XCUIElementTypeButton"]);

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -35,7 +35,7 @@
   
   XCTAssertEqual(rc, 0);
   XCTAssertEqual(1, [elementStore count]);
-  
+
   return [NSString stringWithCString:(const char *)xmlbuff encoding:NSUTF8StringEncoding];
 }
 
@@ -66,7 +66,7 @@
 - (void)testSnapshotXPathResultsMatching
 {
   xmlDocPtr doc;
-  
+
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   XCUIElementDouble *root = [XCUIElementDouble new];
@@ -77,19 +77,19 @@
     xmlFreeDoc(doc);
     XCTAssertEqual(rc, 0);
   }
-  
+
   xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc];
   if (NULL == queryResult) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
     XCTAssertNotEqual(NULL, queryResult);
   }
-  
+
   NSArray *matchingSnapshots = [FBXPath collectMatchingSnapshots:queryResult->nodesetval elementStore:elementStore];
   xmlXPathFreeObject(queryResult);
   xmlFreeTextWriter(writer);
   xmlFreeDoc(doc);
-  
+
   XCTAssertNotNil(matchingSnapshots);
   XCTAssertEqual(1, [matchingSnapshots count]);
 }

--- a/WebDriverAgentTests/UnitTests/FBXPathTests.m
+++ b/WebDriverAgentTests/UnitTests/FBXPathTests.m
@@ -26,7 +26,7 @@
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   int buffersize;
   xmlChar *xmlbuff;
-  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)element writer:writer elementStore:elementStore query:query];
+  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)element writer:writer elementStore:elementStore query:query];
   if (0 == rc) {
     xmlDocDumpFormatMemory(doc, &xmlbuff, &buffersize, 1);
   }
@@ -35,7 +35,7 @@
   
   XCTAssertEqual(rc, 0);
   XCTAssertEqual(1, [elementStore count]);
-
+  
   return [NSString stringWithCString:(const char *)xmlbuff encoding:NSUTF8StringEncoding];
 }
 
@@ -66,32 +66,33 @@
 - (void)testSnapshotXPathResultsMatching
 {
   xmlDocPtr doc;
-
+  
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
   XCUIElementDouble *root = [XCUIElementDouble new];
   NSString *query = [NSString stringWithFormat:@"//%@", root.wdType];
-  int rc = [FBXPath getSnapshotAsXML:(XCElementSnapshot *)root writer:writer elementStore:elementStore query:query];
+  int rc = [FBXPath xmlRepresentationWithRootElement:(XCElementSnapshot *)root writer:writer elementStore:elementStore query:query];
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
     XCTAssertEqual(rc, 0);
   }
-
+  
   xmlXPathObjectPtr queryResult = [FBXPath evaluate:query document:doc];
   if (NULL == queryResult) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
     XCTAssertNotEqual(NULL, queryResult);
   }
-
+  
   NSArray *matchingSnapshots = [FBXPath collectMatchingSnapshots:queryResult->nodesetval elementStore:elementStore];
   xmlXPathFreeObject(queryResult);
   xmlFreeTextWriter(writer);
   xmlFreeDoc(doc);
-
+  
   XCTAssertNotNil(matchingSnapshots);
   XCTAssertEqual(1, [matchingSnapshots count]);
 }
 
 @end
+


### PR DESCRIPTION
This is the backport of fixes we did for Appium in order to properly display RemoteBridgeView  hierarchies in page source and be able to find descendant element there using xpath queries in Xcode 9+. 

The original problem source somehow lies in XCUIApplication snapshots. If the snapshot is taken from any other parent element (we use direct children of the application element) then all its descendant remote views are properly visible in the hierarchy.

The PR also applies some refactoring on page source displaying logic in general.