### PR TITLE
fb_isVisible using interfaceOrientation instead of Device orientation. 

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -40,7 +40,7 @@
     return [(NSNumber *)[self fb_attributeValue:FB_XCAXAIsVisibleAttribute] boolValue];
   }
   CGRect appFrame = [self fb_rootElement].frame;
-  CGSize screenSize = FBAdjustDimensionsForApplication(appFrame.size, (UIInterfaceOrientation)[XCUIDevice sharedDevice].orientation);
+  CGSize screenSize = FBAdjustDimensionsForApplication(appFrame.size, self.application.interfaceOrientation);
   CGRect screenFrame = CGRectMake(0, 0, screenSize.width, screenSize.height);
   if (!CGRectIntersectsRect(frame, screenFrame)) {
     return NO;


### PR DESCRIPTION
[XCUIDevice sharedDevice].orientation may get values like FaceUp, which cause wrong calculation of the app frame size, in landscape.

With devices in Lab, standing portrait, this problem is less common. Working on development with devices on the table it happens more often causing a great deal of confusion.

From my tests, using app interfaceOrientation gives always the reality of the App.
 