### PR TITLE
Fix the incorrect tap coordinate in landscape mode.

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -35,6 +35,7 @@
 #import "FBElementTypeTransformer.h"
 #import "XCUIElement.h"
 #import "XCUIElementQuery.h"
+#import "FBXCodeCompatibility.h"
 
 @interface FBElementCommands ()
 @end
@@ -460,9 +461,23 @@ static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
   if (shouldApplyOrientationWorkaround) {
     point = FBInvertPointForApplication(coordinate, application.frame.size, application.interfaceOrientation);
   }
+  
+  /**
+   If SDK >= 11, the tap coordinate based on application is not correct when
+   the application orientation is landscape and
+   tapX > application portrait width or tapY > application portrait height.
+   Pass the window element to the method [FBElementCommands gestureCoordinateWithCoordinate:element:]
+   will resolve the problem.
+   More details about the bug, please see the following issues:
+   #705: https://github.com/facebook/WebDriverAgent/issues/705
+   #798: https://github.com/facebook/WebDriverAgent/issues/798
+   #856: https://github.com/facebook/WebDriverAgent/issues/856
+   Notice: On iOS 10, if the application is not launched by wda, no elements will be found.
+   See issue #732: https://github.com/facebook/WebDriverAgent/issues/732
+   */
   XCUIElement *element = application;
   if (isSDKVersionGreaterThanOrEqualTo(@"11.0")) {
-    XCUIElement *window = [self findWindowInApplication:application];
+    XCUIElement *window = application.windows.fb_firstMatch;
     if (window) element = window;
   }
   return [self gestureCoordinateWithCoordinate:point element:element];
@@ -479,36 +494,6 @@ static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
 {
   XCUICoordinate *appCoordinate = [[XCUICoordinate alloc] initWithElement:element normalizedOffset:CGVectorMake(0, 0)];
   return [[XCUICoordinate alloc] initWithCoordinate:appCoordinate pointsOffset:CGVectorMake(coordinate.x, coordinate.y)];
-}
-
-/**
- Returns the first window element in the current application under test
- 
- @application the instance of current application under test
- @return the first window element
- 
- If SDK >= 11, the tap coordinate based on application is not correct when
- the application orientation is landscape and
- tapX > application portrait width or tapY > application portrait height.
- Pass the window element to the method [FBElementCommands gestureCoordinateWithCoordinate:element:]
- will resolve the problem.
- More details about the bug, please see the following issues:
- #705: https://github.com/facebook/WebDriverAgent/issues/705
- #798: https://github.com/facebook/WebDriverAgent/issues/798
- #856: https://github.com/facebook/WebDriverAgent/issues/856
- Notice: On iOS 10, if the application is not launched by wda, no elements will be found.
- See issue #732: https://github.com/facebook/WebDriverAgent/issues/732
- */
-+ (XCUIElement *)findWindowInApplication:(XCUIApplication *)application {
-  NSArray<XCUIElement *> *allElements = application.windows.allElementsBoundByIndex;
-  XCUIElement *window = nil;
-  for (XCUIElement *e in allElements) {
-    if (e.elementType == XCUIElementTypeWindow) {
-      window = e;
-      break;
-    }
-  }
-  return window;
 }
 
 @end


### PR DESCRIPTION
Summary:
  If SDK >= 11, the tap coordinate based on application is not correct when
  the application orientation is landscape and
  tapX > application portrait width or tapY > application portrait height.
  Pass the window element to the method [FBElementCommands gestureCoordinateWithCoordinate:element:] will resolve the problem.
  More details about the bug, please see the following issues: #705, #798, #856.
  Notice: On iOS 10, if the application is not launched by wda, no elements will be found. See issue #732.