### PR TITLE
Fix fb_framelessFuzzyMatchesElement method

### DIFF
--- a/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
+++ b/WebDriverAgentLib/Categories/XCElementSnapshot+FBHelpers.m
@@ -20,7 +20,6 @@
 #import "XCUIElement+FBWebDriverAttributes.h"
 #import "FBXPath.h"
 
-inline static BOOL valuesAreEqual(id value1, id value2);
 inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, NSArray<NSNumber *> *types);
 
 @implementation XCElementSnapshot (FBHelpers)
@@ -66,12 +65,7 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
 
 - (BOOL)fb_framelessFuzzyMatchesElement:(XCElementSnapshot *)snapshot
 {
-  return self.elementType == snapshot.elementType &&
-    valuesAreEqual(self.identifier, snapshot.identifier) &&
-    valuesAreEqual(self.title, snapshot.title) &&
-    valuesAreEqual(self.label, snapshot.label) &&
-    valuesAreEqual(self.value, snapshot.value) &&
-    valuesAreEqual(self.placeholderValue, snapshot.placeholderValue);
+  return self.wdUID == snapshot.wdUID;
 }
 
 - (NSArray<XCElementSnapshot *> *)fb_descendantsCellSnapshots
@@ -105,11 +99,6 @@ inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, 
     return targetCellSnapshot;
 }
 @end
-
-inline static BOOL valuesAreEqual(id value1, id value2)
-{
-  return value1 == value2 || [value1 isEqual:value2];
-}
 
 inline static BOOL isSnapshotTypeAmongstGivenTypes(XCElementSnapshot* snapshot, NSArray<NSNumber *> *types)
 {

--- a/WebDriverAgentLib/Utilities/FBKeyboard.m
+++ b/WebDriverAgentLib/Utilities/FBKeyboard.m
@@ -50,20 +50,9 @@
 
 + (BOOL)waitUntilVisibleWithError:(NSError **)error
 {
-  XCUIElement *keyboard =
-  [[[[FBRunLoopSpinner new]
-     timeout:5]
-    timeoutErrorMessage:@"Keyboard is not present"]
-   spinUntilNotNil:^id{
-     return [[FBApplication fb_activeApplication].query descendantsMatchingType:XCUIElementTypeKeyboard].fb_firstMatch;
-   }
-   error:error];
-
-  if (!keyboard) {
-    return NO;
-  }
-
-  if (![keyboard fb_waitUntilFrameIsStable]) {
+  FBApplication *application = [FBApplication fb_activeApplication];
+  
+  if (![application fb_waitUntilFrameIsStable]) {
     return
     [[[FBErrorBuilder builder]
       withDescription:@"Timeout waiting for keybord to stop animating"]

--- a/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
@@ -85,7 +85,7 @@
 - (void)testAttributeWithNullScrollToVisible
 {
   NSError *error;
-  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther[1]/XCUIElementTypeTable[1]/XCUIElementTypeCell[60]" shouldReturnAfterFirstMatch:NO];
+  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"**/XCUIElementTypeTable/XCUIElementTypeCell[60]" shouldReturnAfterFirstMatch:NO];
   XCTAssertEqual(queryMatches.count, 1);
   XCUIElement *element = queryMatches.firstObject;
   XCTAssertFalse(element.fb_isVisible);

--- a/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBScrollingTests.m
@@ -15,6 +15,8 @@
 #import "XCUIElement+FBIsVisible.h"
 #import "XCUIElement+FBScrolling.h"
 
+#import "XCUIElement+FBClassChain.h"
+
 #define FBCellElementWithLabel(label) ([self.testedApplication descendantsMatchingType:XCUIElementTypeAny][label])
 #define FBAssertVisibleCell(label) FBAssertWaitTillBecomesTrue(FBCellElementWithLabel(label).fb_isVisible)
 #define FBAssertInvisibleCell(label) FBAssertWaitTillBecomesTrue(!FBCellElementWithLabel(label).fb_isVisible)
@@ -34,7 +36,7 @@
 {
   [super setUp];
   [self launchApplication];
-  [self goToScrollPageWithCells:NO];
+  [self goToScrollPageWithCells:YES];
   self.scrollView = [[self.testedApplication.query descendantsMatchingType:XCUIElementTypeAny] matchingIdentifier:@"scrollView"].element;
   [self.scrollView resolve];
 }
@@ -80,4 +82,20 @@
   FBAssertVisibleCell(cellName);
 }
 
+- (void)testAttributeWithNullScrollToVisible
+{
+  NSError *error;
+  NSArray<XCUIElement *> *queryMatches = [self.testedApplication fb_descendantsMatchingClassChain:@"XCUIElementTypeWindow[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther[1]/XCUIElementTypeOther[1]/XCUIElementTypeTable[1]/XCUIElementTypeCell[60]" shouldReturnAfterFirstMatch:NO];
+  XCTAssertEqual(queryMatches.count, 1);
+  XCUIElement *element = queryMatches.firstObject;
+  XCTAssertFalse(element.fb_isVisible);
+  [element fb_scrollToVisibleWithError:&error];
+  XCTAssertNil(error);
+  XCTAssertTrue(element.fb_isVisible);
+  [element tap];
+  [element resolve];
+  XCTAssertTrue(element.lastSnapshot.selected);
+}
+
 @end
+


### PR DESCRIPTION
In XCUIElementTypeTable,attribute values of many XCUIElementTypeCell
instances are null.When fb_scrollToVisibleWithNormalizedScrollDistance
function is called by XCUIElementTypeCell instance,it is unable to
accurately slide the specified UI element.