### PR TITLE
Return correct responses if xpath or class chain locator is invalid

### DIFF
--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -19,7 +19,6 @@
 #import "FBPredicate.h"
 #import "FBSession.h"
 #import "FBApplication.h"
-#import "FBXPath.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCUIElement+FBClassChain.h"
@@ -56,16 +55,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindElement:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  XCUIElement *element = nil;
-  @try {
-    element = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application];
-  } @catch (NSException *e) {
-    id response = [self webdriverResponseWithException:e];
-    if (response) {
-      return response;
-    }
-    @throw e;
-  }
+  XCUIElement *element = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application];
   if (!element) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
@@ -75,19 +65,8 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindElements:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  NSArray *elements = @[];
-  @try {
-    elements = [self.class elementsUsing:request.arguments[@"using"]
-                               withValue:request.arguments[@"value"]
-                                   under:session.application
-             shouldReturnAfterFirstMatch:NO];
-  } @catch (NSException *e) {
-    id response = [self webdriverResponseWithException:e];
-    if (response) {
-      return response;
-    }
-    @throw e;
-  }
+  NSArray *elements = [self.class elementsUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application
+                    shouldReturnAfterFirstMatch:NO];
   return FBResponseWithCachedElements(elements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
 }
 
@@ -104,16 +83,7 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
-  XCUIElement *foundElement = nil;
-  @try {
-    foundElement = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:element];
-  } @catch (NSException *e) {
-    id response = [self webdriverResponseWithException:e];
-    if (response) {
-      return response;
-    }
-    @throw e;
-  }
+  XCUIElement *foundElement = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:element];
   if (!foundElement) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
@@ -124,35 +94,14 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
-  NSArray *foundElements = @[];
-  @try {
-    foundElements = [self.class elementsUsing:request.arguments[@"using"]
-                                    withValue:request.arguments[@"value"]
-                                        under:element
-                  shouldReturnAfterFirstMatch:NO];
-  } @catch (NSException *e) {
-    id response = [self webdriverResponseWithException:e];
-    if (response) {
-      return response;
-    }
-    @throw e;
-  }
+  NSArray *foundElements = [self.class elementsUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:element
+                         shouldReturnAfterFirstMatch:NO];
+
   return FBResponseWithCachedElements(foundElements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
 }
 
 
 #pragma mark - Helpers
-
-+ (nullable id)webdriverResponseWithException:(NSException *)e
-{
-  if ([e.name isEqualToString:XCElementSnapshotInvalidXPathException]) {
-    return FBResponseWithStatus(FBCommandStatusInvalidXPathSelector, e.description);
-  }
-  if ([e.name isEqualToString:FBClassChainQueryParseException]) {
-    return FBResponseWithStatus(FBCommandStatusInvalidSelector, e.description);
-  }
-  return nil;
-}
 
 + (XCUIElement *)elementUsing:(NSString *)usingText withValue:(NSString *)value under:(XCUIElement *)element
 {

--- a/WebDriverAgentLib/Commands/FBFindElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBFindElementCommands.m
@@ -19,6 +19,7 @@
 #import "FBPredicate.h"
 #import "FBSession.h"
 #import "FBApplication.h"
+#import "FBXPath.h"
 #import "XCUIElement+FBFind.h"
 #import "XCUIElement+FBIsVisible.h"
 #import "XCUIElement+FBClassChain.h"
@@ -55,7 +56,16 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindElement:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  XCUIElement *element = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application];
+  XCUIElement *element = nil;
+  @try {
+    element = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application];
+  } @catch (NSException *e) {
+    id response = [self webdriverResponseWithException:e];
+    if (response) {
+      return response;
+    }
+    @throw e;
+  }
   if (!element) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
@@ -65,8 +75,19 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 + (id<FBResponsePayload>)handleFindElements:(FBRouteRequest *)request
 {
   FBSession *session = request.session;
-  NSArray *elements = [self.class elementsUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:session.application
-                    shouldReturnAfterFirstMatch:NO];
+  NSArray *elements = @[];
+  @try {
+    elements = [self.class elementsUsing:request.arguments[@"using"]
+                               withValue:request.arguments[@"value"]
+                                   under:session.application
+             shouldReturnAfterFirstMatch:NO];
+  } @catch (NSException *e) {
+    id response = [self webdriverResponseWithException:e];
+    if (response) {
+      return response;
+    }
+    @throw e;
+  }
   return FBResponseWithCachedElements(elements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
 }
 
@@ -83,7 +104,16 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
-  XCUIElement *foundElement = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:element];
+  XCUIElement *foundElement = nil;
+  @try {
+    foundElement = [self.class elementUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:element];
+  } @catch (NSException *e) {
+    id response = [self webdriverResponseWithException:e];
+    if (response) {
+      return response;
+    }
+    @throw e;
+  }
   if (!foundElement) {
     return FBNoSuchElementErrorResponseForRequest(request);
   }
@@ -94,14 +124,35 @@ static id<FBResponsePayload> FBNoSuchElementErrorResponseForRequest(FBRouteReque
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
-  NSArray *foundElements = [self.class elementsUsing:request.arguments[@"using"] withValue:request.arguments[@"value"] under:element
-                         shouldReturnAfterFirstMatch:NO];
-
+  NSArray *foundElements = @[];
+  @try {
+    foundElements = [self.class elementsUsing:request.arguments[@"using"]
+                                    withValue:request.arguments[@"value"]
+                                        under:element
+                  shouldReturnAfterFirstMatch:NO];
+  } @catch (NSException *e) {
+    id response = [self webdriverResponseWithException:e];
+    if (response) {
+      return response;
+    }
+    @throw e;
+  }
   return FBResponseWithCachedElements(foundElements, request.session.elementCache, FBConfiguration.shouldUseCompactResponses);
 }
 
 
 #pragma mark - Helpers
+
++ (nullable id)webdriverResponseWithException:(NSException *)e
+{
+  if ([e.name isEqualToString:XCElementSnapshotInvalidXPathException]) {
+    return FBResponseWithStatus(FBCommandStatusInvalidXPathSelector, e.description);
+  }
+  if ([e.name isEqualToString:FBClassChainQueryParseException]) {
+    return FBResponseWithStatus(FBCommandStatusInvalidSelector, e.description);
+  }
+  return nil;
+}
 
 + (XCUIElement *)elementUsing:(NSString *)usingText withValue:(NSString *)value under:(XCUIElement *)element
 {

--- a/WebDriverAgentLib/Routing/FBExceptionHandler.m
+++ b/WebDriverAgentLib/Routing/FBExceptionHandler.m
@@ -14,6 +14,8 @@
 #import "FBAlert.h"
 #import "FBResponsePayload.h"
 #import "FBSession.h"
+#import "FBXPath.h"
+#import "XCUIElement+FBClassChain.h"
 
 NSString *const FBInvalidArgumentException = @"FBInvalidArgumentException";
 NSString *const FBSessionDoesNotExistException = @"FBSessionDoesNotExistException";
@@ -54,6 +56,16 @@ NSString *const FBElementAttributeUnknownException = @"FBElementAttributeUnknown
   }
   if ([exception.name isEqualToString:FBApplicationCrashedException]) {
     id<FBResponsePayload> payload = FBResponseWithStatus(FBCommandStatusApplicationCrashDetected, [exception description]);
+    [payload dispatchWithResponse:response];
+    return YES;
+  }
+  if ([exception.name isEqualToString:FBInvalidXPathException]) {
+    id<FBResponsePayload> payload = FBResponseWithStatus(FBCommandStatusInvalidXPathSelector, [exception description]);
+    [payload dispatchWithResponse:response];
+    return YES;
+  }
+  if ([exception.name isEqualToString:FBClassChainQueryParseException]) {
+    id<FBResponsePayload> payload = FBResponseWithStatus(FBCommandStatusInvalidSelector, [exception description]);
     [payload dispatchWithResponse:response];
     return YES;
   }

--- a/WebDriverAgentLib/Utilities/FBXPath.h
+++ b/WebDriverAgentLib/Utilities/FBXPath.h
@@ -33,11 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  The exception happends if the provided XPath expession cannot be compiled because of a syntax error
  */
-extern NSString *const XCElementSnapshotInvalidXPathException;
+extern NSString *const FBInvalidXPathException;
 /**
  The exception happends if any internal error is triggered during XPath matching procedure
  */
-extern NSString *const XCElementSnapshotXPathQueryEvaluationException;
+extern NSString *const FBXPathQueryEvaluationException;
 
 @interface FBXPath : NSObject
 

--- a/WebDriverAgentLib/Utilities/FBXPath.m
+++ b/WebDriverAgentLib/Utilities/FBXPath.m
@@ -88,8 +88,8 @@ const static char *_UTF8Encoding = "UTF-8";
 
 static NSString *const kXMLIndexPathKey = @"private_indexPath";
 static NSString *const topNodeIndexPath = @"top";
-NSString *const XCElementSnapshotInvalidXPathException = @"XCElementSnapshotInvalidXPathException";
-NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnapshotXPathQueryEvaluationException";
+NSString *const FBInvalidXPathException = @"FBInvalidXPathException";
+NSString *const FBXPathQueryEvaluationException = @"FBXPathQueryEvaluationException";
 
 @implementation FBXPath
 
@@ -124,7 +124,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   xmlTextWriterPtr writer = xmlNewTextWriterDoc(&doc, 0);
   if (NULL == writer) {
     [FBLogger logFmt:@"Failed to invoke libxml2>xmlNewTextWriterDoc for XPath query \"%@\"", xpathQuery];
-    [FBXPath throwException:XCElementSnapshotXPathQueryEvaluationException forQuery:xpathQuery];
+    [FBXPath throwException:FBXPathQueryEvaluationException forQuery:xpathQuery];
     return nil;
   }
   NSMutableDictionary *elementStore = [NSMutableDictionary dictionary];
@@ -132,7 +132,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   if (rc < 0) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
-    [FBXPath throwException:XCElementSnapshotXPathQueryEvaluationException forQuery:xpathQuery];
+    [FBXPath throwException:FBXPathQueryEvaluationException forQuery:xpathQuery];
     return nil;
   }
 
@@ -140,7 +140,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   if (NULL == queryResult) {
     xmlFreeTextWriter(writer);
     xmlFreeDoc(doc);
-    [FBXPath throwException:XCElementSnapshotInvalidXPathException forQuery:xpathQuery];
+    [FBXPath throwException:FBInvalidXPathException forQuery:xpathQuery];
     return nil;
   }
 
@@ -149,7 +149,7 @@ NSString *const XCElementSnapshotXPathQueryEvaluationException = @"XCElementSnap
   xmlFreeTextWriter(writer);
   xmlFreeDoc(doc);
   if (nil == matchingSnapshots) {
-    [FBXPath throwException:XCElementSnapshotXPathQueryEvaluationException forQuery:xpathQuery];
+    [FBXPath throwException:FBXPathQueryEvaluationException forQuery:xpathQuery];
     return nil;
   }
   return matchingSnapshots;

--- a/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
+++ b/WebDriverAgentTests/IntegrationTests/XCUIElementFBFindTests.m
@@ -137,13 +137,13 @@
 - (void)testDescendantsWithWrongXPathQuery
 {
   XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//*[blabla(@label, Scrolling')]" shouldReturnAfterFirstMatch:NO],
-                               NSException, XCElementSnapshotInvalidXPathException);
+                               NSException, FBInvalidXPathException);
 }
 
 - (void)testFirstDescendantWithWrongXPathQuery
 {
   XCTAssertThrowsSpecificNamed([self.testedView fb_descendantsMatchingXPathQuery:@"//*[blabla(@label, Scrolling')]" shouldReturnAfterFirstMatch:YES],
-                               NSException, XCElementSnapshotInvalidXPathException);
+                               NSException, FBInvalidXPathException);
 }
 
 - (void)testVisibleDescendantWithXPathQuery


### PR DESCRIPTION
This should improve elements lookup flow if done by native clients by returning correct webdriver response codes for incorrect locator expressions.