### PR TITLE
Fix testIconsFromSearchDashboard integration test

### DIFF
--- a/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBElementVisibilityTests.m
@@ -13,6 +13,7 @@
 #import "FBIntegrationTestCase.h"
 #import "FBSpringboardApplication.h"
 #import "FBTestMacros.h"
+#import "FBXCodeCompatibility.h"
 #import "XCUIElement+FBIsVisible.h"
 
 @interface FBElementVisibilityTests : FBIntegrationTestCase
@@ -51,7 +52,9 @@
   [self launchApplication];
   [self goToSpringBoardDashboard];
   XCTAssertFalse(self.springboard.icons[@"Reminders"].fb_isVisible);
-  XCTAssertFalse(self.springboard.icons[@"IntegrationApp"].fb_isVisible);
+  XCTAssertFalse([[[self.springboard descendantsMatchingType:XCUIElementTypeIcon]
+                   matchingIdentifier:@"IntegrationApp"]
+                  fb_firstMatch].fb_isVisible);
 }
 
 - (void)testTableViewCells


### PR DESCRIPTION
It might be there is more than one `IntegrationApp` icon on the dashboard while integration tests are running on Travis. Addresses https://travis-ci.org/facebook/WebDriverAgent/jobs/349725814