### PR TITLE
Support getting the element cache size, clearing the element cache 

### DIFF
--- a/WebDriverAgentLib/Commands/FBCustomCommands.m
+++ b/WebDriverAgentLib/Commands/FBCustomCommands.m
@@ -38,6 +38,8 @@
     [[FBRoute POST:@"/wda/homescreen"].withoutSession respondWithTarget:self action:@selector(handleHomescreenCommand:)],
     [[FBRoute POST:@"/wda/deactivateApp"] respondWithTarget:self action:@selector(handleDeactivateAppCommand:)],
     [[FBRoute POST:@"/wda/keyboard/dismiss"] respondWithTarget:self action:@selector(handleDismissKeyboardCommand:)],
+    [[FBRoute GET:@"/wda/elementCache/size"] respondWithTarget:self action:@selector(handleGetElementCacheSizeCommand:)],
+    [[FBRoute POST:@"/wda/elementCache/clear"] respondWithTarget:self action:@selector(handleClearElementCacheCommand:)],
   ];
 }
 
@@ -93,4 +95,16 @@
   return FBResponseWithOK();
 }
 
++ (id<FBResponsePayload>)handleGetElementCacheSizeCommand:(FBRouteRequest *)request
+{
+  NSNumber *count = [NSNumber numberWithUnsignedInteger:[request.session.elementCache count]];
+  return FBResponseWithObject(count);
+}
+
++ (id<FBResponsePayload>)handleClearElementCacheCommand:(FBRouteRequest *)request
+{
+  FBElementCache *elementCache = request.session.elementCache;
+  [elementCache clear];
+  return FBResponseWithOK();
+}
 @end

--- a/WebDriverAgentLib/Routing/FBElementCache.h
+++ b/WebDriverAgentLib/Routing/FBElementCache.h
@@ -31,6 +31,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable XCUIElement *)elementForUUID:(NSString *__nullable)uuid;
 
+/**
+ Clears the cache
+ */
+- (void)clear;
+
+/**
+ Gets the number of elements in the cache
+ */
+@property (nonatomic, readonly) NSUInteger count;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -47,4 +47,13 @@
   return element;
 }
 
+- (void)clear
+{
+  [self.elementCache removeAllObjects];
+}
+
+- (NSUInteger)count
+{
+  return [self.elementCache count];
+}
 @end


### PR DESCRIPTION
Every time a user finds an element using the `element` or `elements` route, a new `XCUIElement` object is added to the session cache. The elements are never removed from the cache.

A very naïve script which goes to the home screen and queries for the 'Phone' element 1000 times in a row, will cause memory consumption (as measured by Xcode) of the WebDriverAgent to grow to approximately 126 MB. Net, it appears that every `XCUIElement` object consumes about 100KB of memory.

For sessions which persist for a long period of time (say, 30 minutes or more), this can eventually lead to an out of memory situation in which the WebDriverAgent crashes.

This PR tries to provide an 'escape hatch' for applications which want long-running sessions, by allowing them to:
- query the amount of elements in the cache
- clear the element cache
by adding two custom routes.

We're looking at other approaches to keep the cache size under control as well - e.g. by checking the element cache for duplicates and adding an option to remove 'stale' elements (elements which no longer exist); we'll try to submit PRs for that as well.

As usual, let me know what you think & happy to discuss further.