### PR TITLE
Use a natural UUID for elements in the element cache

### DIFF
--- a/PrivateHeaders/XCTest/XCAccessibilityElement.h
+++ b/PrivateHeaders/XCTest/XCAccessibilityElement.h
@@ -13,11 +13,15 @@
     int _processIdentifier;
     struct __AXUIElement *_axElement;
     unsigned long long _elementType;
+    unsigned long long _elementOrHash;
+    unsigned long long _elementID;
 }
 @property(readonly) id payload; // @synthesize payload=_payload;
 @property(readonly) int processIdentifier; // @synthesize processIdentifier=_processIdentifier;
 @property(readonly) const struct __AXUIElement *AXUIElement; // @synthesize AXUIElement=_axElement;
 @property(readonly, getter=isNative) BOOL native;
+@property(readonly) unsigned long long elementID; // @synthesize elementID=_elementID;
+@property(readonly) unsigned long long elementOrHash; // @synthesize elementOrHash=_elementOrHash;
 
 + (id)elementWithAXUIElement:(struct __AXUIElement *)arg1;
 + (id)elementWithProcessIdentifier:(int)arg1;

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -12,7 +12,7 @@
 #import "FBAlert.h"
 #import "XCUIElement.h"
 #import "XCUIElement+FBUtilities.h"
-
+#import "XCAccessibilityElement.h"
 
 @interface FBElementCache ()
 @property (atomic, strong) NSMutableDictionary *elementCache;
@@ -32,7 +32,13 @@
 
 - (NSString *)storeElement:(XCUIElement *)element
 {
-  NSString *uuid = [[NSUUID UUID] UUIDString];
+  XCElementSnapshot *snapshot = element.fb_lastSnapshot;
+  XCAccessibilityElement *axElement = snapshot.accessibilityElement;
+  unsigned long long elementId = [axElement elementID];
+  uint8_t b[16] = {0};
+  memcpy(b, &elementId, sizeof(long long));
+  NSUUID *uuidValue = [[NSUUID alloc] initWithUUIDBytes:b];
+  NSString *uuid = [uuidValue UUIDString];
   self.elementCache[uuid] = element;
   return uuid;
 }

--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -35,8 +35,12 @@
   XCElementSnapshot *snapshot = element.fb_lastSnapshot;
   XCAccessibilityElement *axElement = snapshot.accessibilityElement;
   unsigned long long elementId = [axElement elementID];
+  int processId = [axElement processIdentifier];
+  
   uint8_t b[16] = {0};
   memcpy(b, &elementId, sizeof(long long));
+  memcpy(b + sizeof(long long), &processId, sizeof(int));
+  
   NSUUID *uuidValue = [[NSUUID alloc] initWithUUIDBytes:b];
   NSString *uuid = [uuidValue UUIDString];
   self.elementCache[uuid] = element;


### PR DESCRIPTION
Every time an element is added to the cache, a new UUID is generated for that element.

If the same element is resolved multiple times (though the same or different queries), multiple copies of that element persist in the cache.

The "multiple copies" problem exists because the WebDriverAgent doesn't directly access the UI elements (which live in another process) but uses proxies/remoting/... to invoke those elements, and you end up with multiples proxies for the same element.

It appears, however, it is still possible to determine whether two `XCUIElement` objects point to the same element by looking at element -> snapshot -> accessibilityElement -> elementId + processIdentifier.

You can then avoid duplicates in the element cache by generating a UUID based on this information. That's what this PR does.

A simple test which queries the same element 1000 times now causes the WebDriverAgent to consume 23MB on the device instead of 126MB, with memory usage fairly stable during the test.

Might not be worth the effort if we can implement a LRU-like cache but at least wanted to get feedback on the general idea.