### PR TITLE
force touch support

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0BD9A1222090A1D000038BB2 /* XCUIElement+FBForceTouch.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BD9A1202090A1D000038BB2 /* XCUIElement+FBForceTouch.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0BD9A1232090A1D000038BB2 /* XCUIElement+FBForceTouch.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BD9A1212090A1D000038BB2 /* XCUIElement+FBForceTouch.m */; };
+		0BD9A1282090C5E900038BB2 /* FBForceTouchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0BD9A1252090C5DD00038BB2 /* FBForceTouchTests.m */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */; };
@@ -401,6 +404,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0BD9A1202090A1D000038BB2 /* XCUIElement+FBForceTouch.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "XCUIElement+FBForceTouch.h"; sourceTree = "<group>"; };
+		0BD9A1212090A1D000038BB2 /* XCUIElement+FBForceTouch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "XCUIElement+FBForceTouch.m"; sourceTree = "<group>"; };
+		0BD9A1252090C5DD00038BB2 /* FBForceTouchTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FBForceTouchTests.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
@@ -923,6 +929,8 @@
 				EEE376401D59F81400ED88DD /* XCUIElement+FBUtilities.m */,
 				EEE376471D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.h */,
 				EEE376481D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m */,
+				0BD9A1202090A1D000038BB2 /* XCUIElement+FBForceTouch.h */,
+				0BD9A1212090A1D000038BB2 /* XCUIElement+FBForceTouch.m */,
 			);
 			name = Categories;
 			path = WebDriverAgentLib/Categories;
@@ -1089,6 +1097,7 @@
 				71E504941DF59BAD0020C32A /* XCUIElementAttributesTests.m */,
 				EEBBD48D1D4785FC00656A81 /* XCUIElementFBFindTests.m */,
 				EE1E06E11D181CC9007CF043 /* XCUIElementHelperIntegrationTests.m */,
+				0BD9A1252090C5DD00038BB2 /* FBForceTouchTests.m */,
 			);
 			path = IntegrationTests;
 			sourceTree = "<group>";
@@ -1416,6 +1425,7 @@
 				711084441DA3AA7500F913D6 /* FBXPath.h in Headers */,
 				EE35AD771E3B77D600A02D78 /* XCUIRecorderTimingMessage.h in Headers */,
 				EE35AD271E3B77D600A02D78 /* XCApplicationMonitor.h in Headers */,
+				0BD9A1222090A1D000038BB2 /* XCUIElement+FBForceTouch.h in Headers */,
 				EE158AEA1CBD456F00A3E3F0 /* FBRuntimeUtils.h in Headers */,
 				7136A4791E8918E60024FC3D /* XCUIElement+FBPickerWheel.h in Headers */,
 				EE35AD511E3B77D600A02D78 /* XCTestObservation-Protocol.h in Headers */,
@@ -1772,6 +1782,7 @@
 				EE158AF81CBD456F00A3E3F0 /* FBSpringboardApplication.m in Sources */,
 				EE158AD91CBD456F00A3E3F0 /* FBResponseFilePayload.m in Sources */,
 				EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */,
+				0BD9A1232090A1D000038BB2 /* XCUIElement+FBForceTouch.m in Sources */,
 				EE158ACB1CBD456F00A3E3F0 /* FBTouchIDCommands.m in Sources */,
 				EE158ABD1CBD456F00A3E3F0 /* FBDebugCommands.m in Sources */,
 				716E0BCF1E917E810087A825 /* NSString+FBXMLSafeString.m in Sources */,
@@ -1816,6 +1827,7 @@
 				EE2202131ECC612200A29571 /* FBIntegrationTestCase.m in Sources */,
 				EE22021E1ECC618900A29571 /* FBTapTest.m in Sources */,
 				7126FF0E1FD99C7E00DEFB38 /* FBElementScreenshotTests.m in Sources */,
+				0BD9A1282090C5E900038BB2 /* FBForceTouchTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.h
@@ -17,9 +17,22 @@ NS_ASSUME_NONNULL_BEGIN
  Waits for element to become stable (not move) and performs sync force touch on element
  
  @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @param pressure The pressure of the force touch – valid values are [0, touch.maximumPossibleForce]
+ @param duration The duration of the gesture
  @return YES if the operation succeeds, otherwise NO.
  */
-- (BOOL)fb_forceTouchWithError:(NSError **)error;
+- (BOOL)fb_forceTouchWithPressure:(double)pressure duration:(double)duration error:(NSError **)error;
+
+/**
+ Waits for element to become stable (not move) and performs sync force touch on element
+ 
+ @param relativeCoordinate hit point coordinate relative to the current element position
+ @param pressure The pressure of the force touch – valid values are [0, touch.maximumPossibleForce]
+ @param duration The duration of the gesture
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if the operation succeeds, otherwise NO.
+ */
+- (BOOL)fb_forceTouchCoordinate:(CGPoint)relativeCoordinate pressure:(double)pressure duration:(double)duration error:(NSError **)error;
 
 @end
 

--- a/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.h
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <WebDriverAgentLib/XCUIElement.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface XCUIElement (FBForceTouch)
+
+/**
+ Waits for element to become stable (not move) and performs sync force touch on element
+ 
+ @param error If there is an error, upon return contains an NSError object that describes the problem.
+ @return YES if the operation succeeds, otherwise NO.
+ */
+- (BOOL)fb_forceTouchWithError:(NSError **)error;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.m
@@ -22,27 +22,68 @@
 
 @implementation XCUIElement (FBForceTouch)
 
-- (BOOL)fb_forceTouchWithError:(NSError **)error
+- (BOOL)fb_forceTouchWithPressure:(double)pressure duration:(double)duration error:(NSError **)error
 {
   XCElementSnapshot *snapshot = self.fb_lastSnapshot;
   CGPoint hitpoint = snapshot.fb_hitPoint;
   if (CGPointEqualToPoint(hitpoint, CGPointMake(-1, -1))) {
     hitpoint = [snapshot.suggestedHitpoints.lastObject CGPointValue];
   }
-  return [self fb_performFourceTouchAtPoint:hitpoint error:error];
+  return [self fb_performFourceTouchAtPoint:hitpoint pressure:pressure duration:duration error:error];
 }
 
-- (BOOL)fb_performFourceTouchAtPoint:(CGPoint)hitPoint error:(NSError *__autoreleasing*)error
+- (BOOL)fb_forceTouchCoordinate:(CGPoint)relativeCoordinate pressure:(double)pressure duration:(double)duration error:(NSError **)error
+{
+  CGPoint hitPoint = CGPointMake(self.frame.origin.x + relativeCoordinate.x, self.frame.origin.y + relativeCoordinate.y);
+  if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"10.0")) {
+    /*
+     Since iOS 10.0 XCTest has a bug when it always returns portrait coordinates for UI elements
+     even if the device is not in portait mode. That is why we need to recalculate them manually
+     based on the current orientation value
+     */
+    hitPoint = FBInvertPointForApplication(hitPoint, self.application.frame.size, self.application.interfaceOrientation);
+  }
+  return [self fb_performFourceTouchAtPoint:hitPoint pressure:pressure duration:duration error:error];
+}
+
+- (BOOL)fb_performFourceTouchAtPoint:(CGPoint)hitPoint pressure:(double)pressure duration:(double)duration error:(NSError *__autoreleasing*)error
 {
   [self fb_waitUntilFrameIsStable];
   __block BOOL didSucceed;
   [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)(void)){
-    [[XCEventGenerator sharedGenerator] forcePressAtPoint:hitPoint orientation:self.interfaceOrientation handler:^{
-      didSucceed = YES;
+    XCEventGeneratorHandler handlerBlock = ^(XCSynthesizedEventRecord *record, NSError *commandError) {
+      if (commandError) {
+        [FBLogger logFmt:@"Failed to perform force touch: %@", commandError];
+      }
+      if (error) {
+        *error = commandError;
+      }
+      didSucceed = (commandError == nil);
       completion();
+    };
+    
+    XCSynthesizedEventRecord *event = [self fb_generateForceTouchEvent:hitPoint pressure:pressure duration:duration orientation:self.interfaceOrientation];
+    [[XCTRunnerDaemonSession sharedSession] synthesizeEvent:event completion:^(NSError *invokeError){
+      handlerBlock(event, invokeError);
     }];
   }];
   return didSucceed;
+}
+
+- (XCSynthesizedEventRecord *)fb_generateForceTouchEvent:(CGPoint)hitPoint pressure:(double)pressure duration:(double)duration orientation:(UIInterfaceOrientation)orientation
+{
+  XCPointerEventPath *eventPath = [[XCPointerEventPath alloc] initForTouchAtPoint:hitPoint offset:0.0];
+  [eventPath pressDownWithPressure:pressure atOffset:0.0];
+  if (![XCTRunnerDaemonSession sharedSession].useLegacyEventCoordinateTransformationPath) {
+    orientation = UIInterfaceOrientationPortrait;
+  }
+  [eventPath liftUpAtOffset:duration];
+  XCSynthesizedEventRecord *event =
+  [[XCSynthesizedEventRecord alloc]
+   initWithName:[NSString stringWithFormat:@"Force touch on %@", NSStringFromCGPoint(hitPoint)]
+   interfaceOrientation:orientation];
+  [event addPointerEventPath:eventPath];
+  return event;
 }
 
 @end

--- a/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBForceTouch.m
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import "XCUIElement+FBForceTouch.h"
+
+#import "FBRunLoopSpinner.h"
+#import "FBLogger.h"
+#import "FBMacros.h"
+#import "FBMathUtils.h"
+#import "XCUIElement+FBUtilities.h"
+#import "XCEventGenerator.h"
+#import "XCSynthesizedEventRecord.h"
+#import "XCElementSnapshot+FBHitPoint.h"
+#import "XCPointerEventPath.h"
+#import "XCTRunnerDaemonSession.h"
+
+@implementation XCUIElement (FBForceTouch)
+
+- (BOOL)fb_forceTouchWithError:(NSError **)error
+{
+  XCElementSnapshot *snapshot = self.fb_lastSnapshot;
+  CGPoint hitpoint = snapshot.fb_hitPoint;
+  if (CGPointEqualToPoint(hitpoint, CGPointMake(-1, -1))) {
+    hitpoint = [snapshot.suggestedHitpoints.lastObject CGPointValue];
+  }
+  return [self fb_performFourceTouchAtPoint:hitpoint error:error];
+}
+
+- (BOOL)fb_performFourceTouchAtPoint:(CGPoint)hitPoint error:(NSError *__autoreleasing*)error
+{
+  [self fb_waitUntilFrameIsStable];
+  __block BOOL didSucceed;
+  [FBRunLoopSpinner spinUntilCompletion:^(void(^completion)(void)){
+    [[XCEventGenerator sharedGenerator] forcePressAtPoint:hitPoint orientation:self.interfaceOrientation handler:^{
+      didSucceed = YES;
+      completion();
+    }];
+  }];
+  return didSucceed;
+}
+
+@end

--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -250,50 +250,23 @@
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
   double pressure = [request.arguments[@"pressure"] doubleValue];
   double duration = [request.arguments[@"duration"] doubleValue];
-  if (element) {
-    NSError *error = nil;
-    if (![element fb_forceTouchWithPressure:pressure duration:duration error:&error]) {
-      return FBResponseWithError(error);
-    }
-  } else {
-    [self handleForceTouchByCoordinate:request];
+  NSError *error = nil;
+  if (![element fb_forceTouchWithPressure:pressure duration:duration error:&error]) {
+    return FBResponseWithError(error);
   }
   return FBResponseWithOK();
-}
-
-+ (id<FBResponsePayload>)handleForceTouchByCoordinate:(FBRouteRequest *)request
-{
-  CGPoint forceTouchPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-  double pressure = [request.arguments[@"pressure"] doubleValue];
-  double duration = [request.arguments[@"duration"] doubleValue];
-  NSError *error = nil;
-  BOOL success = [self.class performFourceTouchWithCoordinate:forceTouchPoint
-                                                  application:request.session.application
-                             shouldApplyOrientationWorkaround:isSDKVersionLessThan(@"11.0")
-                                                     pressure:pressure
-                                                     duration:duration
-                                                        error:&error];
-  if (!success) {
-    return FBResponseWithError(error);
-  } else {
-    return FBResponseWithOK();
-  }
 }
 
 + (id<FBResponsePayload>)handleForceTouchByCoordinateOnElement:(FBRouteRequest *)request
 {
   FBElementCache *elementCache = request.session.elementCache;
   XCUIElement *element = [elementCache elementForUUID:request.parameters[@"uuid"]];
-  if (element) {
-    double pressure = [request.arguments[@"pressure"] doubleValue];
-    double duration = [request.arguments[@"duration"] doubleValue];
-    CGPoint forceTouchPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
-    NSError *error = nil;
-    if (![element fb_forceTouchCoordinate:forceTouchPoint pressure:pressure duration:duration error:&error]) {
-      return FBResponseWithError(error);
-    }
-  } else {
-    [self handleForceTouchByCoordinate:request];
+  double pressure = [request.arguments[@"pressure"] doubleValue];
+  double duration = [request.arguments[@"duration"] doubleValue];
+  CGPoint forceTouchPoint = CGPointMake((CGFloat)[request.arguments[@"x"] doubleValue], (CGFloat)[request.arguments[@"y"] doubleValue]);
+  NSError *error = nil;
+  if (![element fb_forceTouchCoordinate:forceTouchPoint pressure:pressure duration:duration error:&error]) {
+    return FBResponseWithError(error);
   }
   return FBResponseWithOK();
 }

--- a/WebDriverAgentLib/WebDriverAgentLib.h
+++ b/WebDriverAgentLib/WebDriverAgentLib.h
@@ -51,5 +51,6 @@ FOUNDATION_EXPORT const unsigned char WebDriverAgentLib_VersionString[];
 #import <WebDriverAgentLib/XCUIElement+FBIsVisible.h>
 #import <WebDriverAgentLib/XCUIElement+FBScrolling.h>
 #import <WebDriverAgentLib/XCUIElement+FBTap.h>
+#import <WebDriverAgentLib/XCUIElement+FBForceTouch.h>
 #import <WebDriverAgentLib/XCUIElement+FBUtilities.h>
 #import <WebDriverAgentLib/XCUIElement+FBWebDriverAttributes.h>

--- a/WebDriverAgentTests/IntegrationApp/Classes/FBAlertViewController.m
+++ b/WebDriverAgentTests/IntegrationApp/Classes/FBAlertViewController.m
@@ -20,12 +20,7 @@
 
 - (IBAction)createAppAlert:(UIButton *)sender
 {
-  UIAlertController *alerController =
-  [UIAlertController alertControllerWithTitle:@"Magic"
-                                      message:@"Should read"
-                               preferredStyle:UIAlertControllerStyleAlert];
-  [alerController addAction:[UIAlertAction actionWithTitle:@"Will do" style:UIAlertActionStyleDefault handler:nil]];
-  [self presentViewController:alerController animated:YES completion:nil];
+    [self presentAlertController];
 }
 
 - (IBAction)createAppSheet:(UIButton *)sender
@@ -55,6 +50,24 @@
 {
   self.locationManager = [CLLocationManager new];
   [self.locationManager requestAlwaysAuthorization];
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesMoved:touches withEvent:event];
+    for (UITouch *touch in touches) {
+        if (fabs(touch.maximumPossibleForce - touch.force) < 0.0001) {
+            [self presentAlertController];
+        }
+    }
+}
+
+- (void)presentAlertController {
+  UIAlertController *alerController =
+  [UIAlertController alertControllerWithTitle:@"Magic"
+                                      message:@"Should read"
+                               preferredStyle:UIAlertControllerStyleAlert];
+  [alerController addAction:[UIAlertAction actionWithTitle:@"Will do" style:UIAlertActionStyleDefault handler:nil]];
+  [self presentViewController:alerController animated:YES completion:nil];
 }
 
 @end

--- a/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
+++ b/WebDriverAgentTests/IntegrationApp/Resources/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nJd-IZ-bfU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nJd-IZ-bfU">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -380,10 +380,18 @@
                                     <action selector="createAppSheet:" destination="gK5-IX-eJx" eventType="touchUpInside" id="U6X-fw-xU2"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D7g-22-s49">
+                                <rect key="frame" x="69" y="360" width="182" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="TzV-CY-64y"/>
+                                </constraints>
+                                <state key="normal" title="Create Alert (Force Touch)"/>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="3Zk-wE-jwj" firstAttribute="centerX" secondItem="JWE-cA-TW0" secondAttribute="centerX" id="83u-1W-xLt"/>
+                            <constraint firstItem="D7g-22-s49" firstAttribute="centerX" secondItem="JWE-cA-TW0" secondAttribute="centerX" id="9nT-k0-9gf"/>
                             <constraint firstItem="ntr-45-Ycd" firstAttribute="top" secondItem="rG5-3k-LFe" secondAttribute="bottom" constant="8" id="DYt-NB-TSO"/>
                             <constraint firstItem="3Zk-wE-jwj" firstAttribute="top" secondItem="ntr-45-Ycd" secondAttribute="bottom" constant="8" id="Edq-zL-Soc"/>
                             <constraint firstItem="y1x-J5-Nkw" firstAttribute="centerX" secondItem="CZ1-7J-OGl" secondAttribute="centerX" constant="117.5" id="Ell-4O-Iqa"/>
@@ -392,6 +400,7 @@
                             <constraint firstItem="y1x-J5-Nkw" firstAttribute="centerX" secondItem="JWE-cA-TW0" secondAttribute="centerX" id="M6w-gn-nXE"/>
                             <constraint firstItem="ntr-45-Ycd" firstAttribute="centerX" secondItem="CZ1-7J-OGl" secondAttribute="centerX" constant="117.5" id="Qj1-d9-KDa"/>
                             <constraint firstItem="CZ1-7J-OGl" firstAttribute="top" secondItem="y1x-J5-Nkw" secondAttribute="bottom" constant="33" id="UHk-wV-Ehk"/>
+                            <constraint firstItem="D7g-22-s49" firstAttribute="top" secondItem="3Zk-wE-jwj" secondAttribute="bottom" constant="8" id="eML-6C-Von"/>
                             <constraint firstItem="plO-2e-XmX" firstAttribute="top" secondItem="y1x-J5-Nkw" secondAttribute="bottom" constant="37" id="f0Z-LP-5Dg"/>
                             <constraint firstItem="4VK-4B-FEF" firstAttribute="centerX" secondItem="CZ1-7J-OGl" secondAttribute="centerX" constant="117" id="fDG-Jl-VER"/>
                             <constraint firstItem="y1x-J5-Nkw" firstAttribute="top" secondItem="Ew1-ik-0G1" secondAttribute="bottom" constant="25" id="gaL-qu-PB6"/>
@@ -405,7 +414,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="B30-xl-1JX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1216" y="-319"/>
+            <point key="canvasLocation" x="1215" y="-319.01408450704224"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="9RM-JC-4C4">

--- a/WebDriverAgentTests/IntegrationTests/FBForceTouchTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBForceTouchTests.m
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+
+#import "FBIntegrationTestCase.h"
+
+#import "FBAlert.h"
+#import "FBElementCache.h"
+#import "FBTestMacros.h"
+#import "XCUIDevice+FBRotation.h"
+#import "XCUIElement+FBForceTouch.h"
+#import "XCUIElement+FBIsVisible.h"
+
+@interface FBForceTouchTests : FBIntegrationTestCase
+@end
+
+// It is recommnded to verify these tests with different iOS versions
+
+@implementation FBForceTouchTests
+
+- (void)verifyTapWithOrientation:(UIDeviceOrientation)orientation
+{
+  [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
+  NSError *error;
+  XCTAssertTrue(self.testedApplication.alerts.count == 0);
+  [self.testedApplication.buttons[FBShowAlertForceTouchButtonName] fb_forceTouchWithError:&error];
+  FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
+}
+
+- (void)setUp
+{
+  [super setUp];
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [self launchApplication];
+    [self goToAlertsPage];
+  });
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+  [[FBAlert alertWithApplication:self.testedApplication] dismissWithError:nil];
+}
+
+- (void)testTap
+{
+  [self verifyTapWithOrientation:UIDeviceOrientationPortrait];
+}
+
+- (void)testTapInLandscapeLeft
+{
+  [self verifyTapWithOrientation:UIDeviceOrientationLandscapeLeft];
+}
+
+- (void)testTapInLandscapeRight
+{
+  [self verifyTapWithOrientation:UIDeviceOrientationLandscapeRight];
+}
+
+- (void)testTapInPortraitUpsideDown
+{
+  [self verifyTapWithOrientation:UIDeviceOrientationPortraitUpsideDown];
+}
+
+@end

--- a/WebDriverAgentTests/IntegrationTests/FBForceTouchTests.m
+++ b/WebDriverAgentTests/IntegrationTests/FBForceTouchTests.m
@@ -30,7 +30,7 @@
   [[XCUIDevice sharedDevice] fb_setDeviceInterfaceOrientation:orientation];
   NSError *error;
   XCTAssertTrue(self.testedApplication.alerts.count == 0);
-  [self.testedApplication.buttons[FBShowAlertForceTouchButtonName] fb_forceTouchWithError:&error];
+  [self.testedApplication.buttons[FBShowAlertForceTouchButtonName] fb_forceTouchWithPressure:1.0 duration:1.0 error:&error];
   FBAssertWaitTillBecomesTrue(self.testedApplication.alerts.count > 0);
 }
 

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.h
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.h
@@ -13,6 +13,7 @@
 
 extern NSString *const FBShowAlertButtonName;
 extern NSString *const FBShowSheetAlertButtonName;
+extern NSString *const FBShowAlertForceTouchButtonName;
 
 /**
  XCTestCase helper class used for integration tests

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
@@ -20,8 +20,8 @@
 #import "XCUIElement+FBIsVisible.h"
 
 NSString *const FBShowAlertButtonName = @"Create App Alert";
-NSString *const FBShowAlertForceTouchButtonName = @"Create Alert (Force Touch)";
 NSString *const FBShowSheetAlertButtonName = @"Create Sheet Alert";
+NSString *const FBShowAlertForceTouchButtonName = @"Create Alert (Force Touch)";
 
 @interface FBIntegrationTestCase ()
 @property (nonatomic, strong) XCUIApplication *testedApplication;

--- a/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
+++ b/WebDriverAgentTests/IntegrationTests/FBIntegrationTestCase.m
@@ -20,6 +20,7 @@
 #import "XCUIElement+FBIsVisible.h"
 
 NSString *const FBShowAlertButtonName = @"Create App Alert";
+NSString *const FBShowAlertForceTouchButtonName = @"Create Alert (Force Touch)";
 NSString *const FBShowSheetAlertButtonName = @"Create Sheet Alert";
 
 @interface FBIntegrationTestCase ()


### PR DESCRIPTION
A couple of commands which make possible to force touch given element or point by coordinates. In fact – copy of the tap extension. Baked with integration tests.

Updated with @mykola-mokhnach improvements in  appium#79