### PR TITLE
Added support to get source for WKWebView

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBUtilities.m
@@ -67,6 +67,11 @@ static const NSTimeInterval FBANIMATION_TIMEOUT = 5.0;
 - (XCElementSnapshot *)fb_lastSnapshot
 {
   [self resolve];
+  XCUIElementQuery *webviews = [self webViews];
+  NSArray *array = [webviews allElementsBoundByIndex];
+  for (XCUIElement *wv in array) {
+    [wv resolve];
+  }
   return [[self query] elementSnapshotForDebugDescription];
 }
 


### PR DESCRIPTION
Hi,

When I use the following command;
curl -X GET $JSON_HEADER $DEVICE_UL/session/7D046797-5D22-4E16-8264-754C5A1C4796/source

and if the app has a WKWebView, I am not getting any elements from the WKWebView.

I couldn't find any place else other than this pull request. With this change, I am able to get the complete source of the app including the WKWebView.

Please let me know if this is the right thing todo or if there is a better way.

--Suman
