### PR TITLE
Fix port value selection

### DIFF
--- a/WebDriverAgentLib/Utilities/FBConfiguration.m
+++ b/WebDriverAgentLib/Utilities/FBConfiguration.m
@@ -43,7 +43,8 @@ static NSUInteger FBMaxTypingFrequency = 60;
   }
 
   // Existence of USE_PORT in the environment implies the port range is managed by the launching process.
-  if (NSProcessInfo.processInfo.environment[@"USE_PORT"]) {
+  if (NSProcessInfo.processInfo.environment[@"USE_PORT"] &&
+      [NSProcessInfo.processInfo.environment[@"USE_PORT"] length] > 0) {
     return NSMakeRange([NSProcessInfo.processInfo.environment[@"USE_PORT"] integerValue] , 1);
   }
 


### PR DESCRIPTION
It turns out, that `NSProcessInfo.processInfo.environment[@"USE_PORT"]` returns an empty string instead of nil if `USE_PORT` is not present in the environment which causes zero value to be assigned by default. 