### PR TITLE
Use NSProxy as base class for FBApplicationProcessProxy 

### DIFF
--- a/WebDriverAgent.xcodeproj/project.pbxproj
+++ b/WebDriverAgent.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		18033EFF208761FC00FED81D /* RoutingHTTPServer.framework in Copy frameworks */ = {isa = PBXBuildFile; fileRef = AD42DD2B1CF1238500806E5D /* RoutingHTTPServer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */; };
 		711084441DA3AA7500F913D6 /* FBXPath.h in Headers */ = {isa = PBXBuildFile; fileRef = 711084421DA3AA7500F913D6 /* FBXPath.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		711084451DA3AA7500F913D6 /* FBXPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 711084431DA3AA7500F913D6 /* FBXPath.m */; };
 		7119E1EC1E891F8600D0B125 /* FBPickerWheelSelectTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7119E1EB1E891F8600D0B125 /* FBPickerWheelSelectTests.m */; };
@@ -320,8 +321,8 @@
 		EEE3764A1D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE376481D59FAE900ED88DD /* XCUIElement+FBWebDriverAttributes.m */; };
 		EEE9B4721CD02B88009D2030 /* FBRunLoopSpinner.h in Headers */ = {isa = PBXBuildFile; fileRef = EEE9B4701CD02B88009D2030 /* FBRunLoopSpinner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EEE9B4731CD02B88009D2030 /* FBRunLoopSpinner.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE9B4711CD02B88009D2030 /* FBRunLoopSpinner.m */; };
-		EEEA70152110605600C8ADE3 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE8980D321105B49001789EE /* XCTest.framework */; };
 		EEEA70152110605600C8ADE2 /* XCTAutomationSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE8980D321105B49001789ED /* XCTAutomationSupport.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		EEEA70152110605600C8ADE3 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE8980D321105B49001789EE /* XCTest.framework */; };
 		EEEC7C921F21F27A0053426C /* FBPredicate.h in Headers */ = {isa = PBXBuildFile; fileRef = EEEC7C901F21F27A0053426C /* FBPredicate.h */; };
 		EEEC7C931F21F27A0053426C /* FBPredicate.m in Sources */ = {isa = PBXBuildFile; fileRef = EEEC7C911F21F27A0053426C /* FBPredicate.m */; };
 /* End PBXBuildFile section */
@@ -412,6 +413,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBApplicationProcessProxyTests.m; sourceTree = "<group>"; };
 		44757A831D42CE8300ECF35E /* XCUIDeviceRotationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = XCUIDeviceRotationTests.m; sourceTree = "<group>"; };
 		711084421DA3AA7500F913D6 /* FBXPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXPath.h; sourceTree = "<group>"; };
 		711084431DA3AA7500F913D6 /* FBXPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXPath.m; sourceTree = "<group>"; };
@@ -618,8 +620,8 @@
 		EE7E271B1D06C69F001BEC7B /* FBXCTestCaseImplementationFailureHoldingProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXCTestCaseImplementationFailureHoldingProxy.m; sourceTree = "<group>"; };
 		EE7E27211D06CA91001BEC7B /* libAccessibility.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libAccessibility.tbd; path = usr/lib/libAccessibility.tbd; sourceTree = SDKROOT; };
 		EE836C021C0F118600D87246 /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		EE8980D321105B49001789EE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		EE8980D321105B49001789ED /* XCTAutomationSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTAutomationSupport.framework; path = Platforms/iPhoneOS.platform/Developer/Library/PrivateFrameworks/XCTAutomationSupport.framework; sourceTree = DEVELOPER_DIR; };
+		EE8980D321105B49001789EE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		EE8BA9781DCCED9A00A9DEF8 /* FBNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBNavigationController.h; sourceTree = "<group>"; };
 		EE8BA9791DCCED9A00A9DEF8 /* FBNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBNavigationController.m; sourceTree = "<group>"; };
 		EE8DDD7820C565FB004D4925 /* XCUIApplicationFBHelpersTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XCUIApplicationFBHelpersTests.m; sourceTree = "<group>"; };
@@ -1126,6 +1128,7 @@
 			isa = PBXGroup;
 			children = (
 				ADBC39951D07840300327304 /* Doubles */,
+				1FC3B2E12121EC8C00B61EE0 /* FBApplicationProcessProxyTests.m */,
 				71A7EAFB1E229302001DA4F2 /* FBClassChainTests.m */,
 				EEE16E961D33A25500172525 /* FBConfigurationTests.m */,
 				ADBC39931D0782CD00327304 /* FBElementCacheTests.m */,
@@ -1882,6 +1885,7 @@
 				EE3F8CFE1D08AA17006F02CE /* FBRunLoopSpinnerTests.m in Sources */,
 				714801D11FA9D9FA00DC5997 /* FBSDKVersionTests.m in Sources */,
 				EE3F8D001D08B05F006F02CE /* FBElementTypeTransformerTests.m in Sources */,
+				1FC3B2E32121ECF600B61EE0 /* FBApplicationProcessProxyTests.m in Sources */,
 				EEE16E971D33A25500172525 /* FBConfigurationTests.m in Sources */,
 				ADBC39941D0782CD00327304 /* FBElementCacheTests.m in Sources */,
 				EE8DDD7920C565FB004D4925 /* XCUIApplicationFBHelpersTests.m in Sources */,

--- a/WebDriverAgentLib/FBApplicationProcessProxy.h
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  Proxy that would forward all calls to it's applicationProcess.
  However it will block call to waitForQuiescence if shouldWaitForQuiescence is set to NO
  */
-@interface FBApplicationProcessProxy : NSObject
+@interface FBApplicationProcessProxy : NSProxy
 
 /**
  Convenience initializer

--- a/WebDriverAgentLib/FBApplicationProcessProxy.m
+++ b/WebDriverAgentLib/FBApplicationProcessProxy.m
@@ -20,10 +20,16 @@
 + (instancetype)proxyWithApplicationProcess:(XCUIApplicationProcess *)applicationProcess
 {
   NSParameterAssert(applicationProcess);
-  FBApplicationProcessProxy *proxy = [self.class new];
+  FBApplicationProcessProxy *proxy = [[self.class alloc] init];
   proxy.applicationProcess = applicationProcess;
   return proxy;
 }
+
+- (instancetype)init {
+  return self;
+}
+
+#pragma mark - Override XCUIApplicationProcess methods
 
 - (void)waitForQuiescence
 {
@@ -45,9 +51,16 @@
   [self.applicationProcess waitForQuiescenceIncludingAnimationsIdle:includeAnimations];
 }
 
-- (id)forwardingTargetForSelector:(SEL)aSelector
+#pragma mark - Forward not implemented methods to applicationProcess
+
+- (void)forwardInvocation:(NSInvocation *)invocation
 {
-  return self.applicationProcess;
+  [invocation invokeWithTarget:self.applicationProcess];
+}
+
+- (nullable NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+  return [self.applicationProcess methodSignatureForSelector:sel];
 }
 
 @end

--- a/WebDriverAgentTests/UnitTests/FBApplicationProcessProxyTests.m
+++ b/WebDriverAgentTests/UnitTests/FBApplicationProcessProxyTests.m
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <XCTest/XCTest.h>
+#import "FBApplicationProcessProxy.h"
+#import "XCUIApplicationProcess.h"
+
+@interface FBApplicationProcessProxy (NonProxiedMethod)
+- (void)objectsMethod;
+@end
+
+@implementation FBApplicationProcessProxy (NonProxiedMethod)
+
+- (void)objectsMethod
+{
+  // intentionally empty
+}
+
+@end
+
+@interface FBApplicationProcessProxy (ProxiedMethod)
+- (NSInteger)proxiedMethod;
+@end
+
+@interface XCUIApplicationProcess (TestableMethods)
+- (void)objectsMethod;
+- (int)proxiedMethod;
+@end
+
+@implementation XCUIApplicationProcess (TestableMethods)
+
+- (int)proxiedMethod;
+{
+  return 1;
+}
+
+- (void)objectsMethod
+{
+  NSString *errorMessage = [NSString stringWithFormat:@"Method %@ must NOT be proxied", NSStringFromSelector(_cmd)];
+  NSException * exception = [[NSException alloc] initWithName:@"Test failed" reason:errorMessage userInfo:nil];
+  [exception raise];
+}
+
+@end
+
+@interface FBApplicationProcessProxyTest : XCTestCase
+
+@end
+
+@implementation FBApplicationProcessProxyTest
+
+- (void)testMethodCallIsProxied {
+  XCUIApplicationProcess *applicationProcess = [[XCUIApplicationProcess alloc] init];
+  FBApplicationProcessProxy *proxy = [FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess];
+  XCTAssertEqual([proxy proxiedMethod], 1);
+}
+
+- (void)testMethodCallIsNotProxied {
+  XCUIApplicationProcess *applicationProcess = [[XCUIApplicationProcess alloc] init];
+  FBApplicationProcessProxy *proxy = [FBApplicationProcessProxy proxyWithApplicationProcess:applicationProcess];
+  XCTAssertNoThrow([proxy objectsMethod]);
+}
+
+@end


### PR DESCRIPTION
Allows to forward NSKeyValueObserverRegistration methods.
Fixes issue #975 